### PR TITLE
feat(vm): Closures

### DIFF
--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -180,6 +180,10 @@ defmodule Lua.Compiler.Scope do
     state
   end
 
+  defp resolve_statement(%Statement.CallStmt{call: call}, state) do
+    resolve_expr(call, state)
+  end
+
   # For now, stub out other statement types - we'll implement them incrementally
   defp resolve_statement(_stmt, state), do: state
 


### PR DESCRIPTION
Implements function closures

- [x] Phase 0: Arithmetic operations and single return
- [x] Phase 1: Local variables with register assignment
- [x] Phase 2: Global variables (get_global, set_global)
- [x] Phase 3: Conditionals (if/elseif/else, and/or short-circuit)
- [x] Phase 4: Loops (while, repeat, numeric for)
- [ ] Phase 5: Functions, closures, and upvalues
- [ ] Phase 6: Tables and method calls
- [ ] Phase 7: Native function calls (Lua→Elixir calling convention)
- [ ] Phase 8: Generic for, varargs, and multiple returns
- [ ] Phase 9: String concatenation and bitwise operations
- [ ] Phase 10: Value encoding/decoding (Lua.VM.Value)
- [ ] Phase 11: deflua integration (reimplement lib/lua.ex against VM.State)
- [ ] Phase 12: Peephole optimizer
- [ ] Phase 13: Remove Luerl dependency