### PR TITLE
feat(vm): Generic For, Varargs, and Multiple Returns

### DIFF
--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -81,6 +81,7 @@ defmodule Lua.Compiler.Instruction do
   def call(base, arg_count, result_count), do: {:call, base, arg_count, result_count}
   def tail_call(base, arg_count), do: {:tail_call, base, arg_count}
   def return_instr(base, count), do: {:return, base, count}
+  def return_vararg, do: {:return_vararg}
   def self_instr(base, object, method_name), do: {:self, base, object, method_name}
   def vararg(base, count), do: {:vararg, base, count}
 

--- a/lib/lua/compiler/prototype.ex
+++ b/lib/lua/compiler/prototype.ex
@@ -30,7 +30,8 @@ defmodule Lua.Compiler.Prototype do
             is_vararg: false,
             max_registers: 0,
             source: <<"-no-source-">>,
-            lines: {0, 0}
+            lines: {0, 0},
+            varargs: []
 
   @doc """
   Creates a new prototype with the given options.


### PR DESCRIPTION
Implements multiple return values, vararg functions (`...`), generic for loops, and the `next`/`pairs`/`ipairs` stdlib functions. Also fixes a pre-existing bug where local variable declarations inside functions got nil register assignments — codegen was using chunk-level locals instead of function-scoped locals.

## Progress

- [x] Phase 0: Arithmetic operations and single return
- [x] Phase 1: Local variables with register assignment
- [x] Phase 2: Global variables (get_global, set_global)
- [x] Phase 3: Conditionals (if/elseif/else, and/or short-circuit)
- [x] Phase 4: Loops (while, repeat, numeric for)
- [x] Phase 5: Functions, closures, and upvalues
- [x] Phase 6: Tables and method calls
- [x] Phase 7: Native function calls (Lua→Elixir calling convention)
- [x] Phase 8: Generic for, varargs, and multiple returns
- [ ] Phase 9: String concatenation and bitwise operations
- [ ] Phase 10: Value encoding/decoding (Lua.VM.Value)
- [ ] Phase 11: deflua integration (reimplement lib/lua.ex against VM.State)
- [ ] Phase 12: Peephole optimizer
- [ ] Phase 13: Remove Luerl dependency