### PR TITLE
Propagate original error information

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -159,19 +159,16 @@ defmodule Lua do
         raise Lua.CompilerException, reason: reason
     end
   rescue
-    e in [ArgumentError, FunctionClauseError] ->
-      reraise e, __STACKTRACE__
-
-    e in [CaseClauseError, MatchError] ->
-      reraise Lua.RuntimeException, "Could not match #{inspect(e.term)}", __STACKTRACE__
-
     e in [UndefinedFunctionError] ->
       reraise Lua.RuntimeException,
               Util.format_function([e.module, e.function], e.arity),
               __STACKTRACE__
 
-    e in [ErlangError] ->
-      reraise Lua.RuntimeException, e.original, __STACKTRACE__
+    e in [Lua.RuntimeException, Lua.CompilerException] ->
+      reraise e, __STACKTRACE__
+
+    e ->
+      reraise Lua.RuntimeException, e, __STACKTRACE__
   end
 
   # Deep-set a value within a nested Lua table structure,

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lua.MixProject do
   use Mix.Project
 
   @url "https://github.com/tv-labs/lua"
-  @version "0.0.2"
+  @version "0.0.3"
 
   def project do
     [

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -272,6 +272,16 @@ defmodule LuaTest do
         """)
       end
     end
+
+    test "arithmetic exceptions are handled" do
+      error = "Lua runtime error: bad argument in arithmetic expression"
+
+      assert_raise Lua.RuntimeException, error, fn ->
+        lua = Lua.new()
+
+        Lua.eval!(lua, "return 5 / 0")
+      end
+    end
   end
 
   describe "set!/2 and get!/2" do
@@ -404,7 +414,9 @@ defmodule LuaTest do
     end
 
     test "it cannot return tuples from Elixir", %{lua: lua} do
-      assert_raise ArgumentError, fn ->
+      error = "Lua runtime error: argument error"
+
+      assert_raise Lua.RuntimeException, error, fn ->
         Lua.eval!(lua, "return example.tuple()")
       end
     end


### PR DESCRIPTION
Improves the error handling of Lua to include the original exception and lua state, so
that callers can provide additional context in their logs and alerts if neccessary