### PR TITLE
chore: sync main and branch off in /next-plan workflow

### DIFF
--- a/.agents/commands/next-plan.md
+++ b/.agents/commands/next-plan.md
@@ -17,7 +17,10 @@ Show me the plan summary first:
 
 Then ask whether to proceed.
 
-If I confirm, load the `ship-a-plan` skill and execute it on that plan file.
+If I confirm, first sync `main` with `origin/main` (checkout main, fetch,
+fast-forward pull), then branch off of the freshly-synced main using the
+plan's `branch:` value before starting work. After that, load the
+`ship-a-plan` skill and execute it on that plan file.
 
 If there are no ready plans, list the plans grouped by status so I can see
 the current state of the pipeline.


### PR DESCRIPTION
## Summary

- Updates the `/next-plan` slash command so that, on confirmation, it syncs `main` with `origin/main` and branches off the freshly-synced `main` using the plan's `branch:` value before invoking `ship-a-plan`.
- Prevents accidentally basing plan PRs on a stale local `main`.

## Why

While running `/next-plan` against `A0-int-overflow-wrapping`, I noticed the workflow didn't explicitly require pulling latest before branching. Codifying this in the command itself keeps the agent honest on every future invocation.