### PR TITLE
fix(vm): handle missing upvalue cells in get/set_open_upvalue

### DIFF
--- a/.agents/plans/A15-open-upvalue-missing-cell.md
+++ b/.agents/plans/A15-open-upvalue-missing-cell.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: fix/open-upvalue-missing-cell
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - sort.lua

--- a/.agents/plans/A15-open-upvalue-missing-cell.md
+++ b/.agents/plans/A15-open-upvalue-missing-cell.md
@@ -2,10 +2,10 @@
 id: A15
 title: set_open_upvalue / get_open_upvalue crash when cell is missing
 issue: null
-pr: null
+pr: 196
 branch: fix/open-upvalue-missing-cell
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - sort.lua
@@ -127,4 +127,88 @@ Capture suite delta in PR body.
 
 ## Discoveries
 
-(populated during implementation)
+### Root cause
+
+The codegen for `Statement.LocalFunc` in `lib/lua/compiler/codegen.ex` (around
+line 684) decided whether to emit `set_open_upvalue` based on
+`MapSet.member?(ctx.scope.captured_locals, name)`. `captured_locals` is the
+*final* set of parent-locals captured by *any* descendant closure across the
+current scope -- it is computed by scope analysis across the full block
+before codegen runs.
+
+That made the check too permissive. For non-recursive `local function L`,
+the closure for `L` doesn't capture itself, so no upvalue cell is created
+when the closure instruction runs. But if a *later* sibling closure
+captures `L` by name, `captured_locals` contains `L`, so codegen emitted a
+`set_open_upvalue` immediately after `move dest_reg, closure_reg`. That
+instruction crashed with `key N not found in: %{}` because the cell only
+gets created later, when the sibling closure's `closure` instruction
+executes.
+
+A second, structurally identical bug lived in `gen_var_by_name` (around
+line 1313). It emitted `get_open_upvalue` for FuncDecl table-chain targets
+(`function obj.method() end`) when `obj` was captured by a later closure.
+Same crash shape, different opcode.
+
+### Fix
+
+Two complementary changes:
+
+1. **Compiler-level (codegen.ex)**: In `LocalFunc`, only emit
+   `set_open_upvalue` when the function's own closure captures itself --
+   the genuine recursive case. The check uses the closure's
+   `upvalue_descriptors` instead of the surrounding scope's
+   `captured_locals`. This eliminates the wasteful, broken emission for
+   non-recursive locals.
+
+2. **Executor-level (executor.ex)**: Make `get_open_upvalue` and
+   `set_open_upvalue` cell-aware. If the register has no entry in
+   `open_upvalues`, the register itself is the source of truth -- read
+   from / write to it directly. The next closure that captures the
+   register will create a cell from the current register value via the
+   existing `closure` handler logic. This handles `gen_var_by_name` and
+   any other downstream sites the compiler can't easily detect at codegen
+   time.
+
+### Suite delta
+
+`sort.lua`, `strings.lua`, `verybig.lua` all now make further progress:
+
+- `sort.lua` reaches an `assert` failure inside `checkerror("wrong number of
+  arguments", table.insert, ...)` -- our `table.insert` raises with a
+  message that doesn't match `"wrong number of arguments"` ("bad argument
+  #1 to 'table.insert' (table expected, got table)"). Out of scope for A15.
+- `strings.lua` reaches an `assert` failure inside
+  `testing strings and string library` -- separate stdlib issue.
+- `verybig.lua` reaches `os.tmpname()` which is sandboxed by default.
+
+None of the three now crash with the original `key N not found in: %{}`
+shape. The lua53 suite keeps these files in `@skipped_tests` until those
+downstream bugs are also fixed; this plan only unblocks them, it does not
+flip them to ready.
+
+## What changed
+
+PR: https://github.com/tv-labs/lua/pull/196
+
+Files touched:
+
+- `lib/lua/compiler/codegen.ex` -- only emit `set_open_upvalue` for
+  `LocalFunc` when the closure captures itself (recursive case). Adds
+  `captures_self?/3` helper.
+- `lib/lua/vm/executor.ex` -- `get_open_upvalue` falls back to reading
+  the register when no cell exists; `set_open_upvalue` is a no-op in
+  that case (the register already holds the correct value).
+- `test/lua/vm/upvalue_test.exs` -- new file with 7 regression tests
+  covering the LocalFunc-sibling-capture case, the FuncDecl
+  table-chain-capture case, the recursive case (still works), and a
+  shared-upvalue-cell case.
+
+Test delta: `mix test` 1375 → 1382 (1373 unchanged + 7 new + 2
+existing-but-untouched-by-this-change net of for-loop-register tests
+that landed concurrently in main). 0 failures, 0 regressions.
+
+Suite delta (`mix test --only lua53`): no change (29 tests, 0 failures,
+25 skipped). The three unblocked files (`sort.lua`, `strings.lua`,
+`verybig.lua`) stay in `@skipped_tests` until their downstream failures
+are fixed -- those are separate plans.

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -678,10 +678,15 @@ defmodule Lua.Compiler.Codegen do
         [Instruction.move(dest_reg, closure_reg)]
       end
 
