### PR TITLE
fix(compiler): bind for-loop variable per statement to fix register reuse

### DIFF
--- a/.agents/plans/A14-for-loop-register-regression.md
+++ b/.agents/plans/A14-for-loop-register-regression.md
@@ -104,4 +104,38 @@ mix test test/lua/vm/for_loop_register_test.exs
 
 ## Discoveries
 
-(populated during implementation)
+The bug was in `lib/lua/compiler/scope.ex`, not in the executor. The
+executor was correct: it copies `regs[base]` (counter) into
+`regs[loop_var]` and then runs the body. The body's instructions read
+from whatever register the **per-occurrence** scope binding assigned to
+`i`.
+
+The mismatch came from how `ForNum` resolved its loop variable:
+
+1. Loop 1's body resolved with `state.locals["i"] = R₁`. Body
+   instructions therefore reference `R₁` for `i`.
+2. Loop 2 then resolved with `state.locals["i"] = R₂` (a fresh
+   register), overwriting the entry. Body instructions reference `R₂`.
+3. After resolution, codegen ran. For each `ForNum`, codegen looked up
+   the loop-variable register via `ctx.scope.locals[var]` — which by
+   that point was `R₂` for **both** loops.
+4. The result: the `numeric_for` instruction for loop 1 wrote the
+   counter to `R₂`, but loop 1's body read `i` from `R₁`. So `i` was
+   `nil` when the body executed, and the second loop blew up first
+   because its body actually used `R₂` and was entitled to expect a
+   number there.
+
+This is the same class of bug that `LocalFunc` already had a fix for
+(see `local_func_reg` in `var_map`). The fix here mirrors that: capture
+the per-statement loop-variable register in `var_map`, keyed by the
+`ForNum`/`ForIn` AST node, and have codegen prefer that lookup over
+`scope.locals[var]`.
+
+The Phase 17 fix (commit `e7c50e5`) had used a different mechanism that
+was lost in the CPS rewrite. The new fix is structurally aligned with
+the existing `LocalFunc` pattern, which should make it more robust to
+future executor refactors.
+
+The plan suggested register-clearing logic between iterations as a
+likely fix; that turned out not to be the issue — the real fix was at
+compile time, before the executor ever runs.

--- a/.agents/plans/A14-for-loop-register-regression.md
+++ b/.agents/plans/A14-for-loop-register-regression.md
@@ -2,10 +2,10 @@
 id: A14
 title: Fix for-loop register regression (consecutive for loops corrupt state)
 issue: 146
-pr: null
+pr: 195
 branch: fix/for-loop-register-regression
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks: []
 ---
@@ -139,3 +139,23 @@ future executor refactors.
 The plan suggested register-clearing logic between iterations as a
 likely fix; that turned out not to be the issue — the real fix was at
 compile time, before the executor ever runs.
+
+## What changed
+
+PR #195 — `fix(compiler): bind for-loop variable per statement to fix register reuse`
+
+Files touched:
+
+- `lib/lua/compiler/scope.ex` — capture per-statement loop-variable
+  registers in `var_map` for both `ForNum` and `ForIn`.
+- `lib/lua/compiler/codegen.ex` — prefer the per-statement `var_map`
+  binding when emitting `numeric_for` and `generic_for` instructions.
+- `test/lua/vm/for_loop_register_test.exs` — new file, 6 regression
+  tests covering consecutive numeric for loops with shared/distinct
+  variable names, explicit step values, and closures over loop variables.
+
+Suite delta: lua53 4/29 → 4/29 (no regression; this fix doesn't unlock
+new suite files but unblocks user code that mixed multiple for loops in
+the same scope).
+
+Test delta: 1369 → 1375 (6 new regression tests, 0 failures).

--- a/.agents/plans/A14-for-loop-register-regression.md
+++ b/.agents/plans/A14-for-loop-register-regression.md
@@ -5,7 +5,7 @@ issue: 146
 pr: null
 branch: fix/for-loop-register-regression
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks: []
 ---

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -464,9 +464,15 @@ defmodule Lua.Compiler.Codegen do
     {[loop_instruction], ctx}
   end
 
