### PR TITLE
feat: guards for encoded Lua values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Guards for encoded Lua values in `deflua` functions
+  - `is_table/1`
+  - `is_userdata/1`
+  - `is_lua_func/1`
+  - `is_erl_func/1`
+  - `is_mfa/1`
+
 ### Fixed
 - `deflua` function can now specify guards when using or not using state
 

--- a/lib/lua/util.ex
+++ b/lib/lua/util.ex
@@ -26,7 +26,7 @@ defmodule Lua.Util do
   # take out when https://github.com/rvirding/luerl/pull/213
   # is released
   def encoded?(number) when is_number(number), do: true
-  def encoded?(table_ref) when Record.is_record(table_ref, :tref), do: true
+  def encoded?(record) when Record.is_record(record, :tref), do: true
   def encoded?(record) when Record.is_record(record, :usdref), do: true
   def encoded?(record) when Record.is_record(record, :funref), do: true
   def encoded?(record) when Record.is_record(record, :erl_func), do: true

--- a/test/lua/api_test.exs
+++ b/test/lua/api_test.exs
@@ -336,4 +336,57 @@ defmodule Lua.APITest do
       assert {"not a int", _} = module.with_state(true, Lua.new())
     end
   end
+
+  describe "guards" do
+    test "can use in functions" do
+      assert [{module, _}] =
+               Code.compile_string("""
+               defmodule GuardCheck do
+                 use Lua.API, scope: "guard"
+
+                 deflua type(value) when is_table(value) do
+                   "table"
+                 end
+
+                 deflua type(value) when is_userdata(value) do
+                   "userdata"
+                 end
+
+                 deflua type(value) when is_lua_func(value) do
+                   "lua function"
+                 end
+
+                 deflua type(value) when is_erl_func(value) do
+                   "erl function"
+                 end
+
+                 deflua type(value) when is_mfa(value) do
+                   "mfa"
+                 end
+
+                 deflua type(_value) do
+                   "other"
+                 end
+               end
+               """)
+
+      lua =
+        Lua.load_api(Lua.new(), module)
+        |> Lua.set!(["foo"], {:userdata, URI.parse("https://tvlabs.ai")})
+
+      assert {["table"], _} = Lua.eval!(lua, "return guard.type({})")
+      assert {["userdata"], _} = Lua.eval!(lua, "return guard.type(foo)")
+
+      assert {["lua function"], _} =
+               Lua.eval!(lua, """
+               return guard.type(function()
+                 return 42
+               end)
+               """)
+
+      assert {["erl function"], _} = Lua.eval!(lua, "return guard.type(guard.type)")
+      assert {["mfa"], _} = Lua.eval!(lua, "return guard.type(string.lower)")
+      assert {["other"], _} = Lua.eval!(lua, "return guard.type(5)")
+    end
+  end
 end


### PR DESCRIPTION
Adds the following guards for use in `deflua` functions

- `is_table/1`
- `is_userdata/1`
- `is_lua_func/1`
- `is_erl_func/1`
- `is_mfa/1`

Closes #82 