### PR TITLE
chore: link plans to GitHub issues, add A14 for regression

### DIFF
--- a/.agents/plans/A0-int-overflow-wrapping.md
+++ b/.agents/plans/A0-int-overflow-wrapping.md
@@ -1,7 +1,7 @@
 ---
 id: A0
 title: 64-bit integer overflow wrapping for arithmetic and bitwise ops
-issue: null
+issue: 161
 pr: null
 branch: feat/int-overflow-wrapping
 base: main

--- a/.agents/plans/A1-table-nil-on-missing-key.md
+++ b/.agents/plans/A1-table-nil-on-missing-key.md
@@ -1,7 +1,7 @@
 ---
 id: A1
 title: Empty/missing-key table reads return nil instead of crashing
-issue: null
+issue: 162
 pr: null
 branch: fix/table-nil-on-missing-key
 base: main

--- a/.agents/plans/A10-suite-timeouts.md
+++ b/.agents/plans/A10-suite-timeouts.md
@@ -1,7 +1,7 @@
 ---
 id: A10
 title: Investigate big.lua, closure.lua, utf8.lua timeouts
-issue: null
+issue: 171
 pr: null
 branch: fix/suite-timeouts
 base: main

--- a/.agents/plans/A11-source-todos.md
+++ b/.agents/plans/A11-source-todos.md
@@ -1,7 +1,7 @@
 ---
 id: A11
 title: Resolve in-source TODOs (compiler error handling, stacktrace formatting, load reader chunks)
-issue: null
+issue: 172
 pr: null
 branch: chore/source-todos
 base: main

--- a/.agents/plans/A12-readme-changelog.md
+++ b/.agents/plans/A12-readme-changelog.md
@@ -1,7 +1,7 @@
 ---
 id: A12
 title: Update README and CHANGELOG for 0.5.0
-issue: null
+issue: 173
 pr: null
 branch: docs/0-5-0
 base: main

--- a/.agents/plans/A13-release-rc1.md
+++ b/.agents/plans/A13-release-rc1.md
@@ -1,7 +1,7 @@
 ---
 id: A13
 title: Cut 0.5.0-rc.1
-issue: null
+issue: 174
 pr: null
 branch: release/0-5-0-rc-1
 base: main