-    # If this local is captured by the inner function (e.g., recursive local function),
-    # also update the open upvalue cell so the closure can reference itself
+    # If this local function captures itself (recursive local function),
+    # update the open upvalue cell so the closure can reference its final value.
+    # The cell is created by the closure instruction above (executor.ex closure
+    # handler creates a cell on capture). We must NOT emit set_open_upvalue
+    # based on whether the name is captured by *any* sibling/descendant
+    # closure -- those closures will create their own cells later when they
+    # run, reading the current register value at that point.
     update_upvalue =
-      if MapSet.member?(ctx.scope.captured_locals, name) do
+      if captures_self?(local_func, name, ctx) do
         [Instruction.set_open_upvalue(dest_reg, closure_reg)]
       else
         []
@@ -1357,6 +1362,24 @@ defmodule Lua.Compiler.Codegen do
     ctx = %{ctx | next_reg: dest_reg + 1}
 
     {[Instruction.closure(dest_reg, proto_index)], dest_reg, ctx}
+  end
+
+  # Returns true when the closure for `local_func` captures its own name as a
+  # parent_local upvalue -- i.e. the recursive case
+  # `local function f() ... f() ... end`. We use the closure's own
+  # upvalue_descriptors (not the surrounding scope's captured_locals set) so
+  # that sibling captures of the same name don't trigger a spurious
+  # set_open_upvalue against a cell that doesn't exist yet.
+  defp captures_self?(local_func, name, ctx) do
+    with {:ok, func_key} <- Map.fetch(ctx.scope.var_map, local_func),
+         {:ok, func_scope} <- Map.fetch(ctx.scope.functions, func_key) do
+      Enum.any?(func_scope.upvalue_descriptors, fn
+        {:parent_local, _reg, captured_name} -> captured_name == name
+        _ -> false
+      end)
+    else
+      _ -> false
+    end
   end
 
   # Move argument values to their expected contiguous positions (base_start+i)

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -297,19 +297,39 @@ defmodule Lua.VM.Executor do
 
   # ── get_open_upvalue ───────────────────────────────────────────────────────
 
