### PR TITLE
fix(compiler): assign function declaration to in-scope local

### DIFF
--- a/.agents/plans/A6-locals-suite.md
+++ b/.agents/plans/A6-locals-suite.md
@@ -2,10 +2,10 @@
 id: A6
 title: Fix locals.lua "attempt to call nil" at line 67
 issue: 167
-pr: null
+pr: 185
 branch: fix/locals-suite
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - locals.lua
@@ -65,6 +65,15 @@ mix test --only lua53
 - May interact with the CPS executor's handling of upvalue cells.
 - May be the same root cause as some `nextvar.lua` failure; check after fix.
 
+## What changed
+
+- `lib/lua/compiler/scope.ex` — added a `resolve_statement` clause for single-name `FuncDecl` that walks locals → upvalue chain → global and records the resolution under `{:func_decl_target, decl}` in `var_map`.
+- `lib/lua/compiler/codegen.ex` — `gen_statement` for single-name `FuncDecl` now reads the namespaced `var_map` entry and emits `move`, `set_open_upvalue`, `set_upvalue`, or `set_global` accordingly.
+- `test/lua/vm/local_func_redef_test.exs` — 4 new unit tests covering the core fix and edge cases.
+
+Suite delta: `locals.lua` now progresses past line 67; fails at line 72 on `debug.getupvalue` (out of scope).
+Tests: 1318 → 1322 (4 new tests added), 0 failures.
+
 ## Discoveries
 
-(populated during implementation)
+The `resolve_function_scope` helper always overwrites `var_map[decl]` with the function-scope reference (`make_ref()`). Using a namespaced key `{:func_decl_target, decl}` sidesteps the collision cleanly without touching `resolve_function_scope`.

--- a/.agents/plans/A6-locals-suite.md
+++ b/.agents/plans/A6-locals-suite.md
@@ -5,7 +5,7 @@ issue: 167
 pr: null
 branch: fix/locals-suite
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - locals.lua

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -610,8 +610,30 @@ defmodule Lua.Compiler.Codegen do
     {closure_instructions, closure_reg, ctx} = gen_closure_from_node(decl, ctx)
 
     case name do
-      [single_name] ->
-        {closure_instructions ++ [Instruction.set_global(single_name, closure_reg)], ctx}
+      [_single_name] ->
+        # Per Lua 5.3: `function name(...) end` is sugar for `name = function(...) end`.
+        # Use the var_map entry resolved by scope analysis (local/upvalue/global).
+        store_instructions =
+          case Map.get(ctx.scope.var_map, {:func_decl_target, decl}) do
+            {:register, local_reg} ->
+              if local_reg == closure_reg, do: [], else: [Instruction.move(local_reg, closure_reg)]
+
+            {:captured_local, local_reg} ->
+              [Instruction.set_open_upvalue(local_reg, closure_reg)]
+
+            {:upvalue, index} ->
+              [Instruction.set_upvalue(index, closure_reg)]
+
+            {:global, gname} ->
+              [Instruction.set_global(gname, closure_reg)]
+
+            nil ->
+              # Fallback: treat as global (shouldn't happen after scope analysis)
+              [single] = name
+              [Instruction.set_global(single, closure_reg)]
+          end
+
+        {closure_instructions ++ store_instructions, ctx}
 
       [first | rest] ->
         # Dotted name: get the table chain, then set the final field

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -200,6 +200,43 @@ defmodule Lua.Compiler.Scope do
     state
   end
 
+  defp resolve_statement(
+         %Statement.FuncDecl{name: [single_name], params: params, body: body, is_method: is_method} = decl,
+         state
+       )
+       when is_binary(single_name) do
+    # Per Lua 5.3 §3.4.11: `function name(...) end` is sugar for `name = function(...) end`.
+    # Resolve the target name through scope (local → captured_local → upvalue → global)
+    # and store the result in var_map so codegen can emit the right store instruction.
+    all_params = if is_method, do: ["self" | params], else: params
+
+    # Resolve the target name (local/upvalue/global) and store under a namespaced
+    # key so resolve_function_scope cannot overwrite it (it always stores the
+    # function-scope reference under the bare `decl` key).
+    target_key = {:func_decl_target, decl}
+
+    state =
+      case Map.get(state.locals, single_name) do
+        nil ->
+          case find_upvalue(single_name, state.parent_scopes, state) do
+            {:ok, upvalue_index, state} ->
+              %{state | var_map: Map.put(state.var_map, target_key, {:upvalue, upvalue_index})}
+
+            :not_found ->
+              %{state | var_map: Map.put(state.var_map, target_key, {:global, single_name})}
+          end
+
+        reg ->
+          if MapSet.member?(state.captured_locals, single_name) do
+            %{state | var_map: Map.put(state.var_map, target_key, {:captured_local, reg})}
+          else
+            %{state | var_map: Map.put(state.var_map, target_key, {:register, reg})}
+          end
+      end
+
+    resolve_function_scope(decl, all_params, body, state)
+  end
+
   defp resolve_statement(%Statement.FuncDecl{params: params, body: body, is_method: is_method} = decl, state) do
     all_params = if is_method, do: ["self" | params], else: params
     resolve_function_scope(decl, all_params, body, state)

