### PR TITLE
Add install callback to Lua.API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ``` elixir
     iex> {[4], _} =
-    ...>   Lua.eval!("""
+    ...>   Lua.eval!(~LUA"""
     ...>   return 2 + 2
     ...>   """)
 
@@ -42,7 +42,7 @@ end
 lua = Lua.new() |> Lua.load_api(MyAPI)
 
 {[10], _} =
-  Lua.eval!(lua, """
+  Lua.eval!(lua, ~LUA"""
   return double(5)
   """)
 
@@ -64,7 +64,7 @@ end
 
 lua = Lua.new() |> Lua.load_api(MyAPI)
 
-{["wow"], _} = Lua.eval!(lua, "return example.foo(\"WOW\")")
+{["wow"], _} = Lua.eval!(lua, ~LUA"return example.foo(\"WOW\")")
 ```
 
 ## Modify Lua state from Elixir

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -5,6 +5,8 @@ defmodule Lua do
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
 
+  @type t :: %__MODULE__{}
+
   defstruct [:state]
 
   alias Luerl.New, as: Luerl
@@ -358,9 +360,9 @@ defmodule Lua do
   end
 
   @doc """
-  Inject functions written with the `deflua` macro into the Lua runtime
+  Inject functions written with the `deflua` macro into the Lua runtime.
 
-  Similar to `:luerl_new.load_module/3` but without the `install` callback
+  See `Lua.API` for more information on writing api modules
   """
   def load_api(lua, module, scope \\ nil) do
     funcs = :functions |> module.__info__() |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
@@ -380,6 +382,7 @@ defmodule Lua do
         end
       )
     end)
+    |> Lua.API.install(module)
   end
 
   defp wrap_variadic_function(module, function_name, with_state?) do

--- a/lib/lua/api.ex
+++ b/lib/lua/api.ex
@@ -42,7 +42,7 @@ defmodule Lua.API do
         def baz(v), do: v
       end
 
-  ## Installing an APi
+  ## Installing an API
 
   A `Lua.API` can provide an optional `install/1` callback, which
   can run arbitrary Lua code or change the `Lua` state in any way.

--- a/lib/lua/api.ex
+++ b/lib/lua/api.ex
@@ -47,8 +47,8 @@ defmodule Lua.API do
   A `Lua.API` can provide an optional `install/1` callback, which
   can run arbitrary Lua code or change the `Lua` state in any way.
 
-  A `install/1` callback takes a t:Lua.t and should either return a
-  Lua script to be evaluated, or return a new t:Lua.t
+  An `install/1` callback takes a `t:Lua.t/0` and should either return a
+  Lua script to be evaluated, or return a new `t:Lua.t/0`
 
       defmodule WithInstall do
         use Lua.API, scope: "install"


### PR DESCRIPTION
Adds an install callback that allows users to run scripts and change the Lua environment after an API is loaded