### PR TITLE
feat(phase-14a): Stubs, bitwise fixes, and math return types

### DIFF
--- a/lib/lua/vm/stdlib/math.ex
+++ b/lib/lua/vm/stdlib/math.ex
@@ -150,7 +150,7 @@ defmodule Lua.VM.Stdlib.Math do
 
   # math.ceil(x)
   defp math_ceil([x], state) when is_number(x) do
-    {[Float.ceil(x / 1)], state}
+    {[trunc(Float.ceil(x / 1))], state}
   end
 
   defp math_ceil([x | _], _state) do
@@ -201,7 +201,7 @@ defmodule Lua.VM.Stdlib.Math do
 
   # math.floor(x)
   defp math_floor([x], state) when is_number(x) do
-    {[Float.floor(x / 1)], state}
+    {[trunc(Float.floor(x / 1))], state}
   end
 
   defp math_floor([x | _], _state) do

--- a/test/lua/vm/stdlib/math_test.exs
+++ b/test/lua/vm/stdlib/math_test.exs
@@ -23,7 +23,7 @@ defmodule Lua.VM.Stdlib.MathTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = Stdlib.install(State.new())
 
-      assert {:ok, [4.0, -3.0, 5.0], _state} = VM.execute(proto, state)
+      assert {:ok, [4, -3, 5], _state} = VM.execute(proto, state)
     end
 
     test "math.floor rounds down" do
@@ -32,7 +32,7 @@ defmodule Lua.VM.Stdlib.MathTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = Stdlib.install(State.new())
 
-      assert {:ok, [3.0, -4.0, 5.0], _state} = VM.execute(proto, state)
+      assert {:ok, [3, -4, 5], _state} = VM.execute(proto, state)
     end
 
     test "math.max returns maximum" do


### PR DESCRIPTION
## Summary
- `collectgarbage` stub accepting all standard modes with plausible return values
- `dofile` stub raising "not supported in embedded mode"
- `_VERSION` global set to `"Lua 5.3"`
- Global `unpack` alias for `table.unpack`
- Bitwise string coercion (e.g., `"0xff" | 0`)
- Lua 5.3 shift semantics: negative shift reverses direction, shift >= 64 yields 0
- Bitwise metamethods: `__band`, `__bor`, `__bxor`, `__bnot`, `__shl`, `__shr`
- `math.floor`/`math.ceil` return integers instead of floats

## Test plan
- [x] collectgarbage returns without error (2 tests)
- [x] `_VERSION == "Lua 5.3"` (1 test)
- [x] `unpack({10, 20, 30})` works as global alias (1 test)
- [x] Bitwise string coercion and shift edge cases (3 tests)
- [x] math.floor/ceil return integers (2 tests)
- [x] Updated math_test.exs assertions for integer return types
- [x] 1224 tests, 0 failures, 35 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)