### PR TITLE
Implement load function

### DIFF
--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -1557,6 +1557,51 @@ defmodule LuaTest do
     end
   end
 
+  describe "load function" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "load compiles and returns a function", %{lua: lua} do
+      code = """
+      f = load("return 1 + 2")
+      return f()
+      """
+
+      assert {[3], _} = Lua.eval!(lua, code)
+    end
+
+    test "load with syntax error returns nil", %{lua: lua} do
+      # Note: Multi-assignment and table constructors don't capture multiple return values yet
+      # So we just test that load returns nil on error
+      code = """
+      f = load("return 1 +")
+      return f == nil
+      """
+
+      assert {[true], _} = Lua.eval!(lua, code)
+    end
+
+    test "loaded function can access upvalues", %{lua: lua} do
+      code = """
+      x = 10
+      f = load("return x + 5")
+      return f()
+      """
+
+      assert {[15], _} = Lua.eval!(lua, code)
+    end
+
+    test "load can compile complex code", %{lua: lua} do
+      code = """
+      f = load("function add(a, b) return a + b end; return add(3, 4)")
+      return f()
+      """
+
+      assert {[7], _} = Lua.eval!(lua, code)
+    end
+  end
+
   defp test_file(name) do
     Path.join(["test", "fixtures", name])
   end


### PR DESCRIPTION
Implements the Lua load() function which compiles a string of Lua code and returns a function that executes it.

Features:
- Compiles string chunks into executable functions
- Returns nil + error message on parse/compile errors
- Compiled functions can access global environment

Limitations:
- Only supports string chunks (not reader functions)
- Does not support chunkname, mode, or env parameters yet
- Error messages include ANSI formatting (cosmetic issue)

Tests added for basic load functionality. Some tests are simplified due to current VM limitations with multi-assignment (a, b = f()) and multi-value table constructors ({f()}).

This enables running Lua 5.3 test suite files that use load() for dynamic code generation and testing.