### PR TITLE
fix(lexer): handle multi-line comments at every bracket level and main.lua-style headers

### DIFF
--- a/.agents/plans/A2-long-string-lexer.md
+++ b/.agents/plans/A2-long-string-lexer.md
@@ -5,7 +5,7 @@ issue: 163
 pr: null
 branch: fix/long-string-lexer
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - literals.lua

--- a/.agents/plans/A2-long-string-lexer.md
+++ b/.agents/plans/A2-long-string-lexer.md
@@ -5,7 +5,7 @@ issue: 163
 pr: null
 branch: fix/long-string-lexer
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - literals.lua
@@ -98,4 +98,43 @@ mix test --only lua53
 
 ## Discoveries
 
-(populated during implementation)
+- The plan's leading hypothesis was wrong. `Lua.Lexer.tokenize/1` already
+  handles long strings at every bracket level correctly:
+
+  - `[[ ... ]]` (level 0)
+  - `[=[ ... ]=]`, `[==[ ... ]==]`, `[===[ ... ]===]` (higher levels)
+  - Embedded `]]` inside a higher-level string (level mismatch is fine)
+  - The first matching close at the right level wins (`[==[]=]==]` → `]=`)
+
+  The literals.lua line 14–17 snippet that motivated the plan tokenizes
+  correctly today. A regression test for that exact snippet is now pinned
+  in `test/lua/lexer_test.exs`.
+
+- The actual blocker for `literals.lua` was *long comments*, not long
+  strings. The lexer's `--[` branch only recognized level-0 multi-line
+  comments (`--[[`); `--[=[`, `--[==[`, `--[===[` all fell through to the
+  single-line comment scanner, which then mis-tokenized the body. Fixed by
+  routing `--[` through the existing `scan_long_bracket/2` helper so all
+  bracket levels share one entry point with long strings. This was listed
+  as out of scope, but the success criterion "literals.lua parses" forced
+  the fix — the file uses level-3 long comments.
+
+- The actual blocker for `main.lua` was the first line: `# testing
+  special comment on first line`. Lua's reference loader skips any first
+  line beginning with `#` (manual §3.1, footnote about `lua` CLI). Our
+  `strip_shebang/1` only handled `#!`. Tightened the rule to strip when
+  the first character is `#` followed by `!` or whitespace, which keeps
+  `#` (length operator) and `#table` (length-of) intact. This is also
+  pinned by tests.
+
+- Three existing lexer tests pinned the buggy `--[=[ ... ]=]` →
+  single-line behaviour with explicit "(known limitation)" comments;
+  those have been rewritten to assert the correct multi-line behaviour.
+
+- The dead `scan_multiline_comment/5` helper (which only existed to
+  consume the second `[` of a level-0 opener) was removed.
+
+- Suite delta: `mix test --only lua53` count is unchanged (4 ready,
+  remainder skipped) because `literals.lua` and `main.lua` are still in
+  `@skipped_tests` — they parse cleanly now but they hit unrelated
+  runtime gaps. Promoting them is a separate plan.

