### PR TITLE
feat(vm): Local variables

### DIFF
--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -49,6 +49,13 @@ defmodule Lua.VM.Executor do
     do_execute(rest, regs, upvals, state)
   end
 
+  # move
+  defp do_execute([{:move, dest, source} | rest], regs, upvals, state) do
+    value = elem(regs, source)
+    regs = put_elem(regs, dest, value)
+    do_execute(rest, regs, upvals, state)
+  end
+
   # return
   defp do_execute([{:return, base, count} | _rest], regs, _upvals, state) do
     results =

--- a/test/lua/compiler/integration_test.exs
+++ b/test/lua/compiler/integration_test.exs
@@ -374,4 +374,76 @@ defmodule Lua.Compiler.IntegrationTest do
       assert results == [10]
     end
   end
+
+  describe "local variables" do
+    test "simple local variable" do
+      code = "local x = 42\nreturn x"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [42]
+    end
+
+    test "local variable with arithmetic" do
+      code = "local x = 1\nreturn x + 2"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [3]
+    end
+
+    test "multiple local variables" do
+      code = "local a = 5\nlocal b = 3\nreturn a * b"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [15]
+    end
+
+    test "local variable reassignment via new declaration" do
+      code = "local x = 10\nlocal x = 20\nreturn x"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [20]
+    end
+
+    test "local variable with expression" do
+      code = "local x = 2 + 3\nreturn x * 4"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [20]
+    end
+
+    test "multiple locals in one declaration" do
+      code = "local a, b = 1, 2\nreturn a + b"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [3]
+    end
+
+    test "local with fewer values than names (implicit nil)" do
+      code = "local a, b = 1\nreturn b"
+
+      {:ok, ast} = Parser.parse(code)
+      {:ok, proto} = Compiler.compile(ast)
+      {:ok, results, _state} = VM.execute(proto)
+
+      assert results == [nil]
+    end
+  end
 end


### PR DESCRIPTION
Implements register-based local variables

- [x]  Phase 0: Arithmetic operations and single return
- [x]  Phase 1: Local variables with register assignment
- [x]  Phase 2: Global variables (get_global, set_global)
- [ ]  Phase 3: Conditionals (if/elseif/else, and/or short-circuit)
- [ ]  Phase 4: Loops (while, repeat, numeric for)
- [ ]  Phase 5: Functions, closures, and upvalues
- [ ]  Phase 6: Tables and method calls
- [ ]  Phase 7: Generic for, varargs, and multiple returns
- [ ]  Phase 8: String concatenation and bitwise operations
- [ ]  Phase 9: Peephole optimizer
- [ ]  Phase 10: Integration with lib/lua.ex