### PR TITLE
fix(pattern): unblock pm.lua through line 110

### DIFF
--- a/.agents/plans/A9-pm-suite.md
+++ b/.agents/plans/A9-pm-suite.md
@@ -2,10 +2,10 @@
 id: A9
 title: Fix pm.lua pattern-matching assertion
 issue: 170
-pr: null
+pr: 188
 branch: fix/pm-suite
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - pm.lua
@@ -23,10 +23,16 @@ generic `assertion failed` — needs triage.
 
 ## Success criteria
 
-- [ ] `mix test` passes (≥ 1273, no regressions)
-- [ ] Each fixed assertion has a unit test in
-      `test/lua/vm/string_test.exs` or `test/lua/vm/pattern_test.exs`.
-- [ ] `pm.lua` passes end-to-end.
+- [x] `mix test` passes (≥ 1273, no regressions)
+- [x] Each fixed assertion has a unit test in
+      `test/lua/vm/string_test.exs` or `test/lua/vm/lexer_test.exs`.
+- [ ] `pm.lua` passes end-to-end. **Narrowed.** The triage on this plan
+      uncovered five distinct, layered bugs blocking pm.lua. The first
+      four are fixed in this PR (see Discoveries) and now pm.lua reaches
+      line 112. The fifth — an executor crash on `string.char(range(0, 255))`
+      caused by multi-return tail-call register expansion — is a separate
+      concern far from the pattern engine and is split into a follow-up
+      plan A9a (`fix/pm-suite-executor`).
 
 ## Implementation notes
 
@@ -65,4 +71,70 @@ mix test test/lua/vm/string_test.exs
 
 ## Discoveries
 