+  # Read a captured-local value, preferring the upvalue cell when one exists.
+  # If no cell has been created yet (no closure has captured this register),
+  # the register itself is the source of truth -- the next closure that
+  # captures the register will create a cell from the current register value.
   defp do_execute([{:get_open_upvalue, dest, reg} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    cell_ref = Map.fetch!(state.open_upvalues, reg)
-    value = Map.get(state.upvalue_cells, cell_ref)
+    value =
+      case Map.get(state.open_upvalues, reg) do
+        nil -> elem(regs, reg)
+        cell_ref -> Map.get(state.upvalue_cells, cell_ref)
+      end
+
     regs = put_elem(regs, dest, value)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 
   # ── set_open_upvalue ───────────────────────────────────────────────────────
 
+  # Write a captured-local value through the upvalue cell when one exists.
+  # If no cell has been created yet, this is a no-op: the register already
+  # holds the value (codegen always emits a move into the register before
+  # set_open_upvalue), and the next closure that captures the register will
+  # create a cell from the current register value.
   defp do_execute([{:set_open_upvalue, reg, source} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    cell_ref = Map.fetch!(state.open_upvalues, reg)
-    value = elem(regs, source)
-    state = %{state | upvalue_cells: Map.put(state.upvalue_cells, cell_ref, value)}
+    state =
+      case Map.get(state.open_upvalues, reg) do
+        nil ->
+          state
+
+        cell_ref ->
+          value = elem(regs, source)
+          %{state | upvalue_cells: Map.put(state.upvalue_cells, cell_ref, value)}
+      end
+
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 

--- a/test/lua/vm/upvalue_test.exs
+++ b/test/lua/vm/upvalue_test.exs
@@ -1,0 +1,172 @@
+defmodule Lua.VM.UpvalueTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.State
+  alias Lua.VM.Stdlib
+
+  # Regression test for plan A15.
+  #
+  # Bug: when a local function L was followed by a sibling/descendant closure
+  # that captured L by name, codegen emitted set_open_upvalue for L's
+  # register at the local-function definition site. Since L's own closure
+  # didn't capture itself (non-recursive), no upvalue cell existed yet for
+  # that register, and set_open_upvalue crashed at runtime with
+  # `key N not found in: %{}`.
+  #
+  # The fix: only emit set_open_upvalue when the local function's *own*
+  # closure captures itself (the recursive case). Sibling captures create
+  # their own cells lazily when their closures execute.
+
+  describe "non-recursive local function captured by a later sibling closure" do
+    test "shrunken repro from test/lua53_tests/sort.lua" do
+      # Original failure path: sort.lua defines `checkerror` (a non-recursive
+      # local function), calls it once, then later defines `check` which
+      # captures `checkerror` as an upvalue. The first call to `checkerror`
+      # crashed at set_open_upvalue with `key 0 not found in: %{}`.
+      #
+      # The original used table.insert/table.sort but the bug is purely about
+      # codegen for `local function` followed by a sibling closure capturing
+      # it. Any non-trivial body and any non-recursive callable suffices.
+      code = """
+      local function checkerror (f, ...)
+        pcall(f, ...)
+      end
+
+      local function noop() end
+      checkerror(noop, 1, 2)
+
+      local function check ()
+        local function f(a, b) return true end
+        checkerror(noop, f)
+      end
+
+      return "ok"
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+      assert {:ok, ["ok"], _state} = VM.execute(proto, state)
+    end
+
+    test "later closure references the local but never calls it" do
+      code = """
+      local function helper(x) return x + 1 end
+      helper(10)
+
+      local function uses_helper()
+        return helper
+      end
+
+      return helper(5), uses_helper() == helper
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [6, true], _state} = VM.execute(proto, state)
+    end
+
+    test "multiple non-recursive locals captured by a single later closure" do
+      code = """
+      local function add(a, b) return a + b end
+      local function sub(a, b) return a - b end
+      local x = add(2, 3) + sub(10, 4)
+
+      local function combine(a, b)
+        return add(a, b) + sub(a, b)
+      end
+
+      return x, combine(7, 2)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [11, 14], _state} = VM.execute(proto, state)
+    end
+  end
+
+  describe "recursive local function still works" do
+    test "factorial via direct recursion" do
+      code = """
+      local function fact(n)
+        if n <= 1 then return 1 end
+        return n * fact(n - 1)
+      end
+      return fact(5)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [120], _state} = VM.execute(proto, state)
+    end
+
+    test "recursive local also captured by a later closure" do
+      # The local function is both recursive (its own closure captures it)
+      # AND captured by a later sibling. set_open_upvalue must still fire so
+      # the recursive reference resolves to the final closure value.
+      code = """
+      local function loop(n)
+        if n <= 0 then return 0 end
+        return 1 + loop(n - 1)
+      end
+
+      local function caller()
+        return loop(3)
+      end
+
+      return loop(5), caller()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [5, 3], _state} = VM.execute(proto, state)
+    end
+  end
+
+  describe "closures created in the same block share upvalue cells" do
+    test "two later closures capture the same earlier local" do
+      code = """
+      local function base(x) return x * 2 end
+
+      local function caller_a() return base(3) end
+      local function caller_b() return base(4) end
+
+      return caller_a(), caller_b()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [6, 8], _state} = VM.execute(proto, state)
+    end
+  end
+
+  describe "FuncDecl on a captured table-chain target" do
+    # Codegen for `function obj.method() end` reads `obj` from a captured-local
+    # cell when `obj` is captured by a later closure. Same crash shape as the
+    # LocalFunc bug: the cell hasn't been created yet at the FuncDecl site.
+    # The executor fallback (read register when no cell exists) handles this.
+    test "function obj.method() end where obj is captured by a later closure" do
+      code = """
+      local obj = {}
+      function obj.method() return 42 end
+
+      local function check() return obj.method() end
+
+      return obj.method(), check()
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = State.new()
+      assert {:ok, [42, 42], _state} = VM.execute(proto, state)
+    end
+  end
+end


### PR DESCRIPTION
## set_open_upvalue / get_open_upvalue crash when cell is missing

Plan: [`.agents/plans/A15-open-upvalue-missing-cell.md`](.agents/plans/A15-open-upvalue-missing-cell.md)

### Goal

Fix the `Map.fetch!` crash in `set_open_upvalue` and `get_open_upvalue` in `lib/lua/vm/executor.ex` that fired with `key N not found in: %{}` when those handlers ran with a register that had no entry in `state.open_upvalues`. Discovered while shipping plan A1; surfaces from a code path unrelated to A1's table-read bug.

### Success criteria

- [x] `mix test` passes (1375 → 1382 tests, 0 failures, +7 from new `upvalue_test.exs`)
- [x] `mix test test/lua/vm/table_index_test.exs` still green (10 tests, 0 failures)
- [x] New unit tests in `test/lua/vm/upvalue_test.exs` reproduce the original sort.lua-style failure as a minimal Lua snippet and assert it does not crash
- [x] `sort.lua`, `strings.lua`, `verybig.lua` all make further progress -- each now fails at a different, later site logged in the plan's Discoveries

### Root cause

Codegen for `Statement.LocalFunc` decided whether to emit `set_open_upvalue` based on `MapSet.member?(ctx.scope.captured_locals, name)`. `captured_locals` is the *final* set of parent-locals captured by *any* descendant closure across the current scope. That made the check too permissive: for non-recursive `local function L`, the closure for `L` doesn't capture itself, so no upvalue cell is created when the closure instruction runs. But if a *later* sibling closure captured `L`, codegen still emitted `set_open_upvalue` immediately after `move dest_reg, closure_reg`, which crashed.

A second, structurally identical bug lived in `gen_var_by_name`: it emitted `get_open_upvalue` for FuncDecl table-chain targets (`function obj.method() end`) when `obj` was captured by a later closure.

### Fix (two complementary changes)

1. **Compiler-level (`codegen.ex`)**: In `LocalFunc`, only emit `set_open_upvalue` when the function's own closure captures itself (the genuine recursive case). The check uses the closure's `upvalue_descriptors` instead of the surrounding scope's `captured_locals`.

2. **Executor-level (`executor.ex`)**: Make `get_open_upvalue` and `set_open_upvalue` cell-aware. If the register has no entry in `open_upvalues`, the register itself is the source of truth -- read from / write to it directly. The next closure that captures the register creates a cell from the current register value via the existing `closure` handler. This handles `gen_var_by_name` and any other downstream sites the compiler can't easily detect at codegen time.

### Changes

```
 .agents/plans/A15-open-upvalue-missing-cell.md |   2 +-
 lib/lua/compiler/codegen.ex                    |  29 ++++-
 lib/lua/vm/executor.ex                         |  30 ++++-
 test/lua/vm/upvalue_test.exs                   | 172 +++++++++++++++++++++++++
 4 files changed, 224 insertions(+), 9 deletions(-)
```

### Discoveries (downstream issues newly visible)

`sort.lua`, `strings.lua`, `verybig.lua` no longer crash with `key N not found`, but each fails at a different later site:

- `sort.lua` reaches an `assert` failure inside `checkerror("wrong number of arguments", table.insert, ...)`. Our `table.insert` raises with `"bad argument #1 to 'table.insert' (table expected, got table)"` instead of `"wrong number of arguments"`. Out of scope for A15.
- `strings.lua` reaches an `assert` failure inside the `string library` block -- separate stdlib issue.
- `verybig.lua` reaches `os.tmpname()` which is sandboxed by default.

The lua53 suite keeps these files in `@skipped_tests` until those downstream bugs are also fixed; this PR only unblocks them, it does not flip them to ready.

### Verification

```
mix format
mix compile --warnings-as-errors
mix test
mix test test/lua/vm/upvalue_test.exs
mix test test/lua/vm/table_index_test.exs
mix test --only lua53
```

```
$ mix test
52 doctests, 45 properties, 1382 tests, 0 failures, 36 skipped

$ mix test --only lua53
29 tests, 0 failures, 25 skipped (1449 excluded)

$ mix test test/lua/vm/upvalue_test.exs
7 tests, 0 failures
```

### Out of scope (intentional)

- The for-loop register regression in A14 (separate bug, separate symptom).
- Any other suite failure that surfaces *after* this fix lands.
- Refactors of the upvalue / closure pipeline beyond what is needed.