--- a/.agents/plans/A2-long-string-lexer.md
+++ b/.agents/plans/A2-long-string-lexer.md
@@ -2,7 +2,7 @@
 id: A2
 title: Long-string [[ ... ]] lexer handles embedded ] and level brackets [==[
 issue: 163
-pr: null
+pr: 180
 branch: fix/long-string-lexer
 base: main
 status: review
@@ -138,3 +138,28 @@ mix test --only lua53
   remainder skipped) because `literals.lua` and `main.lua` are still in
   `@skipped_tests` — they parse cleanly now but they hit unrelated
   runtime gaps. Promoting them is a separate plan.
+
+## What changed
+
+Files touched:
+
+- `lib/lua/lexer.ex` — route `--[` through `scan_long_bracket/2`; widen
+  shebang strip to `#!` or `# `+whitespace; remove dead
+  `scan_multiline_comment/5`.
+- `test/lua/lexer_test.exs` — three tests rewritten to assert correct
+  multi-line behaviour for `--[=[`/`--[==[`; +7 new tests covering long
+  strings at level 3, level-mismatched embedded `]]`, the
+  `literals.lua:14–17` snippet, the `literals.lua:240–245`
+  nested-comment snippet, the `main.lua` `# ...` header, and the `#`
+  length operator.
+- `.agents/plans/A2-long-string-lexer.md` — status, PR number,
+  discoveries, this section.
+
+Test deltas:
+
+- `mix test`: 1294 → 1301, 0 failures.
+- `mix test --only lua53`: unchanged (4 ready, 25 skipped). literals.lua
+  and main.lua still skipped — they parse cleanly now but hit unrelated
+  runtime gaps. Promoting them is a separate plan.
+
+No follow-up issues opened.

--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -43,16 +43,22 @@ defmodule Lua.Lexer do
     do_tokenize(code, [], pos)
   end
 
-  # Strip shebang (#!) if it's the first line
-  defp strip_shebang(<<"#!", rest::binary>>) do
-    # Skip entire first line (everything up to and including the newline)
+  # Strip the first line if it looks like a shebang/header directive. Lua's
+  # reference loader skips any first line beginning with `#`, but the lexer is
+  # also called on free-form snippets where `#` is the length operator, so we
+  # only strip when the first character is followed by something that clearly
+  # isn't a length-operator expression: `!` (the canonical shebang) or a
+  # whitespace character (the form `# ...` used by Lua's own main.lua test).
+  defp strip_shebang(<<"#!", rest::binary>>), do: strip_first_line(rest)
+  defp strip_shebang(<<"#", c, rest::binary>>) when c in [?\s, ?\t], do: strip_first_line(rest)
+  defp strip_shebang(code), do: code
+
+  defp strip_first_line(rest) do
     case String.split(rest, ~r/\r\n|\r|\n/, parts: 2) do
-      [_shebang_line, remaining] -> remaining
-      [_only_shebang] -> ""
+      [_first_line, remaining] -> remaining
+      [_only_line] -> ""
     end
   end
-
-  defp strip_shebang(code), do: code
 
   # End of input
   defp do_tokenize(<<>>, acc, pos) do
@@ -82,15 +88,23 @@ defmodule Lua.Lexer do
     do_tokenize(rest, acc, new_pos)
   end
 
-  # Comments: single-line (--) or multi-line (--[[ ... ]])
+  # Comments: single-line (--) or multi-line (--[[ ... ]] or --[=[ ... ]=] etc.)
   defp do_tokenize(<<"--[", rest::binary>>, acc, pos) do
-    # Check if it's a multi-line comment
-    case rest do
-      <<"[", _::binary>> ->
-        # Multi-line comment --[[ ... ]]
-        scan_multiline_comment(rest, acc, advance_column(pos, 3), pos, 0)
+    # scan_long_bracket eats `=` characters then requires a closing `[`,
+    # so it correctly detects --[[ (level 0), --[=[ (level 1), --[==[ (level 2), etc.
+    case scan_long_bracket(rest, 0) do
+      {:ok, equals, after_bracket} ->
+        # Multi-line comment of the given level
+        scan_multiline_comment_text(
+          after_bracket,
+          "",
+          acc,
+          advance_column(pos, 3 + equals),
+          pos,
+          equals
+        )
 
-      _ ->
+      :error ->
         # Single-line comment starting with --[
         scan_single_line_comment(rest, acc, advance_column(pos, 3), pos)
     end
@@ -284,12 +298,9 @@ defmodule Lua.Lexer do
     scan_single_line_comment_content(rest, text <> <<c>>, acc, advance_column(pos, 1), start_pos)
   end
 
-  # Scan multi-line comment --[[ ... ]] or --[=[ ... ]=]
-  # pos is current scanning position, token_pos is where the comment started
-  defp scan_multiline_comment(<<"[", rest::binary>>, acc, pos, token_pos, level) do
-    scan_multiline_comment_text(rest, "", acc, advance_column(pos, 1), token_pos, level)
-  end
-
+  # Scan multi-line comment body. The opening bracket level was determined by
+  # scan_long_bracket in do_tokenize/3. `pos` is the current scanning position
+  # (right after the opener), `start_pos` is where the comment started.
   defp scan_multiline_comment_text(<<"]", rest::binary>>, text, acc, pos, start_pos, level) do
     case try_close_long_bracket(rest, level, 0) do
       {:ok, after_bracket} ->

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -215,6 +215,84 @@ defmodule Lua.LexerTest do
       assert {:error, {:unclosed_long_string, _}} = Lexer.tokenize("[=[test")
     end
 
+    test "long strings handle higher bracket levels and embedded brackets" do
+      # Level-3 bracket
+      assert {:ok, [{:string, "hi", _}, {:eof, _}]} = Lexer.tokenize("[===[hi]===]")
+
+      # ]] inside a [=[ ... ]=] is part of the body, not a close
+      assert {:ok, [{:string, " has ]] inside ", _}, {:eof, _}]} =
+               Lexer.tokenize("[=[ has ]] inside ]=]")
+
+      # The first close at the matching level wins
+      assert {:ok, [{:string, "]=", _}, {:eof, _}]} = Lexer.tokenize("[==[]=]==]")
+    end
+
+    test "long strings reproduce the literals.lua line 14-17 snippet" do
+      # From the official Lua 5.3 test suite test/lua53_tests/literals.lua:
+      #
+      #   assert('\n\"\'\\' == [[
+      #
+      #   "'\]])
+      #
+      # The long string body is a literal newline, blank line, then "'\, then
+      # ]] closes. The trailing ]) is a literal `]` followed by `)` that closes
+      # the assert call. Inside a long string, `\` has no escape meaning.
+      assert {:ok, [{:string, body, _}, {:delimiter, :rparen, _}, {:eof, _}]} =
+               Lexer.tokenize("[[\n\n\"'\\]])")
+
+      assert body == "\n\n\"'\\"
+    end
+  end
+
+  describe "long comments" do
+    test "tokenizes long comments at every bracket level" do
+      assert {:ok, [{:comment, :multi, " hi ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[[ hi ]]")
+
+      assert {:ok, [{:comment, :multi, " hi ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[=[ hi ]=]")
+
+      assert {:ok, [{:comment, :multi, " hi ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[==[ hi ]==]")
+
+      assert {:ok, [{:comment, :multi, " hi ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[===[ hi ]===]")
+    end
+
+    test "long comments allow embedded close brackets at lower levels" do
+      # ]] inside [=[ ... ]=] doesn't close the comment
+      assert {:ok, [{:comment, :multi, " has ]] inside ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[=[ has ]] inside ]=]")
+    end
+
+    test "long comments reproduce the literals.lua nested-comment snippet" do
+      # Adapted from test/lua53_tests/literals.lua line 240-245:
+      #
+      #   --[===[
+      #   x y z [==[ blu foo
+      #   ]==
+      #   ]
+      #   ]=]==]
+      #   error error]=]===]
+      #
+      # The level-3 comment swallows everything up to the first matching
+      # ]===]. None of ]==, ], or ]=]==] inside the body close it; the
+      # close is the ]===] at the end of `error error]=]===]`.
+      assert {:ok, tokens} =
+               Lexer.tokenize("--[===[\nx y z [==[ blu foo\n]==\n]\n]=]==]\nerror error]=]===]\nprint(1)")
+
+      assert [
+               {:comment, :multi, body, _},
+               {:identifier, "print", _},
+               {:delimiter, :lparen, _},
+               {:number, 1, _},
+               {:delimiter, :rparen, _},
+               {:eof, _}
+             ] = tokens
+
+      assert body == "\nx y z [==[ blu foo\n]==\n]\n]=]==]\nerror error]="
+    end
+
     test "handles \\z escape sequence (skip whitespace)" do
       # \z skips all following whitespace including newlines
       assert {:ok, [{:string, "abcdef", _}, {:eof, _}]} = Lexer.tokenize("\"abc\\z  \n   def\"")
@@ -305,13 +383,15 @@ defmodule Lua.LexerTest do
                Lexer.tokenize("x --[[ comment ]] ")
     end
 
-    test "handles multi-line comments with equals signs (currently as single-line)" do
-      # Note: --[=[ is currently treated as single-line comment (known limitation)
-      assert {:ok, [{:comment, :single, "=[ comment ]=]", _}, {:eof, _}]} =
+    test "handles multi-line comments with equals signs at every level" do
+      assert {:ok, [{:comment, :multi, " comment ", _}, {:eof, _}]} =
                Lexer.tokenize("--[=[ comment ]=]")
 
-      assert {:ok, [{:comment, :single, "==[ comment ]==]", _}, {:eof, _}]} =
+      assert {:ok, [{:comment, :multi, " comment ", _}, {:eof, _}]} =
                Lexer.tokenize("--[==[ comment ]==]")
+
+      assert {:ok, [{:comment, :multi, " comment ", _}, {:eof, _}]} =
+               Lexer.tokenize("--[===[ comment ]===]")
     end
 
     test "handles content with brackets in multi-line comments" do
@@ -320,9 +400,8 @@ defmodule Lua.LexerTest do
       assert [{:comment, :multi, " comment ", _}, {:eof, _}] = tokens
 
       # With nesting levels using =, you can include ]] in the comment
-      # Note: Currently treated as single-line comment
       assert {:ok, tokens2} = Lexer.tokenize("--[=[ comment with ]] in it ]=]")
-      assert [{:comment, :single, "=[ comment with ]] in it ]=]", _}, {:eof, _}] = tokens2
+      assert [{:comment, :multi, " comment with ]] in it ", _}, {:eof, _}] = tokens2
     end
 
     test "reports error for unclosed multi-line comment" do
@@ -330,12 +409,11 @@ defmodule Lua.LexerTest do
     end
 
     test "handles false closing brackets in multi-line comments" do
-      # Test a ] that is not followed by the right number of =
-      # Note: --[=[ is currently treated as single-line comment
-      assert {:ok, [{:comment, :single, "=[ test ] more ]=]", _}, {:eof, _}]} =
+      # A bare `]` inside a level-1 comment should not close it
+      assert {:ok, [{:comment, :multi, " test ] more ", _}, {:eof, _}]} =
                Lexer.tokenize("--[=[ test ] more ]=]")
 
-      # Test a ] that is not followed by ]
+      # `]=` without the trailing `]` should not close a level-0 comment
       assert {:ok, [{:comment, :multi, " test ]= more ", _}, {:eof, _}]} =
                Lexer.tokenize("--[[ test ]= more ]]")
     end
@@ -376,6 +454,20 @@ defmodule Lua.LexerTest do
 
       # Second line with # should cause error (not a shebang)
       assert {:error, _} = Lexer.tokenize(code2)
+    end
+
+    test "ignores '# ...' header on first line (Lua reference allows any #-prefixed first line)" do
+      # The official Lua 5.3 main.lua test starts with `# testing special comment...`,
+      # so we strip when the first character is `#` followed by whitespace.
+      code = "# testing special comment on first line\nlocal x = 1\n"
+      assert {:ok, [{:keyword, :local, _} | _]} = Lexer.tokenize(code)
+    end
+
+    test "leaves the length operator alone when # is not a header" do
+      # `#` standalone or directly followed by an identifier is the length
+      # operator and must NOT be consumed as a header.
+      assert {:ok, [{:operator, :len, _}, {:eof, _}]} = Lexer.tokenize("#")
+      assert {:ok, [{:operator, :len, _}, {:identifier, "t", _}, {:eof, _}]} = Lexer.tokenize("#t")
     end
   end
 
@@ -631,12 +723,9 @@ defmodule Lua.LexerTest do
     end
 
     test "multi-line comment with mismatched bracket level" do
-      # The closing bracket doesn't match the opening level
-      # Note: --[=[ is currently treated as single-line comment
-      assert {:ok, [{:comment, :single, "=[ comment ]]", _}, {:eof, _}]} =
-               Lexer.tokenize("--[=[ comment ]]")
-
-      # This should continue scanning until EOF because ]] doesn't match the opening [=[
+      # ]] inside a [=[...]=] comment is NOT a close (level mismatch),
+      # so the comment runs past EOF and is reported as unclosed.
+      assert {:error, {:unclosed_comment, _}} = Lexer.tokenize("--[=[ comment ]]")
     end
 
     test "long string with mismatched closing bracket" do


### PR DESCRIPTION
## Long-string `[[ ... ]]` lexer handles embedded `]` and level brackets `[==[`

Plan: [`.agents/plans/A2-long-string-lexer.md`](https://github.com/tv-labs/lua/blob/fix/long-string-lexer/.agents/plans/A2-long-string-lexer.md)
Closes #163

### Goal

Make the lexer correctly handle Lua's long-string literal syntax (and, as
discovered during implementation, long *comments* at every bracket level).
Previously both `literals.lua` and `main.lua` failed to parse.

### Success criteria

- [x] `mix test` passes (1294 → 1301, no regressions; +7 new lexer tests)
- [x] New unit tests in `test/lua/lexer_test.exs` for `[[ ... ]]` with
  embedded `]`, including a verbatim regression test for the
  `literals.lua` line 14–17 snippet that originally motivated the plan
- [x] `[=[ ... ]=]` works (already did; now pinned)
- [x] `[==[ ... ]==]` works (already did; now pinned)
- [x] `[=[ contains ]] inside ]=]` works (level mismatch is fine)
- [x] `literals.lua` and `main.lua` both at least parse cleanly via
  `Lua.Parser.parse/1`

### Changes

```
 .agents/plans/A2-long-string-lexer.md |  43 +++++++++++-
 lib/lua/lexer.ex                      |  51 ++++++++------
 test/lua/lexer_test.exs               | 121 +++++++++++++++++++++++++++++-----
 3 files changed, 177 insertions(+), 38 deletions(-)
```

### Discoveries

- The plan's leading hypothesis was wrong. Long *strings* already worked
  at every bracket level — the literals.lua line 14–17 snippet tokenises
  correctly today. A regression test for it is now pinned.
- The actual blocker was long *comments*. The lexer's `--[` branch only
  recognised level-0 (`--[[`); `--[=[`, `--[==[`, `--[===[` all fell
  through to the single-line scanner. Fixed by routing `--[` through the
  existing `scan_long_bracket/2` helper so all levels share one entry
  point with long strings. literals.lua line 240–245 uses a level-3 long
  comment.
- main.lua's first line is `# testing special comment on first line`.
  Lua's reference loader skips any first line starting with `#`; we only
  handled `#!`. Tightened to `#!` or `# `+whitespace, which keeps the
  `#` length operator (`#`, `#t`, `#table`) working everywhere else.
- Three existing lexer tests pinned the buggy single-line behaviour for
  `--[=[` with explicit `"(known limitation)"` notes; updated to assert
  the correct multi-line behaviour.
- The dead `scan_multiline_comment/5` helper was removed.
- `mix test --only lua53` count is unchanged. literals.lua and main.lua
  parse cleanly now but they hit unrelated runtime gaps; promoting them
  to ready is a separate plan.

### Verification

```
mix format
mix compile --warnings-as-errors      # clean
mix test                               # 52 doctests, 45 properties, 1301 tests, 0 failures, 32 skipped
mix test test/lua/lexer_test.exs       # 1 doctest, 90 tests, 0 failures
mix test --only lua53                  # 29 tests, 0 failures, 25 skipped
```

### Out of scope (intentional)

- Promoting `literals.lua` or `main.lua` from `@skipped_tests` to
  `@ready_tests`. They parse cleanly now but fail at runtime for reasons
  unrelated to the lexer (missing `debug` stdlib, etc.). Separate plan.
- Long-string position tracking after a stripped shebang/header line —
  the existing implementation resets line/column at offset 0 regardless,
  and that's not a regression.