### PR TITLE
fix: local function declarations

### DIFF
--- a/test/language/function_test.exs
+++ b/test/language/function_test.exs
@@ -39,4 +39,134 @@ defmodule Lua.Language.FunctionTest do
 
     assert {["error msg"], _} = Lua.eval!(lua, code)
   end
+
+  describe "FuncDecl local assignment" do
+    test "function f() updates local f when it exists in scope", %{lua: lua} do
+      code = """
+      local f = function(x) return "first: " .. x end
+      assert(f("test") == "first: test")
+
+      function f(x)
+        return "second: " .. x
+      end
+
+      return f("test")
+      """
+
+      assert {["second: test"], _} = Lua.eval!(lua, code)
+    end
+
+    test "function f() creates global when no local exists", %{lua: lua} do
+      code = """
+      function f(x)
+        return "global: " .. x
+      end
+
+      return f("test")
+      """
+
+      assert {["global: test"], _} = Lua.eval!(lua, code)
+    end
+
+    test "function f() in nested do block does not see outer local", %{lua: lua} do
+      code = """
+      local f = function() return "outer" end
+
+      do
+        local f = function() return "inner" end
+
+        function f()
+          return "updated inner"
+        end
+
+        assert(f() == "updated inner")
+      end
+
+      -- outer f should be unchanged
+      return f()
+      """
+
+      assert {["outer"], _} = Lua.eval!(lua, code)
+    end
+
+    test "dotted name always uses table assignment", %{lua: lua} do
+      code = """
+      local t = {}
+
+      function t.method(x)
+        return x + 1
+      end
+
+      return t.method(41)
+      """
+
+      assert {[42], _} = Lua.eval!(lua, code)
+    end
+
+    test "function f() does not see locals declared after the FuncDecl", %{lua: lua} do
+      code = """
+      function f()
+        return "global"
+      end
+
+      local f = function() return "local" end
+
+      -- The global f is unaffected by the later local declaration
+      return f()
+      """
+
+      assert {["local"], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "local function declarations" do
+    test "basic local function", %{lua: lua} do
+      code = """
+      local function add(a, b)
+        return a + b
+      end
+      return add(1, 2)
+      """
+
+      assert {[3], _} = Lua.eval!(lua, code)
+    end
+
+    test "recursive local function", %{lua: lua} do
+      code = """
+      local function fact(n)
+        if n <= 1 then return 1 end
+        return n * fact(n - 1)
+      end
+      return fact(5)
+      """
+
+      assert {[120], _} = Lua.eval!(lua, code)
+    end
+
+    test "local function captures outer locals", %{lua: lua} do
+      code = """
+      local base = 10
+      local function add_base(x)
+        return x + base
+      end
+      return add_base(5)
+      """
+
+      assert {[15], _} = Lua.eval!(lua, code)
+    end
+
+    test "local function is not visible outside its scope", %{lua: lua} do
+      code = """
+      do
+        local function helper()
+          return 42
+        end
+        assert(helper() == 42)
+      end
+      return helper == nil
+      """
+
+      assert {[true], _} = Lua.eval!(lua, code)
+    end
+  end
 end


### PR DESCRIPTION
Pulled from #142
Closes #144 

### FuncDecl Local Assignment ⭐
Fixed `function f()` syntax to properly update local variables:
- `function f()` now correctly updates local `f` when one exists in scope
- Scope resolution marks assignment target in `var_map` at declaration time
- Prevents future locals from incorrectly affecting earlier code during codegen
- Fixes common Lua pattern where `local f = function()...` is followed by `function f()`

**Example fixed pattern:**
```lua
local f = function(x) return "first" end
-- Later redefine f
function f(x) return "second" end
-- f now correctly refers to "second"
```

**FuncDecl Fix:**
- Scope resolution checks if local exists at FuncDecl position
- Stores target as `{:func_decl_target, decl}` in `var_map`
- Codegen uses this marker instead of checking `ctx.scope.locals` (which contains all function-scope locals)