-  defp gen_statement(%Statement.ForNum{var: var, start: start_expr, limit: limit_expr, step: step_expr, body: body}, ctx) do
-    # Get the loop variable's register from scope
-    loop_var_reg = ctx.scope.locals[var]
+  defp gen_statement(
+         %Statement.ForNum{var: var, start: start_expr, limit: limit_expr, step: step_expr, body: body} = for_stmt,
+         ctx
+       ) do
+    # Get the loop variable's register. Prefer the per-statement binding
+    # captured during scope resolution so consecutive `for` loops with the
+    # same variable name use distinct registers (issue #146).
+    loop_var_reg =
+      Map.get(ctx.scope.var_map, {:for_num_var_reg, for_stmt}, ctx.scope.locals[var])
 
     # Allocate 3 internal registers for: counter, limit, step
     base = ctx.next_reg
@@ -510,9 +516,12 @@ defmodule Lua.Compiler.Codegen do
        [loop_instruction], ctx}
   end
 
-  defp gen_statement(%Statement.ForIn{vars: vars, iterators: iterators, body: body}, ctx) do
-    # Look up loop variable registers from scope
-    var_regs = Enum.map(vars, fn name -> ctx.scope.locals[name] end)
+  defp gen_statement(%Statement.ForIn{vars: vars, iterators: iterators, body: body} = for_stmt, ctx) do
+    # Look up loop variable registers from scope. Prefer the per-statement
+    # bindings captured during scope resolution so consecutive `for` loops
+    # with the same variable names use distinct registers (issue #146).
+    var_regs =
+      Map.get(ctx.scope.var_map, {:for_in_var_regs, for_stmt}, Enum.map(vars, fn name -> ctx.scope.locals[name] end))
 
     # Allocate 3 internal registers for: iterator function, invariant state, control variable
     base = ctx.next_reg

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -171,7 +171,7 @@ defmodule Lua.Compiler.Scope do
   end
 
   defp resolve_statement(
-         %Statement.ForNum{var: var, start: start_expr, limit: limit_expr, step: step_expr, body: body},
+         %Statement.ForNum{var: var, start: start_expr, limit: limit_expr, step: step_expr, body: body} = for_stmt,
          state
        ) do
     # Resolve start, limit, and step expressions with current scope
@@ -186,6 +186,12 @@ defmodule Lua.Compiler.Scope do
     # Reserve 3 registers: the loop variable shares with the internal counter,
     # plus limit and step registers (codegen allocates base, base+1, base+2)
     state = %{state | next_register: loop_var_reg + 3}
+
+    # Store this loop's variable register in var_map so codegen can find the
+    # correct register even when consecutive `for` statements share a variable
+    # name (each loop binds the same name to a fresh register, but
+    # `state.locals[var]` only retains the most recent binding).
+    state = %{state | var_map: Map.put(state.var_map, {:for_num_var_reg, for_stmt}, loop_var_reg)}
 
     # Update max_register
     func_scope = state.functions[state.current_function]
@@ -246,17 +252,23 @@ defmodule Lua.Compiler.Scope do
     resolve_expr(call, state)
   end
 
-  defp resolve_statement(%Statement.ForIn{vars: vars, iterators: iterators, body: body}, state) do
+  defp resolve_statement(%Statement.ForIn{vars: vars, iterators: iterators, body: body} = for_stmt, state) do
     # Resolve iterator expressions with current scope
     state = Enum.reduce(iterators, state, &resolve_expr/2)
 
     # Assign registers for loop variables (same pattern as ForNum)
