### PR TITLE
feat(phase-10): Polish & Remaining TODOs

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -569,10 +569,9 @@ defmodule Lua do
   @doc """
   Calls a function in Lua's state
 
-      # TODO: Restore once string stdlib is implemented
-      #iex> {:ok, [ret], _lua} = Lua.call_function(Lua.new(), [:string, :lower], ["HELLO ROBERT"])
-      #iex> ret
-      #"hello robert"
+      iex> {:ok, [ret], _lua} = Lua.call_function(Lua.new(), [:string, :lower], ["HELLO ROBERT"])
+      iex> ret
+      "hello robert"
 
       iex> lua = Lua.new()
       iex> lua = Lua.set!(lua, [:double], fn [val] -> [val * 2] end)
@@ -580,11 +579,10 @@ defmodule Lua do
 
   References to functions can also be passed
 
-      # TODO: Restore once string stdlib is implemented
-      #iex> {[ref], lua} = Lua.eval!("return string.lower", decode: false)
-      #iex> {:ok, [ret], _lua} = Lua.call_function(lua, ref, ["FUNCTION REF"])
-      #iex> ret
-      #"function ref"
+      iex> {[ref], lua} = Lua.eval!(Lua.new(), "return string.lower", decode: false)
+      iex> {:ok, [ret], _lua} = Lua.call_function(lua, ref, ["FUNCTION REF"])
+      iex> ret
+      "function ref"
 
       iex> {[ref], lua} = Lua.eval!(Lua.new(), "return function(x) return x end", decode: false)
       iex> {:ok, [ret], _lua} = Lua.call_function(lua, ref, [42])
@@ -660,12 +658,8 @@ defmodule Lua do
   defmodule MyAPI do
     use Lua.API, scope: "example"
 
-    # TODO: Restore once string stdlib is implemented
-    # deflua foo(value), state do
-    #   Lua.call_function!(state, [:string, :lower], [value])
-    # end
     deflua foo(value), state do
-      Lua.call_function!(state, [:my_func], [value])
+      Lua.call_function!(state, [:string, :lower], [value])
     end
   end
   ```


### PR DESCRIPTION
## Phase 10: Polish & Remaining TODOs

Completes the final phase of the Lua 5.3 VM implementation plan.

### Summary

This PR addresses remaining TODOs from earlier phases and implements critical compiler gaps needed for the Lua 5.3 test suite.

### Changes

#### 1. Restored String Standard Library Doctests
Since the string stdlib was fully implemented in Phase 5, restored 3 commented-out doctests in `lib/lua.ex`:
- `call_function/3` with `string.lower` 
- Function reference passing with `string.lower`
- API module example using `string.lower`

All doctests now pass successfully.

#### 2. Local Function Declarations (`local function`)
Implemented compiler support for `local function name() ... end` syntax:

**Scope Resolution:**
- Allocates register for the local function name
- Adds name to parent locals map before resolving function body
- Resolves function body scope with upvalue access

**Code Generation:**
- Generates closure from function node
- Stores closure in allocated local register

**Examples:**
```lua
local function add(a, b)
  return a + b
end

local function make_counter()
  local count = 0
  local function increment()
    count = count + 1
    return count
  end
  return increment
end
```

**Known Limitations:**
- Self-recursive local functions not yet supported (requires upvalue self-reference support)
- These cases are marked with `@tag :skip` in tests

#### 3. Do...End Blocks
Implemented compiler support for `do...end` blocks:

**Scope Resolution:**
- Resolves block body within current scope

**Code Generation:**
- Generates block instructions inline

**Examples:**
```lua
local x = 1
do
  local y = 2
  x = x + y
end
return x -- returns 3
```

**Known Limitations:**
- Proper nested scope creation/cleanup not fully implemented
- Inner `local` declarations may shadow outer ones incorrectly
- These edge cases are marked with `@tag :skip` in tests

### Testing

Added 9 new integration tests:
- ✅ Basic local function (3 passing tests)
- ✅ Local function with closure
- ⏭️ Local function recursive (skipped - requires self-reference support)
- ✅ Local function reassignment
- ✅ Basic do block (4 passing tests)
- ⏭️ Do block creates new scope (skipped - requires scope cleanup)
- ✅ Nested do blocks  
- ✅ Empty do block
- ✅ Do block with return

### Test Results

```
mix test
# 52 doctests, 14 properties, 1129 tests, 0 failures, 34 skipped
```

- **+9 new tests** (1129 total, up from 1120)
- **+2 skipped** (34 total, up from 32 - known limitations documented)
- **0 failures**

### Verification

- [x] `mix format` completed
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` passes (1129 tests, 0 failures)
- [x] Tests added: 9
- [x] Doctests restored: 3

### Impact on Lua 5.3 Test Suite

These compiler features unblock many Lua 5.3 test suite files that use:
- `local function` declarations (used in `all.lua`, `api.lua`, `constructs.lua`, etc.)
- `do...end` blocks for scoping (used throughout the test suite)

While edge cases remain (recursion, nested scoping), the basic functionality enables significantly more test files to parse and run.

### Next Steps

Future work to address limitations:
- Implement upvalue self-reference for recursive local functions
- Implement proper scope depth tracking and cleanup for nested scopes
- These can be addressed incrementally as needed

---
Implements Phase 10 from plan.md