### PR TITLE
Lua Table pretty printer

### DIFF
--- a/test/lua/table_test.exs
+++ b/test/lua/table_test.exs
@@ -2,4 +2,34 @@ defmodule Lua.TableTest do
   use ExUnit.Case, async: true
 
   doctest Lua.Table
+
+  defmacro assert_table(table) do
+    quote bind_quoted: [table: table] do
+      assert output = Lua.Table.as_string(table)
+      assert {[ret], _lua} = Lua.eval!("return " <> output)
+      assert ret == table
+      output
+    end
+  end
+
+  describe "as_string" do
+    test "it can convert basic tables to strings" do
+      assert assert_table([]) == "{}"
+      assert assert_table([{"a", 1}, {"b", 2}]) == "{a = 1, b = 2}"
+      assert assert_table([{"a b", "value"}, {"b", 2}]) == ~S<{["a b"] = "value", b = 2}>
+    end
+
+    test "lists are converted" do
+      assert assert_table([{1, "foo"}, {2, "bar"}]) == ~S[{"foo", "bar"}]
+    end
+
+    test "it can handle tables with many keys" do
+      big_table =
+        for {letter, index} <- Enum.with_index(?a..?z) do
+          {to_string([letter]), index}
+        end
+
+      assert_table(big_table)
+    end
+  end
 end

--- a/test/lua/table_test.exs
+++ b/test/lua/table_test.exs
@@ -8,7 +8,6 @@ defmodule Lua.TableTest do
   defmacro assert_table(table) do
     quote bind_quoted: [table: table] do
       assert output = Lua.Table.as_string(table)
-      dbg(output)
       assert {[ret], _lua} = Lua.eval!("return " <> output)
       assert ret == table
       output
@@ -40,7 +39,7 @@ defmodule Lua.TableTest do
 
       assert Lua.Table.as_string(table) == ~S[{a = 1, b = "<userdata>"}]
 
-      assert Lua.Table.as_string(table, userdata: &inspect/1) == ~S[{a = 1, b = "~D[2024-09-22]"}]
+      assert Lua.Table.as_string(table, userdata: &inspect/1) == ~S<{a = 1, b = "~D[2024-09-22]"}>
     end
 
     # We can't handle self-referential tables as


### PR DESCRIPTION
Adds a very basic implementation of a pretty printer that take's an Elixir representation of a table, and outputs a syntactically valid Lua table constructor (literal).

Currently doesn't nicely format large tables into multilines, and will inspect :userdata values as is.

### Example

```elixir
iex> Lua.Table.as_string([{"a", 1}, {"b", 2}])
"{a = 1, b = 2}"

iex> Lua.Table.as_string([{1, "foo"}, {2, "bar"}])
~S[{"foo", "bar"}]
```

Closes #40 