--- a/test/lua/vm/local_func_redef_test.exs
+++ b/test/lua/vm/local_func_redef_test.exs
@@ -1,0 +1,72 @@
+defmodule Lua.VM.LocalFuncRedefTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.State
+
+  # Per Lua 5.3 §3.4.11:
+  #   `function name(...) end` is syntactic sugar for `name = function(...) end`.
+  # When `name` is already declared as a local, the assignment must update that
+  # local's register, not write to the global environment.
+
+  describe "function declaration assigns to in-scope local" do
+    test "local f; function f(x) ... end updates the local" do
+      code = """
+      local f
+      function f(x) return x * 2 end
+      return f(5)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [10], _state} = VM.execute(proto, state)
+    end
+
+    test "function declaration does not pollute the global when a local is in scope" do
+      code = """
+      local f
+      function f(x) return x + 1 end
+      local global_f = _G and _G.f
+      return f(3), global_f == nil
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      # f(3) == 4; global_f should be nil (no global leak)
+      assert {:ok, [4, true], _state} = VM.execute(proto, state)
+    end
+
+    test "global function declaration still writes to global when no local is in scope" do
+      code = """
+      function g(x) return x * 3 end
+      return g(4)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [12], _state} = VM.execute(proto, state)
+    end
+
+    test "function declaration inside a block assigns to the enclosing local" do
+      code = """
+      local result
+      do
+        local f
+        function f(n) return n * n end
+        result = f(7)
+      end
+      return result
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [49], _state} = VM.execute(proto, state)
+    end
+  end
+end


### PR DESCRIPTION
## Fix locals.lua "attempt to call nil" at line 67

Plan: [`.agents/plans/A6-locals-suite.md`](.agents/plans/A6-locals-suite.md)
Closes #167

### Goal

Make `locals.lua` progress past line 67. The failure was `f(2)` where `f` is nil — a top-level `function f(a)` declaration at line 44 didn't update the `local f` declared at line 37.

Per Lua 5.3 §3.4.11, `function name(...) end` is syntactic sugar for `name = function(...) end`. When `name` is already in scope as a local, the store must go to the local's register, not the global environment.

### Success criteria

- [x] `mix test` passes — 1322 tests, 0 failures (up from 1318, no regressions; 4 new unit tests added)
- [x] New unit test in `test/lua/vm/local_func_redef_test.exs` covering the `local f; function f(x) ... end` pattern (4 cases)
- [x] `locals.lua` progresses past line 67 — now fails at line 72 (`debug.getupvalue`) which is explicitly out of scope

### Changes

```
 lib/lua/compiler/codegen.ex           | 26 ++++++++++++-
 lib/lua/compiler/scope.ex             | 37 ++++++++++++++++++
 test/lua/vm/local_func_redef_test.exs | 72 +++++++++++++++++++++++++++++++++++
 3 files changed, 133 insertions(+), 2 deletions(-)
```

**`lib/lua/compiler/scope.ex`** — `resolve_statement` for `FuncDecl` with a single name now resolves the target name through scope (local → captured_local → upvalue → global) and stores the resolution under a namespaced key `{:func_decl_target, decl}`. The namespacing avoids collision with `resolve_function_scope`, which always stores the function-scope reference under the bare `decl` key.

**`lib/lua/compiler/codegen.ex`** — `gen_statement` for `FuncDecl` single-name case now reads `{:func_decl_target, decl}` from `var_map` and emits the appropriate store instruction (`move` for local, `set_open_upvalue` for captured local, `set_upvalue`, or `set_global`).

**`test/lua/vm/local_func_redef_test.exs`** — New test module with 4 cases covering: basic local reassignment, no global leak when local exists, global write when no local is in scope, and assignment to enclosing local from inside a `do` block.

### Verification

```
mix format           # clean
mix compile --warnings-as-errors  # clean
mix test             # 1322 tests, 0 failures, 32 skipped
mix test --only lua53  # 29 tests, 0 failures, 25 skipped
```

### Out of scope (intentional)

- Backward goto (separate plan, deferred)
- `debug.getupvalue` semantics — locals.lua now fails at line 72 on this; it is a separate concern