-(populated during implementation)
+Triage walked the file in order, fixing each blocker as it surfaced. Each
+fix has a unit test attached; pm.lua acts as the integration regression.
+
+1. **Lexer never decoded numeric escapes.** `"a\0o"` parsed as four bytes
+   (`a`, `\`, `0`, `o`) instead of three. Affected pm.lua from line 21
+   onward — almost every assertion uses `\0`, `\200`, `\xff`, etc.
+   - Added `\ddd`, `\xXX`, `\u{...}` handling to `lib/lua/lexer.ex`,
+     including UTF-8 encoding for codepoints up to 0x7FFFFFFF.
+   - Updated the existing "invalid escape" test, which incorrectly
+     asserted that `\1` and `\x` should pass through verbatim. Per the
+     Lua 5.3 reference manual §3.1, `\ddd` is a valid decimal escape
+     and a bare `\x` is a malformed escape (parse-time error).
+
+2. **Pattern engine missing `%g`, `%G`, `%x`, `%X` character classes.**
+   pm.lua line 51 (`%g%g%g+`) was the first user; many later lines use
+   `%x` for hex-digit matching.
+
+3. **`string.gsub` crashed when an end-anchored zero-width pattern
+   matched at the end of the subject.** The `pos > len` cleanup branch
+   passed a negative length to `:erlang.binary_part/3`. Fixed by
+   clamping the remainder length to zero.
+
+4. **`string.sub(s, i, j)` returned the wrong value when `j == 0`.**
+   The `normalize_index/2` helper collapsed both `0` and `1` to the
+   same 0-based offset, so the empty `[1,0]` range became a one-char
+   match. Replaced with PUC-Lua's `posrelat`-then-clamp algorithm.
+
+5. **Position captures `()` were treated as zero-width string captures
+   instead of numeric byte positions.** The `f1` helper in pm.lua (and
+   anything using `()` for position tracking) returned the wrong types.
+   Compiler now emits `:position_capture` for `()` and the matcher
+   records `pos + 1` as a number.
+
+6. **Out of scope (split to A9a):** pm.lua line 112's
+   `string.char(range(0, 255))` triggers an executor crash —
+   `:erlang.setelement/3` is called with an index past the end of the
+   register tuple when a tail-recursive multi-return funnels 256 values
+   into a fixed-size register file. This is a pure executor bug
+   unrelated to patterns; addressing it requires register growth in
+   `Lua.VM.Executor.do_frame_return/6` and is tracked in
+   `.agents/plans/A9a-pm-suite-executor.md`.
+
+## What changed
+
+PR: #188
+
+Files touched:
+
+- `lib/lua/lexer.ex` — decimal/hex/unicode numeric escapes, plus
+  Bitwise import for the UTF-8 encoder.
+- `lib/lua/vm/stdlib/pattern.ex` — `%g`/`%G`/`%x`/`%X` classes;
+  position-capture compile + match; gsub clamp on end-overflow.
+- `lib/lua/vm/stdlib/string.ex` — PUC-Lua `posrelat`-then-clamp
+  semantics for `string.sub`.
+- `test/lua/lexer_test.exs` — new tests for `\ddd`, `\xXX`,
+  `\u{...}`, malformed `\x`, plus relaxed "unknown escape"
+  passthrough; the old "invalid escape" test (which contradicted the
+  Lua 5.3 reference) was replaced.
+- `test/lua/vm/string_test.exs` — regression tests for `string.sub`
+  edge cases, `%g`/`%x` classes, position captures, NUL-in-pattern,
+  and the gsub end-overflow.
+
+Suite delta: 1327 → 1342 unit tests (+15 regressions). lua53 official
+suite: 4/24 ready (unchanged). pm.lua remains in `@skipped_tests` —
+moving it to `@ready_tests` is gated on A9a.
+
+Follow-up: [`.agents/plans/A9a-pm-suite-executor.md`](A9a-pm-suite-executor.md).

--- a/.agents/plans/A9-pm-suite.md
+++ b/.agents/plans/A9-pm-suite.md
@@ -5,7 +5,7 @@ issue: 170
 pr: null
 branch: fix/pm-suite
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - pm.lua

--- a/.agents/plans/A9a-pm-suite-executor.md
+++ b/.agents/plans/A9a-pm-suite-executor.md
@@ -1,0 +1,93 @@
+---
+id: A9a
+title: Fix multi-return register expansion exposed by pm.lua
+issue: null
+pr: null
+branch: fix/pm-suite-executor
+base: main
+status: ready
+direction: A
+unlocks:
+  - pm.lua (continuation of A9)
+---
+
+## Goal
+
+Make `pm.lua` runnable past line 112 by fixing the executor's multi-return
+handling. Once unblocked, finish triaging any remaining pm.lua failures
+and land the suite test under `@ready_tests`.
+
+## Out of scope
+
+- Pattern-engine work (covered by A9 / future A9b if needed).
+- General executor refactors. Make the smallest change that grows the
+  register tuple safely on multi-return.
+
+## Success criteria
+
+- [ ] `string.char(<256 returns from a recursive multi-return function>)`
+      no longer crashes.
+- [ ] `pm.lua` passes end-to-end (or the next failure surfaces and is
+      either fixed in scope or split into A9b).
+- [ ] `pm.lua` is moved from `@skipped_tests` to `@ready_tests` in
+      `test/lua53_suite_test.exs`.
+- [ ] Unit test added in `test/lua/vm/call_stack_test.exs` (or new file)
+      that exercises a recursive multi-return ≥ 100 values feeding a
+      variadic native call.
+- [ ] `mix test` passes (≥ current count, no regressions).
+
+## Implementation notes
+
+Failure (reproducible from `pm.lua` line 112):
+
+```
+:erlang.setelement(26, {tuple of 25 elements}, 255)
+lib/lua/vm/executor.ex:1143  do_frame_return/6
+```
+
+Triggered by:
+
+```lua
+local function range(i, j)
+  if i <= j then return i, range(i+1, j) end
+end
+local abc = string.char(range(0, 255))
+```
+
+`range(0, 255)` returns 256 values via tail-position multi-return. The
+`-2` (multi-return expansion) branch in `do_frame_return/6` writes them
+into the caller's register tuple starting at `base`, but the tuple was
+allocated by the compiler for the syntactic call site and isn't sized
+for 256 expanded slots.
+
+Likely fix: in the `-2` arm of `do_frame_return/6`, ensure
+`caller_regs` is grown to at least `base + length(results_list)` slots
+before the `Enum.reduce/3` writes happen. The same precaution probably
+belongs in the fixed-N arm (`n > 0`) and in `continue_after_call/12`.
+
+Use `:erlang.tuple_size/1` to check capacity, and rebuild the tuple
+with appended `nil`s if needed. Keep the change to a single helper
+function so the three call sites stay aligned.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+mix test test/lua/vm/call_stack_test.exs
+mix test test/lua/vm/string_test.exs
+```
+
+## Risks
+
+- Growing the register tuple changes a hot-path invariant. Make sure
+  the new path is taken only when actually needed (`needed_size >
+  tuple_size(regs)`), so the common case stays a single `put_elem`.
+- Coroutines and pcall use the same return path; verify their tests
+  still pass before opening the PR.
+
+## Discoveries
+
+(populated during implementation)

--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -5,6 +5,8 @@ defmodule Lua.Lexer do
   Tokenizes Lua source code into a list of tokens with position tracking.
   """
 
+  import Bitwise
+
   @type position :: %{line: pos_integer(), column: pos_integer(), byte_offset: non_neg_integer()}
   @type token ::
           {:keyword, atom(), position()}
@@ -353,6 +355,45 @@ defmodule Lua.Lexer do
     scan_string(remaining, str_acc, acc, new_pos, start_pos, quote)
   end
 
+  # \xXX hex escape: exactly two hex digits
+  defp scan_string(<<?\\, ?x, h1, h2, rest::binary>>, str_acc, acc, pos, start_pos, quote)
+       when h1 in ?0..?9 or h1 in ?a..?f or h1 in ?A..?F do
+    if hex?(h2) do
+      byte = hex_value(h1) * 16 + hex_value(h2)
+      scan_string(rest, str_acc <> <<byte>>, acc, advance_column(pos, 4), start_pos, quote)
+    else
+      {:error, {:invalid_escape, pos}}
+    end
+  end
+
+  defp scan_string(<<?\\, ?x, _rest::binary>>, _str_acc, _acc, pos, _start_pos, _quote) do
+    {:error, {:invalid_escape, pos}}
+  end
+
+  # \u{XXX} unicode escape (UTF-8 encoded codepoint)
+  defp scan_string(<<?\\, ?u, ?{, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
+    case scan_unicode_escape(rest, 0, 0) do
+      {:ok, codepoint, digits, after_brace} when codepoint <= 0x7FFFFFFF ->
+        utf8 = encode_lua_utf8(codepoint)
+        # consumed: \u{ + digits + }
+        scan_string(after_brace, str_acc <> utf8, acc, advance_column(pos, 4 + digits), start_pos, quote)
+
+      _ ->
+        {:error, {:invalid_escape, pos}}
+    end
+  end
+
+  # \ddd decimal escape: 1-3 decimal digits, value must fit in a byte
+  defp scan_string(<<?\\, d1, rest::binary>>, str_acc, acc, pos, start_pos, quote) when d1 in ?0..?9 do
+    {value, digits, remaining} = read_decimal_escape(d1 - ?0, 1, rest)
+
+    if value > 255 do
+      {:error, {:invalid_escape, pos}}
+    else
+      scan_string(remaining, str_acc <> <<value>>, acc, advance_column(pos, 1 + digits), start_pos, quote)
+    end
+  end
+
   defp scan_string(<<?\\, esc, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
     # Escape sequence
     case escape_char(esc) do
@@ -375,6 +416,70 @@ defmodule Lua.Lexer do
 
   defp scan_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
     scan_string(rest, str_acc <> <<c>>, acc, advance_column(pos, 1), start_pos, quote)
+  end
+
+  # Read up to two more decimal digits for a \ddd escape
+  defp read_decimal_escape(value, digits, <<d, rest::binary>>) when d in ?0..?9 and digits < 3 do
+    next = value * 10 + (d - ?0)
+
+    if next > 255 do
+      {value, digits, <<d, rest::binary>>}
+    else
+      read_decimal_escape(next, digits + 1, rest)
+    end
+  end
+
+  defp read_decimal_escape(value, digits, rest), do: {value, digits, rest}
+
+  # Read hex digits inside \u{...}
+  defp scan_unicode_escape(<<?}, rest::binary>>, value, digits) when digits > 0 do
+    {:ok, value, digits + 1, rest}
+  end
+
+  defp scan_unicode_escape(<<c, rest::binary>>, value, digits) when digits < 8 do
+    if hex?(c) do
+      scan_unicode_escape(rest, value * 16 + hex_value(c), digits + 1)
+    else
+      :error
+    end
+  end
+
+  defp scan_unicode_escape(_rest, _value, _digits), do: :error
+
+  defp hex?(c), do: c in ?0..?9 or c in ?a..?f or c in ?A..?F
+
+  defp hex_value(c) when c in ?0..?9, do: c - ?0
+  defp hex_value(c) when c in ?a..?f, do: c - ?a + 10
+  defp hex_value(c) when c in ?A..?F, do: c - ?A + 10
+
+  # Encode a codepoint as UTF-8. Lua 5.3 accepts codepoints up to 0x7FFFFFFF
+  # (6-byte UTF-8), beyond what Erlang's :unicode module emits, so handle the
+  # full range manually.
+  defp encode_lua_utf8(c) when c < 0x80 do
+    <<c>>
+  end
+
+  defp encode_lua_utf8(c) when c < 0x800 do
+    <<0b110_00000 ||| c >>> 6, 0b10_000000 ||| (c &&& 0b111111)>>
+  end
+
+  defp encode_lua_utf8(c) when c < 0x10000 do
+    <<0b1110_0000 ||| c >>> 12, 0b10_000000 ||| (c >>> 6 &&& 0b111111), 0b10_000000 ||| (c &&& 0b111111)>>
+  end
+
+  defp encode_lua_utf8(c) when c < 0x200000 do
+    <<0b11110_000 ||| c >>> 18, 0b10_000000 ||| (c >>> 12 &&& 0b111111), 0b10_000000 ||| (c >>> 6 &&& 0b111111),
+      0b10_000000 ||| (c &&& 0b111111)>>
+  end
+
+  defp encode_lua_utf8(c) when c < 0x4000000 do
+    <<0b111110_00 ||| c >>> 24, 0b10_000000 ||| (c >>> 18 &&& 0b111111), 0b10_000000 ||| (c >>> 12 &&& 0b111111),
+      0b10_000000 ||| (c >>> 6 &&& 0b111111), 0b10_000000 ||| (c &&& 0b111111)>>
+  end
+
+  defp encode_lua_utf8(c) do
+    <<0b1111110_0 ||| c >>> 30, 0b10_000000 ||| (c >>> 24 &&& 0b111111), 0b10_000000 ||| (c >>> 18 &&& 0b111111),
+      0b10_000000 ||| (c >>> 12 &&& 0b111111), 0b10_000000 ||| (c >>> 6 &&& 0b111111), 0b10_000000 ||| (c &&& 0b111111)>>
   end
 
   # Escape character mapping

--- a/lib/lua/vm/stdlib/pattern.ex
+++ b/lib/lua/vm/stdlib/pattern.ex
@@ -93,8 +93,10 @@ defmodule Lua.VM.Stdlib.Pattern do
 
   defp gsub_from(subject, pos, len, _pattern, _repl, max_n, count, acc)
        when pos > len or (max_n != nil and count >= max_n) do
-    # Append remaining subject
-    remaining = binary_part(subject, pos, len - pos)
+    # Append remaining subject (clamp pos so we never read past end_of_string)
+    remaining =
+      if pos < len, do: binary_part(subject, pos, len - pos), else: ""
+
     {IO.iodata_to_binary([Enum.reverse(acc), remaining]), count}
   end
 
@@ -185,6 +187,11 @@ defmodule Lua.VM.Stdlib.Pattern do
 
   defp compile_elements("$", acc) do
     Enum.reverse([:anchor_end | acc])
+  end
+
+  defp compile_elements("()" <> rest, acc) do
+    # Position capture: records the current byte position (1-based) at this point.
+    compile_elements(rest, [:position_capture | acc])
   end
 
   defp compile_elements("(" <> rest, acc) do
@@ -283,6 +290,11 @@ defmodule Lua.VM.Stdlib.Pattern do
   # Capture start
   defp match_elements(subject, pos, [:capture_start | rest], full, cstack, captures) do
     match_elements(subject, pos, rest, full, [{pos, nil} | cstack], captures)
+  end
+
+  # Position capture — record the current 1-based byte position as a number
+  defp match_elements(subject, pos, [:position_capture | rest], full, cstack, captures) do
+    match_elements(subject, pos, rest, full, cstack, captures ++ [pos + 1])
   end
 
   # Capture end
@@ -476,6 +488,14 @@ defmodule Lua.VM.Stdlib.Pattern do
 
   defp match_char_class(ch, ?c), do: ch < 32 or ch == 127
   defp match_char_class(ch, ?C), do: not (ch < 32 or ch == 127)
+
+  # %g — printable characters except space (ASCII 0x21..0x7E)
+  defp match_char_class(ch, ?g), do: ch in 0x21..0x7E
+  defp match_char_class(ch, ?G), do: ch not in 0x21..0x7E
+
+  # %x — hexadecimal digit
+  defp match_char_class(ch, ?x), do: ch in ?0..?9 or ch in ?a..?f or ch in ?A..?F
+  defp match_char_class(ch, ?X), do: not (ch in ?0..?9 or ch in ?a..?f or ch in ?A..?F)
 
   # Escaped literal (non-alphanumeric after %)
   defp match_char_class(ch, literal), do: ch == literal

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -124,19 +124,20 @@ defmodule Lua.VM.Stdlib.String do
         expected: "number"
     end
 
-    # Convert Lua 1-based indices to 0-based, handle negative indices
+    # Mirror PUC-Lua's str_sub: keep 1-based positions, then clamp.
     len = byte_size(str)
-    start_idx = normalize_index(i, len)
-    end_idx = if j == nil, do: len - 1, else: normalize_index(j, len)
+    start_pos = posrelat(i, len)
+    end_pos = if j == nil, do: -1, else: j
+    end_pos = posrelat(end_pos, len)
+
+    start_pos = if start_pos < 1, do: 1, else: start_pos
+    end_pos = if end_pos > len, do: len, else: end_pos
 
     result =
-      if start_idx > end_idx or start_idx >= len do
-        ""
+      if start_pos <= end_pos do
+        binary_part(str, start_pos - 1, end_pos - start_pos + 1)
       else
-        start_byte = max(0, start_idx)
-        end_byte = min(len - 1, end_idx)
-        length = end_byte - start_byte + 1
-        binary_part(str, start_byte, length)
+        ""
       end
 
     {[result], state}
@@ -810,6 +811,13 @@ defmodule Lua.VM.Stdlib.String do
   defp normalize_index(idx, _len) when idx > 0, do: idx - 1
   defp normalize_index(idx, len) when idx < 0, do: len + idx
   defp normalize_index(0, _len), do: 0
+
+  # PUC-Lua's posrelat: keep 1-based positions, translate negatives.
+  # Negative indices are relative to len+1 (so -1 = len). If a negative is
+  # smaller than -len, it clamps to 0 (which the caller then bumps to 1).
+  defp posrelat(pos, _len) when pos >= 0, do: pos
+  defp posrelat(pos, len) when -pos > len, do: 0
+  defp posrelat(pos, len), do: len + pos + 1
 
   # Error helpers
   defp raise_string_expected(arg_num, func_name, value) do

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -657,10 +657,43 @@ defmodule Lua.LexerTest do
                Lexer.tokenize("> =")
     end
 
-    test "handles invalid escape sequences in strings" do
-      # Invalid escape sequences should be included as-is
-      assert {:ok, [{:string, "\\x", _}, {:eof, _}]} = Lexer.tokenize(~s("\\x"))
-      assert {:ok, [{:string, "\\1", _}, {:eof, _}]} = Lexer.tokenize(~s("\\1"))
+    test "handles unknown escape sequences in strings" do
+      # Unknown alpha-escapes (not part of the Lua 5.3 escape set and not a
+      # numeric escape) are kept verbatim. Per the reference, only escapes
+      # that look numeric (\\xXX, \\u{...}, \\ddd) but are malformed are
+      # parse-time errors — see the dedicated tests below.
+      assert {:ok, [{:string, "\\q", _}, {:eof, _}]} = Lexer.tokenize(~s("\\q"))
+    end
+
+    test "decimal escape \\ddd produces the corresponding byte" do
+      assert {:ok, [{:string, <<0>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\0"))
+      assert {:ok, [{:string, <<1>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\1"))
+      assert {:ok, [{:string, <<255>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\255"))
+      # Greedy up to 3 digits when they all fit in a byte (102 == 'f')
+      assert {:ok, [{:string, <<102>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\102"))
+      # \\256 overflows a byte so the third digit is not consumed
+      assert {:ok, [{:string, <<25, ?6>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\256"))
+      # \\10x — third char isn't a digit, only \\10 is consumed
+      assert {:ok, [{:string, <<10, ?x>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\10x"))
+    end
+
+    test "hex escape \\xXX produces the corresponding byte" do
+      assert {:ok, [{:string, <<0>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\x00"))
+      assert {:ok, [{:string, <<0xFF>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\xff"))
+      assert {:ok, [{:string, <<0xAB>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\xAB"))
+    end
+
+    test "malformed numeric escape sequences error" do
+      # \\x must be followed by exactly two hex digits
+      assert {:error, {:invalid_escape, _}} = Lexer.tokenize(~s("\\x"))
+      assert {:error, {:invalid_escape, _}} = Lexer.tokenize(~s("\\xZ"))
+      assert {:error, {:invalid_escape, _}} = Lexer.tokenize(~s("\\x1g"))
+    end
+
+    test "unicode escape \\u{XXX} encodes as UTF-8" do
+      assert {:ok, [{:string, "A", _}, {:eof, _}]} = Lexer.tokenize(~s("\\u{41}"))
+      # Codepoint 0x4E2D (中) → 3-byte UTF-8 sequence
+      assert {:ok, [{:string, <<0xE4, 0xB8, 0xAD>>, _}, {:eof, _}]} = Lexer.tokenize(~s("\\u{4E2D}"))
     end
 
     test "reports error for string with unescaped newline" do

--- a/test/lua/vm/string_test.exs
+++ b/test/lua/vm/string_test.exs
@@ -88,6 +88,33 @@ defmodule Lua.VM.StringTest do
       state = Stdlib.install(State.new())
       assert {:ok, [""], _state} = VM.execute(proto, state)
     end
+
+    test "string.sub with j == 0 returns empty string (PUC-Lua semantics)" do
+      # Regression: string.find on a zero-width pattern returns (1, 0) and
+      # idiomatic Lua then calls string.sub(s, 1, 0) expecting "". This
+      # exercises the i > j case after PUC-Lua's clamp-after-relative-index.
+      code = ~S|return string.sub("aaa", 1, 0)|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [""], _state} = VM.execute(proto, state)
+    end
+
+    test "string.sub with i past end returns empty string" do
+      code = ~S|return string.sub("hello", 6)|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [""], _state} = VM.execute(proto, state)
+    end
+
+    test "string.sub clamps very negative i to start of string" do
+      code = ~S|return string.sub("hello", -100, 3)|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, ["hel"], _state} = VM.execute(proto, state)
+    end
   end
 
   describe "string.rep" do
@@ -828,6 +855,83 @@ defmodule Lua.VM.StringTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = Stdlib.install(State.new())
       assert {:ok, ["ello"], _state} = VM.execute(proto, state)
+    end
+
+    test "character class %g matches printable except space" do
+      # %g is non-space printable (ASCII 0x21..0x7E). pm.lua line 51 uses
+      # %g%g%g+ to extract the contiguous non-space, non-newline run "xuxu".
+      code = ~S|return string.match("  \n\r*&\n\r   xuxu  \n\n", "%g%g%g+")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, ["xuxu"], _state} = VM.execute(proto, state)
+    end
+
+    test "character class %G matches whitespace and non-printable" do
+      code = ~S|return string.match("ab cd", "%G")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [" "], _state} = VM.execute(proto, state)
+    end
+
+    test "character class %x matches hexadecimal digits" do
+      # %x covers 0-9, a-f, A-F — covers the deadBEEF99 run; "hello" fails
+      # the first match early (h is not hex), so we anchor with a space.
+      code = ~S|return string.match(" deadBEEF99 ", "%x+")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, ["deadBEEF99"], _state} = VM.execute(proto, state)
+    end
+
+    test "position capture () returns numeric byte position" do
+      # () captures the current 1-based byte position as a number, not a
+      # zero-length string. This is what pm.lua's f1 helper relies on.
+      code = ~S|return string.match("hello", "()l")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [3], _state} = VM.execute(proto, state)
+    end
+
+    test "position capture mixed with normal capture" do
+      code = ~S|return string.match("abc=xyz", "()(%w+)=()")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      # Three captures: position 1, "abc", position 5
+      assert {:ok, [1, "abc", 5], _state} = VM.execute(proto, state)
+    end
+
+    test "string.find handles literal NUL bytes in pattern" do
+      # The lexer must decode \0 as a NUL byte so the pattern "a\0o" is three
+      # bytes and matches positions 1..3 in "a\0o a\0o a\0o".
+      code = ~S|return string.find("a\0o a\0o a\0o", "a\0o")|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [1, 3], _state} = VM.execute(proto, state)
+    end
+
+    test "string.find with init past end returns nil" do
+      code = ~S|return string.find("abc", "a", 10)|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, [nil], _state} = VM.execute(proto, state)
+    end
+
+    test "gsub with end-anchored zero-width pattern does not crash" do
+      # Regression: pm.lua line 96 uses string.gsub(p, "($?)$", "()%1", 1) to
+      # append a position capture to the end of a pattern. Previously the
+      # gsub recursion blew past the end of the subject and tripped
+      # binary_part with a negative length.
+      code = ~S|return string.gsub("(..*) %2", "($?)$", "()%1", 1)|
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, ["(..*) %2()", 1], _state} = VM.execute(proto, state)
     end
 
     test "lazy quantifier -" do


### PR DESCRIPTION
## Fix pm.lua pattern-matching assertion

Plan: [`.agents/plans/A9-pm-suite.md`](https://github.com/tv-labs/lua/blob/fix/pm-suite/.agents/plans/A9-pm-suite.md)
Closes #170

### Goal

Make `pm.lua` (the Lua 5.3 pattern-matching test file) pass. The plan
called for triage of a generic `assertion failed` and anticipated that
the work might split into sub-plans. Triage walked the file in order,
peeling back five distinct bugs that all live upstream of the pattern
engine's deeper corners. The sixth — an executor multi-return register
expansion crash — is split out into A9a.

### Success criteria

- [x] `mix test` passes (1327 → 1342, no regressions).
- [x] Each fixed assertion has a unit test in
      `test/lua/vm/string_test.exs` or `test/lua/vm/lexer_test.exs`.
- [ ] `pm.lua` passes end-to-end. **Narrowed.** Fixed in this PR:
      pm.lua now executes through line 110 (was blocked at line 24).
      The next blocker is an executor multi-return register expansion
      bug surfaced by `string.char(range(0, 255))` at line 112; it is
      tracked in [`A9a`](https://github.com/tv-labs/lua/blob/fix/pm-suite/.agents/plans/A9a-pm-suite-executor.md).

### What changed

#### Lexer — numeric escape sequences (`lib/lua/lexer.ex`)

Added decoding for `\ddd` (1–3 decimal digits, byte value), `\xXX` (two
hex digits) and `\u{X…}` (UTF-8 codepoint up to 0x7FFFFFFF). Before
this change `"a\0o"` was four bytes (`a`, `\`, `0`, `o`) instead of
three, breaking nearly every assertion in pm.lua that uses a literal
NUL byte (lines 21, 23, 25, 27, 29, 31, 32, …).

The existing "invalid escape" lexer test asserted that `\1` and `\x`
should round-trip verbatim. That contradicts §3.1 of the Lua 5.3
reference manual (`\1` is decimal `1`; bare `\x` is malformed). The
test is now four targeted tests covering the valid forms plus an
explicit error case.

#### Pattern engine — character classes (`lib/lua/vm/stdlib/pattern.ex`)

Added `%g`/`%G` (printable except space, ASCII 0x21..0x7E) and
`%x`/`%X` (hex digit). pm.lua line 51 (`%g%g%g+`) was the first
caller; many later assertions use `%x` for hex matching.

#### Pattern engine — `gsub` overflow (`lib/lua/vm/stdlib/pattern.ex`)

When an end-anchored zero-width pattern matched at `pos == len`, the
recursion advanced `pos` past `len` and the cleanup branch passed a
negative length to `:erlang.binary_part/3`. Clamped the remainder
length so it can never go negative.

#### Pattern engine — position captures (`lib/lua/vm/stdlib/pattern.ex`)

`()` in a Lua pattern captures the current 1-based byte position as a
**number**, not a zero-length string. Previously the compiler emitted
a normal start/end capture pair around an empty span, so `f1` in
pm.lua got back strings and crashed on `t[#t] - 1`. The compiler now
emits `:position_capture` for the immediate `()` form and the matcher
appends `pos + 1` as a number.

#### `string.sub` — PUC-Lua-accurate index handling (`lib/lua/vm/stdlib/string.ex`)

`string.sub("aaa", 1, 0)` returned `"a"` instead of `""`. The old
`normalize_index/2` collapsed both `0` and `1` to the same 0-based
offset. Replaced with the PUC-Lua algorithm: keep 1-based positions,
translate negatives via `posrelat`, then clamp `start < 1 → 1` and
`end > len → len` and emit `""` if `start > end`. This also makes the
"very-negative `i`" case match the reference (`string.sub("hello",
-100, 3) == "hel"`).

### Discoveries (split out)

- **A9a — executor multi-return register expansion.** Line 112 of
  pm.lua does `string.char(range(0, 255))` where `range/2` returns
  256 values via tail-position multi-return. The `-2` arm of
  `Lua.VM.Executor.do_frame_return/6` writes them into the caller's
  register tuple via `put_elem(regs, base + i, val)` without checking
  that the tuple is large enough, blowing up with
  `:erlang.setelement(26, {25-element tuple}, 255)`. Fix is a
  one-helper register-grow shared across the three return-fan-in
  paths. Filed as `.agents/plans/A9a-pm-suite-executor.md`.

### Verification

```
mix format
mix compile --warnings-as-errors
mix test                            # 1342 tests, 0 failures (was 1327)
mix test --only lua53               # 4 ready, 25 skipped, no regressions
mix test test/lua/vm/string_test.exs    # 94 tests, 0 failures
mix test test/lua/lexer_test.exs    # 94 tests, 0 failures
```

### Out of scope (intentional)

- Reworking the pattern engine.
- Adding new pattern features beyond what pm.lua exercises (e.g.
  `%b()` and `%f[set]` were not blockers in the lines we now reach).
- The executor multi-return bug — split to A9a.