### PR TITLE
Add call_function!/3

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -248,10 +248,11 @@ defmodule Lua do
   Encodes a Lua value into its internal form
   """
   def encode!(%__MODULE__{} = lua, value) do
-    case :luerl_new.encode(value, lua.state) do
-      {encoded, state} -> {encoded, wrap(state)}
-      {:lua_error, _, _} = error -> raise Lua.RuntimeException, error
-    end
+    {encoded, state} = :luerl_new.encode(value, lua.state)
+    {encoded, wrap(state)}
+  rescue
+    ArgumentError ->
+      reraise Lua.RuntimeException, "Failed to encode value", __STACKTRACE__
   end
 
   @doc """

--- a/test/lua/api_test.exs
+++ b/test/lua/api_test.exs
@@ -34,9 +34,9 @@ defmodule Lua.APITest do
 
                  deflua foo(a, b), state do
                    value = Lua.get!(state, [:some_var])
-                   {:ok, _ , state} = Luerl.New.set_table_keys_dec(state, [:some_var], a + b)
+                   lua = Lua.set!(state, [:some_var], a + b)
 
-                   {[value], state}
+                   {[value], lua}
                  end
                end
                """)

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -164,15 +164,17 @@ defmodule LuaTest do
 
   describe "call_function/3" do
     test "can call standard library functions" do
-      assert {["hello robert"], %Lua{}} = Lua.call_function!(Lua.new(), [:string, :lower], ["HELLO ROBERT"])
+      assert {["hello robert"], %Lua{}} =
+               Lua.call_function!(Lua.new(), [:string, :lower], ["HELLO ROBERT"])
     end
 
     test "can call user defined functions" do
-      {[], lua} = Lua.eval!("""
-      function double(val)
-        return 2 * val
-      end
-      """)
+      {[], lua} =
+        Lua.eval!("""
+        function double(val)
+          return 2 * val
+        end
+        """)
 
       assert {[20], %Lua{}} = Lua.call_function!(lua, :double, [10])
     end
@@ -181,7 +183,6 @@ defmodule LuaTest do
       {[func], lua} = Lua.eval!("return string.lower")
 
       assert {["it works"], %Lua{}} = Lua.call_function!(lua, func, ["IT WORKS"])
-
     end
 
     test "it plays nicely with elixir function callbacks" do
@@ -195,16 +196,29 @@ defmodule LuaTest do
 
       lua = Lua.new() |> Lua.load_api(Callback)
 
-      assert {["maybe"], %Lua{}} = Lua.eval!(lua, """
-      return callback.callme(function(value)
-        return string.lower(value)
-      end)
-      """)
-
+      assert {["maybe"], %Lua{}} =
+               Lua.eval!(lua, """
+               return callback.callme(function(value)
+                 return string.lower(value)
+               end)
+               """)
     end
 
     test "calling non-functions raises" do
+      {_, lua} =
+        Lua.eval!("""
+        foo = "bar"
+        """)
 
+      error = """
+      Lua runtime error: undefined function 'bar'
+
+
+      """
+
+      assert_raise Lua.RuntimeException, error, fn ->
+        Lua.call_function!(lua, :foo, [])
+      end
     end
   end
 

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -222,6 +222,26 @@ defmodule LuaTest do
     end
   end
 
+  describe "encode!/1" do
+    test "it can encode values into their internal representation" do
+      lua = Lua.new()
+
+      assert {"hello", lua} = Lua.encode!(lua, "hello")
+      assert {"hello", lua} = Lua.encode!(lua, :hello)
+      assert {5, lua} = Lua.encode!(lua, 5)
+      assert {{:tref, _}, lua} = Lua.encode!(lua, %{a: 1, b: 2})
+      assert {{:tref, _}, _lua} = Lua.encode!(lua, [1, 2, 3, 4])
+    end
+
+    test "it raises for values that cannot be encoded" do
+      error = "Lua runtime error: Failed to encode value"
+
+      assert_raise Lua.RuntimeException, error, fn ->
+        Lua.encode!(Lua.new(), {:foo, :bar})
+      end
+    end
+  end
+
   describe "error messages" do
     test "function doesn't exist" do
       lua = Lua.new()


### PR DESCRIPTION
Adds a new API function `call_function!/3` which executes Lua functions inside the passed environment. Allows for calling functions by keys (fully qualified name), references, and direct function callbacks

Also adds the `encode!/1` function for encoding values

## Usage

```elixir
defmodule MyAPI do
  use Lua.API, scope: "example"

  deflua foo(value), state do
    Lua.call_function!(state, [:string, :lower], [value])
  end
end

lua = Lua.new() |> Lua.load_api(MyAPI)

{["wow"], _} = Lua.eval!(lua, "return example.foo(\"WOW\")")
```