### PR TITLE
feat(phase-12): Complete metamethods support

### DIFF
--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -57,7 +57,14 @@ defmodule Lua.VM.Stdlib.String do
     {tref, state} = State.alloc_table(state, string_table)
 
     # Register as global
-    State.set_global(state, "string", tref)
+    state = State.set_global(state, "string", tref)
+
+    # Create string metatable with __index = string table
+    # This enables ("hello"):upper() syntax
+    {mt_ref, state} = State.alloc_table(state, %{"__index" => tref})
+
+    # Store as the type metatable for strings
+    %{state | metatables: Map.put(state.metatables, "string", mt_ref)}
   end
 
   # string.lower(s) - converts string to lowercase

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -1445,9 +1445,7 @@ defmodule LuaTest do
       assert {[true], _} = Lua.eval!(lua, "return _G._G == _G")
     end
 
-    @tag :skip
     test "can set globals via _G", %{lua: lua} do
-      # Requires _G to be a live reference with __index/__newindex metamethods
       code = """
       _G.myvar = 42
       return myvar
@@ -1456,9 +1454,7 @@ defmodule LuaTest do
       assert {[42], _} = Lua.eval!(lua, code)
     end
 
-    @tag :skip
     test "can read globals via _G", %{lua: lua} do
-      # Requires _G to be a live reference with __index metamethods
       code = """
       myvar = 123
       return _G.myvar
@@ -1598,6 +1594,175 @@ defmodule LuaTest do
       """
 
       assert {[7], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "function-valued __index and __newindex" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "function __index is called on missing key", %{lua: lua} do
+      code = """
+      local t = {}
+      local mt = {__index = function(tbl, key) return key .. "!" end}
+      setmetatable(t, mt)
+      return t.hello, t.world
+      """
+
+      assert {["hello!", "world!"], _} = Lua.eval!(lua, code)
+    end
+
+    test "function __newindex is called on new key", %{lua: lua} do
+      code = """
+      local log = {}
+      local t = {}
+      local mt = {__newindex = function(tbl, key, val) log[#log + 1] = key .. "=" .. tostring(val) end}
+      setmetatable(t, mt)
+      t.x = 10
+      t.y = 20
+      return log[1], log[2]
+      """
+
+      assert {["x=10", "y=20"], _} = Lua.eval!(lua, code)
+    end
+
+    test "__index chain follows tables", %{lua: lua} do
+      code = """
+      local base = {greeting = "hello"}
+      local mid = {}
+      setmetatable(mid, {__index = base})
+      local top = {}
+      setmetatable(top, {__index = mid})
+      return top.greeting
+      """
+
+      assert {["hello"], _} = Lua.eval!(lua, code)
+    end
+
+    test "existing keys bypass __index", %{lua: lua} do
+      code = """
+      local t = {x = 1}
+      setmetatable(t, {__index = function() return 999 end})
+      return t.x
+      """
+
+      assert {[1], _} = Lua.eval!(lua, code)
+    end
+
+    test "existing keys bypass __newindex", %{lua: lua} do
+      code = """
+      local called = false
+      local t = {x = 1}
+      setmetatable(t, {__newindex = function() called = true end})
+      t.x = 2
+      return t.x, called
+      """
+
+      assert {[2, false], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "__call metamethod" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "table with __call can be called as function", %{lua: lua} do
+      code = """
+      local t = {}
+      setmetatable(t, {__call = function(self, a, b) return a + b end})
+      return t(3, 4)
+      """
+
+      assert {[7], _} = Lua.eval!(lua, code)
+    end
+
+    test "__call receives self as first argument", %{lua: lua} do
+      code = """
+      local t = {value = 10}
+      setmetatable(t, {__call = function(self) return self.value end})
+      return t()
+      """
+
+      assert {[10], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "__tostring metamethod" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "tostring uses __tostring metamethod", %{lua: lua} do
+      code = """
+      local t = {name = "foo"}
+      setmetatable(t, {__tostring = function(self) return "MyObj(" .. self.name .. ")" end})
+      return tostring(t)
+      """
+
+      assert {["MyObj(foo)"], _} = Lua.eval!(lua, code)
+    end
+
+    test "print uses __tostring metamethod", %{lua: lua} do
+      code = """
+      local t = {}
+      setmetatable(t, {__tostring = function() return "custom" end})
+      return tostring(t)
+      """
+
+      assert {["custom"], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "__metatable protection" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "getmetatable returns __metatable sentinel", %{lua: lua} do
+      code = """
+      local t = {}
+      setmetatable(t, {__metatable = "protected"})
+      return getmetatable(t)
+      """
+
+      assert {["protected"], _} = Lua.eval!(lua, code)
+    end
+
+    test "setmetatable errors on protected metatable", %{lua: lua} do
+      code = """
+      local t = {}
+      setmetatable(t, {__metatable = "protected"})
+      local ok = pcall(setmetatable, t, {})
+      return ok
+      """
+
+      assert {[false], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "string metatable" do
+    setup do
+      %{lua: Lua.new(sandboxed: [])}
+    end
+
+    test "string method syntax works", %{lua: lua} do
+      assert {["HELLO"], _} = Lua.eval!(lua, ~S[return ("hello"):upper()])
+    end
+
+    test "string.method via colon syntax", %{lua: lua} do
+      assert {["olleh"], _} = Lua.eval!(lua, ~S[return ("hello"):reverse()])
+    end
+
+    test "string indexing for methods", %{lua: lua} do
+      code = """
+      local s = "hello"
+      local f = s.upper
+      return f(s)
+      """
+
+      assert {["HELLO"], _} = Lua.eval!(lua, code)
     end
   end
 


### PR DESCRIPTION
## Summary
- Function-valued `__index` and `__newindex` with chain depth limit (200)
- `__call` metamethod for calling non-function values
- `__tostring` metamethod in `tostring()` and `print()`
- `__metatable` protection in `getmetatable`/`setmetatable`
- String metatable with `__index = string` table (enables `("hello"):upper()` syntax)
- `_G` dynamic proxy with `__index`/`__newindex` delegating to `state.globals`
- Refactored table access into `table_index`/`table_newindex`/`index_value` helpers

## Test plan
- [x] Function-valued __index and __newindex (5 tests)
- [x] __call on tables (2 tests)
- [x] __tostring with custom objects (2 tests)
- [x] __metatable protection (2 tests)
- [x] String method syntax `("hello"):upper()` (3 tests)
- [x] _G bidirectional read/write (2 unskipped tests)
- [x] 1229 tests, 0 failures, 33 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)