--- a/.agents/plans/A14-for-loop-register-regression.md
+++ b/.agents/plans/A14-for-loop-register-regression.md
@@ -1,0 +1,107 @@
+---
+id: A14
+title: Fix for-loop register regression (consecutive for loops corrupt state)
+issue: 146
+pr: null
+branch: fix/for-loop-register-regression
+base: main
+status: ready
+direction: A
+unlocks: []
+---
+
+## Goal
+
+Fix the regression where two consecutive numeric `for` loops in any scope
+produce a runtime type error on the second loop. This was originally fixed
+in PR #141 (Phase 17) but reintroduced by the perf rewrites (likely the
+CPS executor in PR #156).
+
+## Reproduction
+
+```lua
+local sum = 0
+for i = 1, 3 do sum = sum + i end
+for i = 1, 3 do sum = sum + i end
+return sum
+```
+
+Expected: `12`. Actual: `Lua runtime error: Runtime Type Error — attempt
+to perform arithmetic on a nil value`.
+
+A single for loop works fine. The bug appears only with two or more
+consecutive `for` loops that share scope.
+
+Stack trace points to:
+
+```
+lib/lua/vm/executor.ex:1594 anonymous fn/1 in safe_add/2
+lib/lua/vm/executor.ex:1485 try_binary_metamethod/5
+lib/lua/vm/executor.ex:713 do_execute/8
+```
+
+## Out of scope
+
+- Other for-loop edge cases not directly tied to this regression.
+- Architectural changes to the CPS executor (PR #156).
+- Performance optimization of for-loop dispatch.
+
+## Success criteria
+
+- [ ] `mix test` passes (≥ 1273, no regressions)
+- [ ] New unit test in `test/lua/vm/for_loop_register_test.exs`:
+  - Two consecutive `for i = 1, n` loops produce correct sum.
+  - Three consecutive `for i = 1, n` loops produce correct sum.
+  - Two consecutive loops with different variable names work.
+  - Two consecutive loops with the same variable name work (was the
+    original #146 case).
+- [ ] `mix test --only lua53` count: should not regress; may improve.
+- [ ] Issue #146 closed automatically by the merging PR.
+
+## Implementation notes
+
+The original Phase 17 fix (commit `e7c50e5`) reserved 3 registers in scope
+for the for-loop's internal counter/limit/step to prevent body-local
+conflicts. The CPS refactor (PR #156, commit `13b2964`) reorganized the
+executor and likely lost the register-clearing logic between iterations.
+
+Steps:
+
+1. Reproduce in isolation as a unit test (already verified above).
+2. Inspect the current `:numeric_for` (or equivalent) handler in
+   `lib/lua/vm/executor.ex` after the CPS rewrite. The handler may have
+   been renamed.
+3. Compare against what Phase 17 did: when a for loop completes, ensure
+   the loop's local registers (counter, limit, step, loop_var) are not
+   left polluting the parent scope's register file.
+4. Fix the leak. Likely a missing register-clear between for-loop end and
+   the next instruction, or a missing `open_upvalues` reset that was
+   present in `e7c50e5`.
+
+Read `lib/lua/compiler/codegen.ex` for how the for loop emits its
+internal-register reservations — the codegen side may also need
+adjustment if the bug is at compile time, not runtime.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+mix test test/lua/vm/for_loop_register_test.exs
+```
+
+## Risks
+
+- The CPS refactor was substantial; the fix needs to fit the new shape
+  without re-introducing the perf cost it eliminated.
+- If the bug is in codegen rather than executor, the unit test still
+  passes after the fix but a downstream test may break — keep the suite
+  test running throughout.
+- The original fix (Phase 17) also touched upvalue handling; verify
+  closures-over-loop-variables still work after this fix.
+
+## Discoveries
+
+(populated during implementation)

--- a/.agents/plans/A2-long-string-lexer.md
+++ b/.agents/plans/A2-long-string-lexer.md
@@ -1,7 +1,7 @@
 ---
 id: A2
 title: Long-string [[ ... ]] lexer handles embedded ] and level brackets [==[
-issue: null
+issue: 163
 pr: null
 branch: fix/long-string-lexer
 base: main

--- a/.agents/plans/A3-comment-leak.md
+++ b/.agents/plans/A3-comment-leak.md
@@ -1,7 +1,7 @@
 ---
 id: A3
 title: Comment tokens leak past lexer in calls.lua path
-issue: null
+issue: 164
 pr: null
 branch: fix/lexer-comment-leak
 base: main

--- a/.agents/plans/A4-preload-stdlib-modules.md
+++ b/.agents/plans/A4-preload-stdlib-modules.md
@@ -1,7 +1,7 @@
 ---
 id: A4
 title: Pre-load Lua stdlib tables into package.loaded
-issue: null
+issue: 165
 pr: null
 branch: fix/preload-stdlib-modules
 base: main

--- a/.agents/plans/A5-bitwise-suite.md
+++ b/.agents/plans/A5-bitwise-suite.md
@@ -1,7 +1,7 @@
 ---
 id: A5
 title: Fix bitwise.lua failing assertion
-issue: null
+issue: 166
 pr: null
 branch: fix/bitwise-suite
 base: main

--- a/.agents/plans/A6-locals-suite.md
+++ b/.agents/plans/A6-locals-suite.md
@@ -1,7 +1,7 @@
 ---
 id: A6
 title: Fix locals.lua "attempt to call nil" at line 67
-issue: null
+issue: 167
 pr: null
 branch: fix/locals-suite
 base: main

--- a/.agents/plans/A7-nextvar-suite.md
+++ b/.agents/plans/A7-nextvar-suite.md
@@ -1,7 +1,7 @@
 ---
 id: A7
 title: Fix nextvar.lua "concatenate nil" failure
-issue: null
+issue: 168
 pr: null
 branch: fix/nextvar-suite
 base: main

--- a/.agents/plans/A8-events-suite.md
+++ b/.agents/plans/A8-events-suite.md
@@ -1,7 +1,7 @@
 ---
 id: A8
 title: Fix events.lua metamethod assertion
-issue: null
+issue: 169
 pr: null
 branch: fix/events-suite
 base: main

--- a/.agents/plans/A9-pm-suite.md
+++ b/.agents/plans/A9-pm-suite.md
@@ -1,7 +1,7 @@
 ---
 id: A9
 title: Fix pm.lua pattern-matching assertion
-issue: null
+issue: 170
 pr: null
 branch: fix/pm-suite
 base: main


### PR DESCRIPTION
## Summary

Setup-2 follow-up to PR #160. Pure metadata: links plans to issues, adds one new plan for a regression discovered during housekeeping.

## What landed in GitHub state

### Stale issues closed (verified fixed on `main`)

- **#144** — `local function` declarations silently dropped (fixed by Phase 11, #137).
- **#145** — `function t.method()` dot-syntax fails at runtime (fixed by Phase 17, #141).
- **#148** — `string.format` precision specifiers (fixed by Phase 16, #136).

### PR closed as superseded

- **#142** — phase-17 integer overflow + FuncDecl. Vararg/scope portion already on main; integer overflow carried over as plan A0.

### Issues created (one per Direction A plan)

| Plan | Issue | Title |
|------|-------|-------|
| A0  | #161 | 64-bit integer overflow wrapping |
| A1  | #162 | empty/missing-key table reads return nil |
| A2  | #163 | long-string lexer correctness |
| A3  | #164 | comment-token leak |
| A4  | #165 | pre-load stdlib modules |
| A5  | #166 | bitwise.lua (blocked on A0) |
| A6  | #167 | locals.lua line 67 |
| A7  | #168 | nextvar.lua (blocked on A1) |
| A8  | #169 | events.lua metamethod |
| A9  | #170 | pm.lua pattern match |
| A10 | #171 | big/closure/utf8 timeouts |
| A11 | #172 | in-source TODOs |
| A12 | #173 | README and CHANGELOG |
| A13 | #174 | cut 0.5.0-rc.1 (blocked) |
| A14 | #146 | for-loop register regression (NEW) |

All in milestone [`0.5.0 — Suite Triage`](https://github.com/tv-labs/lua/milestone/1).

### Labels created

`direction:A`, `direction:B`, `kind:suite`, `kind:perf`, `kind:cleanup`, `defer`, `regression`.

### Milestones created

- `0.5.0 — Suite Triage` — Direction A goal: ≥12/24 suite files passing.
- `0.5.x — Performance` — Direction B (post-0.5.0).

## What landed in this PR

### A14 — new plan: for-loop register regression

While verifying #146 was fixed (so I could close it), I found it had **regressed**. Two consecutive numeric `for` loops now produce a runtime type error on the second loop:

```lua
local sum = 0
for i = 1, 3 do sum = sum + i end
for i = 1, 3 do sum = sum + i end
return sum  -- crashes
```

The original fix (Phase 17, commit `e7c50e5`) reserved 3 registers in scope for the loop's internal counter/limit/step. The CPS executor refactor (PR #156) reorganized the executor and lost that protection.

Added as plan `.agents/plans/A14-for-loop-register-regression.md`, tracking issue #146 (which stays open with a comment confirming the regression).

### Plan frontmatter updates

Each `A*.md` file now has its `issue:` frontmatter set. This means `/open-pr` can generate accurate `Closes #N` lines and `/next-plan` can show the linked issue.

## Verification

- `mix compile --warnings-as-errors` ✅
- `mix test` ✅ (1274 passing, 0 failing — no regressions from this PR)
- `mix format --check-formatted` ✅