### PR TITLE
Improve the implementations of get/set. Remove .functions

### DIFF
--- a/lib/lua/util.ex
+++ b/lib/lua/util.ex
@@ -10,31 +10,6 @@ defmodule Lua.Util do
     Record.defrecord(name, fields)
   end
 
-  @doc """
-  Lists all user-defined functions in the global Lua scope
-
-      iex> lua = Lua.set!(Lua.new(), [:my_func], fn value -> value end)
-      iex> user_functions(lua)
-      ["my_func(_)"]
-
-  Nested functions are nicely scoped
-
-      iex> lua = Lua.set!(Lua.new(), [:my_func], fn value -> value end)
-      iex> lua = Lua.set!(lua, [:foo, :bar], fn value, _ -> value end)
-      iex> user_functions(lua)
-      ["foo.bar(_, _)", "my_func(_)"]
-
-  ## Options
-  * :formatter - formats the function, defaults to &format_function/1
-  """
-  def user_functions(%Lua{functions: functions}, opts \\ []) do
-    formatter = Keyword.get(opts, :formatter, &format_function/2)
-
-    functions
-    |> Enum.map(fn {keys, arity} -> formatter.(keys, arity) end)
-    |> Enum.sort(:asc)
-  end
-
   def format_error(error) do
     case error do
       {line, type, {:illegal, value}} ->

--- a/test/fixtures/returns_value.lua
+++ b/test/fixtures/returns_value.lua
@@ -1,0 +1,5 @@
+function foo()
+  return "returns value"
+end
+
+return 5

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -58,7 +58,6 @@ defmodule LuaTest do
                Lua.eval!(lua, """
                return foo()
                """)
-
     end
 
     test "loading files with syntax errors returns an error" do
@@ -358,11 +357,11 @@ defmodule LuaTest do
     end
 
     test "if the key already has a value, it raises" do
-      error = "Lua runtime error: invalid index \"one.two\"\n\n\n"
+      error = "Lua runtime error: invalid index \"print.nope\"\n\n\n"
+
       assert_raise Lua.RuntimeException, error, fn ->
         Lua.set!(Lua.new(), [:_G, :print, :nope], "uh oh")
       end
-
     end
 
     test "returns nil for non-existent keys" do
@@ -371,6 +370,7 @@ defmodule LuaTest do
 
     test "if a path is nil, it raises a runtime error" do
       error = "Lua runtime error: invalid index \"one.two\"\n\n\n"
+
       assert_raise Lua.RuntimeException, error, fn ->
         Lua.get!(Lua.new(), [:one, :two])
       end
@@ -378,6 +378,7 @@ defmodule LuaTest do
 
     test "if the key is not a table, it raises" do
       error = "Lua runtime error: invalid index \"print.nope\"\n\n\n"
+
       assert_raise Lua.RuntimeException, error, fn ->
         Lua.get!(Lua.new(), [:print, :nope])
       end
@@ -534,7 +535,7 @@ defmodule LuaTest do
       lua = Lua.new()
 
       message = """
-      Lua runtime error: invalid index "path"
+      Lua runtime error: invalid index "package.path"
 
 
       """

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -22,9 +22,20 @@ defmodule LuaTest do
     end
   end
 
-  describe "load_file/2" do
+  describe "load_file!/2" do
     test "loads the lua file into the state" do
       path = test_file("test_api")
+
+      assert lua = Lua.load_file!(Lua.new(), path)
+
+      assert {["Hi ExUnit!"], _} =
+               Lua.eval!(lua, """
+               return foo("ExUnit!")
+               """)
+    end
+
+    test "it can load files with the .lua extension" do
+      path = test_file("test_api.lua")
 
       assert lua = Lua.load_file!(Lua.new(), path)
 


### PR DESCRIPTION
1. Raise better errors for `Lua.get!/2` and `Lua.set!/3`
2. `Lua.load_lua_file!/2` -> `Lua.load_file!/2`
3. Remove `.functions` from state