### PR TITLE
Add support for Lua chunks

### DIFF
--- a/lib/lua/chunk.ex
+++ b/lib/lua/chunk.ex
@@ -1,0 +1,10 @@
+defmodule Lua.Chunk do
+  @moduledoc """
+  A pre-compiled [chunk](https://www.lua.org/pil/1.1.html) of Lua code
+  that can be executed at a future point in time
+  """
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:instructions, :ref]
+end

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -42,6 +42,14 @@ defmodule LuaTest do
       end
     end
 
+    test "it returns the Lua string by default" do
+      assert ~LUA[print("hello")] == ~S[print("hello")]
+    end
+
+    test "it returns chunks with the ~LUA c option" do
+      assert %Lua.Chunk{} = ~LUA[print("hello")]c
+    end
+
     test "it can handle multi-line programs" do
       message = """
       Failed to compile Lua!
@@ -164,6 +172,15 @@ defmodule LuaTest do
 
       assert {[], %Lua{}} = Lua.eval!(lua, "foo(5)")
       assert {[2], %Lua{}} = Lua.eval!(lua, "return foo(1)")
+    end
+
+    test "it can evaluate chunks" do
+      assert %Lua.Chunk{} = chunk = ~LUA[return 2 + 2]c
+      lua = Lua.new()
+
+      assert {ref, lua} = :luerl_emul.load_chunk(chunk.instructions, lua.state)
+
+      assert {:ok, [4], _} = :luerl_new.call_chunk(ref, lua)
     end
 
     test "invalid functions raise" do

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -176,11 +176,8 @@ defmodule LuaTest do
 
     test "it can evaluate chunks" do
       assert %Lua.Chunk{} = chunk = ~LUA[return 2 + 2]c
-      lua = Lua.new()
 
-      assert {ref, lua} = :luerl_emul.load_chunk(chunk.instructions, lua.state)
-
-      assert {:ok, [4], _} = :luerl_new.call_chunk(ref, lua)
+      assert {[4], _} = Lua.eval!(chunk)
     end
 
     test "invalid functions raise" do
@@ -220,6 +217,23 @@ defmodule LuaTest do
         os.exit(1)
         """)
       end
+    end
+  end
+
+  describe "load_chunk/2" do
+    test "loads a chunk into state" do
+      assert %Lua.Chunk{ref: nil} = chunk = ~LUA[print("hello")]c
+      assert {%Lua.Chunk{} = chunk, %Lua{}} = Lua.load_chunk(Lua.new(), chunk)
+      assert chunk.ref
+    end
+
+    test "chunks can be loaded multiple times" do
+      lua = Lua.new()
+      chunk = ~LUA[print("hello")]c
+
+      assert {chunk, lua} = Lua.load_chunk(lua, chunk)
+      assert {chunk, lua} = Lua.load_chunk(lua, chunk)
+      assert {_chunk, _lua} = Lua.load_chunk(lua, chunk)
     end
   end
 


### PR DESCRIPTION
Adds chunk support, which allows users to precompile Lua statements and then execute them later, as opposed re-parsing and code generating at eval time. We achieve this with the following two features

1. The ability to return chunks from the Lua sigil with the 'c' modifier

```elixir
~LUA"""
print("hello world")
"""c
```

2. The ability to load and evaluate chunks

```elixir
{[4], _} = Lua.eval!(~LUA[return 2 + 2]c)
```

Closes #35 