### PR TITLE
feat(vm): Source Line Tracking & Call Stack

### DIFF
--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -11,7 +11,9 @@ defmodule Lua.VM.State do
             upvalue_cells: %{},
             tables: %{},
             table_next_id: 0,
-            private: %{}
+            private: %{},
+            current_line: 0,
+            current_source: nil
 
   @type t :: %__MODULE__{
           globals: map(),
@@ -20,7 +22,9 @@ defmodule Lua.VM.State do
           upvalue_cells: map(),
           tables: %{optional(non_neg_integer()) => Table.t()},
           table_next_id: non_neg_integer(),
-          private: map()
+          private: map(),
+          current_line: non_neg_integer(),
+          current_source: binary() | nil
         }
 
   @doc """

--- a/test/lua/compiler/source_line_test.exs
+++ b/test/lua/compiler/source_line_test.exs
@@ -1,0 +1,108 @@
+defmodule Lua.Compiler.SourceLineTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.{Parser, Compiler}
+
+  describe "source line tracking" do
+    test "emits source_line instructions before statements" do
+      code = """
+      local x = 1
+      local y = 2
+      return x + y
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      # Check that source_line instructions are present
+      source_line_instructions =
+        proto.instructions
+        |> Enum.filter(fn
+          {:source_line, _, _} -> true
+          _ -> false
+        end)
+
+      # Should have source_line before each of the 3 statements
+      assert length(source_line_instructions) >= 3
+    end
+
+    test "source_line instructions contain correct line numbers" do
+      code = """
+      local x = 1
+      local y = 2
+      local z = 3
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      # Extract line numbers from source_line instructions
+      line_numbers =
+        proto.instructions
+        |> Enum.filter(fn
+          {:source_line, _, _} -> true
+          _ -> false
+        end)
+        |> Enum.map(fn {:source_line, line, _} -> line end)
+
+      # Should track lines 1, 2, 3
+      assert 1 in line_numbers
+      assert 2 in line_numbers
+      assert 3 in line_numbers
+    end
+
+    test "source_line instructions reference correct source file" do
+      code = "return 42"
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "my_file.lua")
+
+      # Find a source_line instruction
+      source_line_instr =
+        Enum.find(proto.instructions, fn
+          {:source_line, _, _} -> true
+          _ -> false
+        end)
+
+      assert {:source_line, _line, "my_file.lua"} = source_line_instr
+    end
+
+    test "computes correct line range for chunk" do
+      code = """
+      local x = 1
+
+
+      local y = 5
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      # Lines should span from 1 to at least 4
+      assert {first, last} = proto.lines
+      assert first == 1
+      assert last >= 4
+    end
+
+    test "computes line range for nested functions" do
+      code = """
+      local x = function()
+        local y = 2
+        return y
+      end
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      # Should have a nested prototype for the function
+      assert length(proto.prototypes) >= 1
+      nested_proto = hd(proto.prototypes)
+
+      # Nested function should have lines 2-3
+      assert {first, last} = nested_proto.lines
+      assert first >= 2
+      assert last >= 3
+    end
+  end
+end

--- a/test/lua/vm/call_stack_test.exs
+++ b/test/lua/vm/call_stack_test.exs
@@ -1,0 +1,124 @@
+defmodule Lua.VM.CallStackTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.{Parser, Compiler, VM}
+  alias Lua.VM.State
+
+  describe "call stack tracking" do
+    test "tracks current line during execution" do
+      code = """
+      local x = 1
+      local y = 2
+      return x + y
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      # Execute and capture state
+      state = State.new()
+      assert {:ok, _results, final_state} = VM.execute(proto, state)
+
+      # State should have current_line field
+      assert Map.has_key?(final_state, :current_line)
+    end
+
+    test "pushes call stack frame on function call" do
+      code = """
+      local bar = function()
+        return 42
+      end
+
+      local foo = function()
+        return bar()
+      end
+
+      return foo()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      state = State.new()
+      assert {:ok, results, _final_state} = VM.execute(proto, state)
+
+      # Should execute successfully and return 42
+      assert results == [42]
+    end
+
+    test "call stack is empty after execution completes" do
+      code = """
+      local nested = function()
+        return "deep"
+      end
+
+      local outer = function()
+        return nested()
+      end
+
+      return outer()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      state = State.new()
+      assert {:ok, _results, final_state} = VM.execute(proto, state)
+
+      # Call stack should be empty after execution
+      assert final_state.call_stack == []
+    end
+
+    test "handles recursive function calls" do
+      code = """
+      local factorial
+      factorial = function(n)
+        if n <= 1 then
+          return 1
+        else
+          return n * factorial(n - 1)
+        end
+      end
+
+      return factorial(5)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      state = State.new()
+      assert {:ok, results, final_state} = VM.execute(proto, state)
+
+      # Should compute 5! = 120
+      assert results == [120]
+
+      # Call stack should be empty after completion
+      assert final_state.call_stack == []
+    end
+
+    test "maintains call stack across multiple function calls" do
+      code = """
+      local a = function()
+        return 1
+      end
+
+      local b = function()
+        return 2
+      end
+
+      local x = a()
+      local y = b()
+      return x + y
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      state = State.new()
+      assert {:ok, results, final_state} = VM.execute(proto, state)
+
+      assert results == [3]
+      assert final_state.call_stack == []
+    end
+  end
+end


### PR DESCRIPTION
## Phase 1: Source Line Tracking & Call Stack

### Goal
Compiler emits debug info, executor tracks it at runtime. Foundation for all error reporting.

### Implementation
Implemented all steps from Phase 1:
- Compiler emits `source_line(line, source)` instructions before each statement
- Executor handles `source_line` instruction and updates `current_line` in state
- Call stack frames pushed/popped on Lua closure calls
- State struct extended with `current_line` and `current_source` fields
- Prototype line ranges computed from AST metadata

### Changes
- `lib/lua/compiler/codegen.ex` — emit source_line before statements, compute line ranges
- `lib/lua/vm/executor.ex` — handle source_line instruction, push/pop call stack frames
- `lib/lua/vm/state.ex` — add current_line, current_source fields

### Tests
- `test/lua/compiler/source_line_test.exs` — 5 tests for source line tracking in compiler
  - Verifies source_line instructions are emitted before statements
  - Validates correct line numbers and source file references
  - Tests line range computation for chunks and nested functions
- `test/lua/vm/call_stack_test.exs` — 5 tests for call stack management
  - Verifies current_line tracking during execution
  - Tests call stack push/pop on function calls
  - Validates call stack cleanup after execution
  - Tests recursive functions and multiple function calls

### Verification
- [x] `mix format` completed
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test --exclude pending` passes (885 tests, 0 failures)
- [x] Tests added: 10 new tests
- [x] Total tests: 910 (up from 900)

### Next Steps
This establishes the foundation for Phase 2 (Beautiful Stack Traces & Error Messages), which will use the call stack and source line information to generate rich error output.

---
Implements Phase 1 from plan.md