-    {state, _} =
-      Enum.reduce(vars, {state, state.next_register}, fn name, {state, reg} ->
+    {state, _, var_regs} =
+      Enum.reduce(vars, {state, state.next_register, []}, fn name, {state, reg, acc} ->
         state = %{state | locals: Map.put(state.locals, name, reg)}
         state = %{state | next_register: reg + 1}
-        {state, reg + 1}
+        {state, reg + 1, [reg | acc]}
       end)
+
+    # Store this loop's variable registers in var_map so codegen can find the
+    # correct registers even when consecutive `for` statements share variable
+    # names (each loop binds the same names to fresh registers, but
+    # `state.locals[name]` only retains the most recent binding).
+    state = %{state | var_map: Map.put(state.var_map, {:for_in_var_regs, for_stmt}, Enum.reverse(var_regs))}
 
     # Update max_register
     func_scope = state.functions[state.current_function]

--- a/test/lua/vm/for_loop_register_test.exs
+++ b/test/lua/vm/for_loop_register_test.exs
@@ -1,0 +1,114 @@
+defmodule Lua.VM.ForLoopRegisterTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.State
+
+  # Regression test for issue #146.
+  #
+  # Two consecutive numeric `for` loops in the same scope corrupted the
+  # register file: the second loop saw `nil` where its loop counter should
+  # have been, producing:
+  #
+  #   Runtime Type Error — attempt to perform arithmetic on a nil value
+  #
+  # The original Phase 17 fix (commit e7c50e5) ensured the for-loop's
+  # internal counter/limit/step registers did not leak into the surrounding
+  # scope. The CPS executor refactor (PR #156) reintroduced the regression.
+  #
+  # This test locks in correct behaviour for the cases that exercised the bug.
+
+  describe "consecutive numeric for loops" do
+    test "two consecutive `for i = 1, n` loops produce correct sum" do
+      code = """
+      local sum = 0
+      for i = 1, 3 do sum = sum + i end
+      for i = 1, 3 do sum = sum + i end
+      return sum
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [12], _state} = VM.execute(proto, state)
+    end
+
+    test "three consecutive `for i = 1, n` loops produce correct sum" do
+      code = """
+      local sum = 0
+      for i = 1, 3 do sum = sum + i end
+      for i = 1, 3 do sum = sum + i end
+      for i = 1, 3 do sum = sum + i end
+      return sum
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [18], _state} = VM.execute(proto, state)
+    end
+
+    test "two consecutive loops with different variable names" do
+      code = """
+      local sum = 0
+      for i = 1, 3 do sum = sum + i end
+      for j = 1, 5 do sum = sum + j end
+      return sum
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      # 1+2+3 + 1+2+3+4+5 = 6 + 15 = 21
+      assert {:ok, [21], _state} = VM.execute(proto, state)
+    end
+
+    test "two consecutive loops with the same variable name (original #146 case)" do
+      code = """
+      local sum = 0
+      for i = 1, 4 do sum = sum + i end
+      for i = 1, 4 do sum = sum + i end
+      return sum
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      # (1+2+3+4) * 2 = 20
+      assert {:ok, [20], _state} = VM.execute(proto, state)
+    end
+
+    test "consecutive loops with explicit step values" do
+      code = """
+      local sum = 0
+      for i = 1, 6, 2 do sum = sum + i end
+      for i = 10, 2, -2 do sum = sum + i end
+      return sum
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      # 1+3+5 + 10+8+6+4+2 = 9 + 30 = 39
+      assert {:ok, [39], _state} = VM.execute(proto, state)
+    end
+
+    test "closures over loop variables still work after the fix" do
+      # Sanity check that the original Phase 17 closure-over-loop-var
+      # behaviour is preserved alongside this regression fix.
+      code = """
+      local fns = {}
+      for i = 1, 3 do fns[i] = function() return i end end
+      for i = 1, 3 do fns[i + 3] = function() return i * 10 end end
+      return fns[1](), fns[2](), fns[3](), fns[4](), fns[5](), fns[6]()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [1, 2, 3, 10, 20, 30], _state} = VM.execute(proto, state)
+    end
+  end
+end


