### PR TITLE
test: Add ArgumentError tests for setmetatable

### DIFF
--- a/test/lua/vm/metatable_test.exs
+++ b/test/lua/vm/metatable_test.exs
@@ -403,5 +403,41 @@ defmodule Lua.VM.MetatableTest do
 
       assert {:ok, [42], _state} = VM.execute(proto, state)
     end
+
+    test "setmetatable raises ArgumentError when first argument is not a table" do
+      code = "setmetatable(42, {})"
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new() |> Lua.VM.Stdlib.install()
+
+      assert_raise Lua.VM.ArgumentError, fn ->
+        VM.execute(proto, state)
+      end
+    end
+
+    test "setmetatable raises ArgumentError when second argument is not nil or table" do
+      code = "setmetatable({}, 42)"
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new() |> Lua.VM.Stdlib.install()
+
+      assert_raise Lua.VM.ArgumentError, fn ->
+        VM.execute(proto, state)
+      end
+    end
+
+    test "setmetatable raises ArgumentError when no arguments provided" do
+      code = "setmetatable()"
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new() |> Lua.VM.Stdlib.install()
+
+      assert_raise Lua.VM.ArgumentError, fn ->
+        VM.execute(proto, state)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Add setmetatable ArgumentError Tests

Adds comprehensive test coverage for `setmetatable` argument validation that was originally bundled with the userdata PR but belongs with the metatable/metamethod implementation.

### Tests Added

1. **Invalid first argument** - Verifies `ArgumentError` is raised when first argument is not a table
2. **Invalid second argument** - Verifies `ArgumentError` is raised when second argument is not nil or a table
3. **Missing arguments** - Verifies `ArgumentError` is raised when no arguments are provided

### Why This PR?

These tests were initially included in PR #122 (userdata support) but were correctly identified as belonging with the metatable implementation instead. This PR moves them to their proper place.

### Test Results

✅ All 1,051 tests passing
- Added 3 new ArgumentError validation tests
- No regressions