### PR TITLE
Fix Elixir 1.19 type warning

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -406,7 +406,7 @@ defmodule Lua do
   def eval!(%__MODULE__{} = lua, %Lua.Chunk{} = chunk, opts) do
     opts = Keyword.validate!(opts, decode: true)
 
-    {chunk, lua} = load_chunk!(lua, chunk)
+    {chunk, %__MODULE__{} = lua} = load_chunk!(lua, chunk)
 
     case :luerl.call_chunk(chunk.ref, lua.state) do
       {:ok, result, new_state} ->


### PR DESCRIPTION
```
> mix compile
Compiling 1 file (.ex)
     warning: a struct for Lua is expected on struct update:

         %Lua{lua | state: new_state}

     but got type:

         dynamic()

     where "lua" was given the type:

         # type: dynamic()
         # from: lib/lua.ex:409:18
         {chunk, lua} = load_chunk!(lua, chunk)

     when defining the variable "lua", you must also pattern match on "%Lua{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_fun()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_fun()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 413 │         lua = %__MODULE__{lua | state: new_state}
     │               ~
     │
     └─ lib/lua.ex:413:15: Lua.eval!/3
```