### PR DESCRIPTION
## Fix for-loop register regression (consecutive for loops corrupt state)

Plan: [`.agents/plans/A14-for-loop-register-regression.md`](.agents/plans/A14-for-loop-register-regression.md)
Closes #146

### Goal

Fix the regression where two consecutive numeric `for` loops in any scope
produce a runtime type error on the second loop. This was originally
fixed in PR #141 (Phase 17) but reintroduced by the perf rewrites
(suspected to be the CPS executor in PR #156, but turned out to be a
compile-time issue exposed by the rewrite).

### Root cause

The bug was in `lib/lua/compiler/scope.ex`, not the executor. When two
`for` loops shared a variable name in the same scope:

1. Loop 1 resolved its body with `scope.locals["i"] = R₁`. Body
   instructions reference `R₁` for `i`.
2. Loop 2 then resolved with `scope.locals["i"] = R₂`, overwriting the
   binding.
3. Codegen then ran `ctx.scope.locals["i"]` for **both** `numeric_for`
   instructions and got `R₂` either way.
4. Loop 1's `numeric_for` wrote the counter to `R₂`, but loop 1's body
   read `i` from `R₁` (which was nil) — and loop 2 then performed
   arithmetic on the leftover nil.

This is the same bug pattern `LocalFunc` had already been patched for
(see `local_func_reg` in `var_map`). Capture each `ForNum`/`ForIn`
statement's loop-variable register(s) in `var_map` keyed by the AST
node, and have codegen prefer that per-statement binding over
`scope.locals[var]`.

### Success criteria

- [x] `mix test` passes — 1369 → 1375, 0 failures (6 new regression tests).
- [x] New unit test `test/lua/vm/for_loop_register_test.exs` covers:
  - [x] Two consecutive `for i = 1, n` loops produce correct sum.
  - [x] Three consecutive `for i = 1, n` loops produce correct sum.
  - [x] Two consecutive loops with different variable names work.
  - [x] Two consecutive loops with the same variable name work
        (original #146 case).
  - [x] Consecutive loops with explicit step values.
  - [x] Closures over loop variables still work after the fix
        (Phase 17 sanity check).
- [x] `mix test --only lua53` count: 4/29 → 4/29, no regression.
- [x] Issue #146 closed automatically by this PR.

### Changes

```
 .agents/plans/A14-for-loop-register-regression.md |  46 +++++++-
 lib/lua/compiler/codegen.ex                       |  18 ++-
 lib/lua/compiler/scope.ex                         |  22 ++--
 test/lua/vm/for_loop_register_test.exs            | 113 ++++++++++++++++++++
 4 files changed, 181 insertions(+), 12 deletions(-)
```

### Discoveries

- The plan suggested register-clearing logic in the executor as a
  likely fix; that turned out not to be the issue. The executor was
  correct all along — it was reading the wrong register *number* from
  the codegen-emitted instruction.
- The Phase 17 fix (commit `e7c50e5`) had used a different mechanism
  that was lost in the CPS rewrite. The new fix is structurally aligned
  with the existing `LocalFunc` pattern, which should make it more
  robust to future executor refactors.

### Verification

```
$ mix format
$ mix compile --warnings-as-errors
Compiling 1 file (.ex)
Generated lua app

$ mix test
Finished in 1.6 seconds (1.6s async, 0.00s sync)
52 doctests, 45 properties, 1375 tests, 0 failures, 36 skipped

$ mix test --only lua53
Finished in 1.7 seconds (1.7s async, 0.00s sync)
29 tests, 0 failures, 25 skipped (1443 excluded)

$ mix test test/lua/vm/for_loop_register_test.exs
Finished in 0.02 seconds (0.02s async, 0.00s sync)
6 tests, 0 failures
```

### Out of scope (intentional)

- Other for-loop edge cases not directly tied to this regression.
- Architectural changes to the CPS executor (PR #156).
- Performance optimization of for-loop dispatch.