### PR TITLE
Implement ~LUA for validating Lua code at compile time

### DIFF
--- a/lib/lua/compiler_exception.ex
+++ b/lib/lua/compiler_exception.ex
@@ -3,6 +3,23 @@ defmodule Lua.CompilerException do
 
   alias Lua.Util
 
+  def exception(errors) when is_list(errors) do
+    for error <- errors do
+      Util.format_error(error)
+    end
+
+    errors = Enum.map_join(errors, "\n", &Util.format_error/1)
+
+    message = """
+    Failed to compile Lua!
+
+    #{errors}
+
+    """
+
+    %__MODULE__{message: message}
+  end
+
   def exception({:lua_error, error, state}) do
     stacktrace = Luerl.New.get_stacktrace(state)
 

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -1,7 +1,8 @@
 defmodule LuaTest do
   use ExUnit.Case, async: true
 
-  alias Lua
+  # import Lua, only: [sigil_LUA: 1]
+  import Lua
 
   doctest Lua
 
@@ -19,6 +20,27 @@ defmodule LuaTest do
       lua = Lua.set!(lua, [:bar, :my_func], fn _, _ -> [] end)
 
       assert inspect(lua) == "#Lua<>"
+    end
+  end
+
+  describe "~LUA" do
+    test "it can validate code at compile time" do
+      message = """
+      Failed to compile Lua!
+
+      Failed to tokenize: illegal token on line 1: \"hi)
+
+      """
+
+      assert_raise Lua.CompilerException, message, fn ->
+        Code.compile_quoted(
+          quote do
+            import Lua
+
+            ~LUA[print("hi)]
+          end
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Adds a sigil ~LUA which compiles the passed string and raises a Lua.CompilerException if the code does not compile, returning the original string.

This is useful if you have Lua literals in your codebase that you would like to validate before executing them.