### PR TITLE
fix: handle Lua with unicode characters

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -87,12 +87,12 @@ defmodule Lua do
   defmacro sigil_LUA(code, opts) do
     code =
       case code do
-        {:<<>>, _, [literal]} -> String.to_charlist(literal)
+        {:<<>>, _, [literal]} -> literal
         _ -> raise "~Lua only accepts string literals, received:\n\n#{Macro.to_string(code)}"
       end
 
     chunk =
-      case :luerl_comp.string(code, [:return]) do
+      case :luerl_comp.string(String.to_charlist(code), [:return]) do
         {:ok, chunk} -> %Lua.Chunk{instructions: chunk}
         {:error, error, _warnings} -> raise Lua.CompilerException, error
       end

--- a/test/unicode_test.exs
+++ b/test/unicode_test.exs
@@ -1,0 +1,23 @@
+defmodule Lua.UnicodeTest do
+  use ExUnit.Case, async: true
+
+  import Lua, only: [sigil_LUA: 2]
+
+  test "it can contain unicode" do
+    assert {["é"], _} = Lua.eval!("return 'é'")
+  end
+
+  test "chunks can contain unicode" do
+    {:ok, chunk} = Lua.parse_chunk("return 'é'")
+    assert {["é"], _} = Lua.eval!(chunk)
+  end
+
+  test "sigil lua can contain unicode" do
+    assert {["é"], _} = Lua.eval!(~LUA"return 'é'"c)
+  end
+
+  test "a chunk can be loaded with unicode" do
+    assert {chunk, lua} = Lua.load_chunk!(Lua.new(), "return 'é'")
+    assert {["é"], _} = Lua.eval!(lua, chunk)
+  end
+end


### PR DESCRIPTION
Handles a quirk of Luerl where it double encodes unicode data by always converting binaries to charlists. See https://github.com/rvirding/luerl/issues/197

Closes #63