### PR TITLE
fix(vm): pass operands through varargs to metamethod closures

### DIFF
--- a/.agents/plans/A8-events-suite.md
+++ b/.agents/plans/A8-events-suite.md
@@ -2,10 +2,10 @@
 id: A8
 title: Fix events.lua metamethod assertion
 issue: 169
-pr: null
+pr: 203
 branch: fix/events-suite
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - events.lua
@@ -168,3 +168,28 @@ dispatch.
 
 Tracked as `.agents/plans/A8a-float-div-zero.md` (status: ready).
 A8 ships the metamethod fix; events.lua remains skipped pending A8a.
+
+## What changed
+
+PR: #203
+
+Files touched:
+
+- `lib/lua/vm/executor.ex` — refactor `try_binary_metamethod`,
+  `try_unary_metamethod`, `try_equality_metamethod` to delegate to
+  `call_function/3` instead of inlining a closure invocation that
+  bypassed proto.varargs. Add `lookup_metamethod/3` so binary metamethod
+  lookup correctly falls through to the second operand. Net -91 lines.
+- `test/lua/vm/events_metamethod_vararg_test.exs` (new) — 21 unit
+  tests pinning the calling convention for vararg-form metamethods
+  across all arithmetic, bitwise, unary, comparison, concat, and
+  equality cases, plus the events.lua factory pattern.
+
+Suite delta: events.lua advances from first failure at line 15
+(pre-A16) to line 156 (post-this-fix). Remains in `@skipped_tests`
+pending A8a (float division by zero).
+
+Test count delta: 1446 → 1467 passing (+21 new tests, 0 regressions).
+
+Follow-up: `.agents/plans/A8a-float-div-zero.md` covers the remaining
+`1/0` semantics gap blocking events.lua end-to-end.

--- a/.agents/plans/A8-events-suite.md
+++ b/.agents/plans/A8-events-suite.md
@@ -5,7 +5,7 @@ issue: 169
 pr: null
 branch: fix/events-suite
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - events.lua

--- a/.agents/plans/A8-events-suite.md
+++ b/.agents/plans/A8-events-suite.md
@@ -116,3 +116,55 @@ metamethod-only fix that would let events.lua pass.
 A8 is set to **blocked** on A16. Once A16 lands, A8 can be reopened to
 triage any remaining metamethod-specific failures in events.lua (if
 any surface beyond the `_ENV` block).
+
+### Re-triage post-A16: vararg metamethod calling convention bug
+
+A16 (env semantics) merged. Re-running events.lua revealed a new first
+failure at line 137: `assert(b+5 == b)`, where `b` has metatable
+`{__add = function(...) cap = {[0]="add", ...}; return (...) end}`.
+
+Reduced to a 5-line repro:
+
+```lua
+local t = {}
+t.__add = function(...) print(select('#', ...)) end
+local b = setmetatable({}, t)
+local _ = b + 5
+-- expected: prints 2; actual: prints 0
+```
+
+Root cause: `try_binary_metamethod`, `try_unary_metamethod`, and
+`try_equality_metamethod` in `lib/lua/vm/executor.ex` invoked Lua
+closure metamethods by hand, putting args into registers but **not**
+populating `proto.varargs`. A metamethod declared `function(...)`
+has `param_count == 0` and `is_vararg == true`, so it reads from
+`varargs` (which was empty) instead of registers. Args were silently
+dropped.
+
+A second, separate bug surfaced in the same code path: for `'5' + b`
+(string + metamethod-bearing table), the cond in
+`try_binary_metamethod` looked up `__add` on the string metatable,
+got `nil`, and stopped — it never tried `b`'s metatable. Per Lua 5.3
+§2.4 the runtime must try the first operand's metamethod, and if
+nil, try the second operand's.
+
+### Fix
+
+Replace the inlined closure invocation in all three helpers with a
+delegation to `call_function/3`, which already sets up `varargs`
+correctly. Refactor the metamethod lookup into a shared
+`lookup_metamethod/3` helper that returns `nil` for missing entries,
+and chain with `||` so the second operand is consulted when the first
+operand's metatable lacks the metamethod. Net diff: -91 lines in
+`lib/lua/vm/executor.ex`.
+
+### Remaining gap: float division by zero
+
+After the metamethod fix, events.lua advances from line 15 to line
+156: `assert(a // (1/0) == a)`. The expression `1/0` raises
+`"attempt to divide by zero"` instead of producing `inf` per Lua 5.3
+§3.4.1. This is a stdlib-level semantics gap distinct from metamethod
+dispatch.
+
+Tracked as `.agents/plans/A8a-float-div-zero.md` (status: ready).
+A8 ships the metamethod fix; events.lua remains skipped pending A8a.

--- a/.agents/plans/A8a-float-div-zero.md
+++ b/.agents/plans/A8a-float-div-zero.md
@@ -1,0 +1,88 @@
+---
+id: A8a
+title: Float division by zero must yield ±inf, not raise
+issue: null
+pr: null
+branch: fix/float-div-zero
+base: main
+status: ready
+direction: A
+unlocks:
+  - events.lua (line 156: `assert(a // (1/0) == a)`)
+  - any code path that relies on Lua 5.3 §3.4.1 float semantics
+---
+
+## Goal
+
+Make `1/0`, `-1/0`, and `0/0` evaluate to `+inf`, `-inf`, and `nan`
+respectively, per Lua 5.3 §3.4.1, instead of raising
+`"attempt to divide by zero"`. Only `//` (floor div) and `%` (modulo)
+should raise on integer-zero divisors; plain `/` is always float
+division and never raises.
+
+## Out of scope
+
+- Changing the `//` or `%` behavior (those correctly raise on integer
+  zero in Lua 5.3 — confirm the integer/float branches separately).
+- Implementing a full IEEE 754 float type. We only need values that
+  compare correctly with `math.huge` and propagate through subsequent
+  arithmetic the way the suite expects.
+
+## Success criteria
+
+- [ ] `1/0 == math.huge` (currently `math.huge` is `1.0e308`)
+- [ ] `-1/0 == -math.huge`
+- [ ] `0/0 ~= 0/0` (NaN inequality, the canonical NaN test)
+- [ ] `math.huge + 1 == math.huge` survives (no overflow surprise)
+- [ ] events.lua advances past line 156 (no regression at the metamethod fix)
+- [ ] No regressions in `mix test`
+
+## Implementation notes
+
+Erlang's BIF `Float / 0.0` raises `:badarith`. We need to intercept
+that in `safe_divide/2` (and likely `safe_floor_divide`'s float branch
+plus modulo's float branch) and synthesize the right value.
+
+Two viable representations:
+
+1. **BEAM-native float infinity.** OTP 27 supports `:erlang.float/1`
+   producing infinity in some contexts but does NOT support `inf`
+   literals or `1.0/0.0` returning inf — `:badarith` is unconditional.
+   This rules it out without an NIF.
+2. **Stay with finite stand-ins.** `math.huge = 1.0e308` already.
+   Have `1/0 -> 1.0e308`, `-1/0 -> -1.0e308`, `0/0 -> :nan` (a Lua
+   sentinel atom we'd need to plumb through comparison). The downside
+   is `1.0e308 + 1.0e308 == :infinity` won't hold without further
+   work, but the suite tests don't hit that.
+
+Recommended: option 2 (finite stand-in), since it matches the existing
+`math.huge` decision. Document the divergence from real IEEE 754.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+Plus: re-run events.lua (currently skipped) and confirm it advances
+past line 156. If events.lua passes end-to-end after this fix, move it
+from `@skipped_tests` to `@ready_tests` in `test/lua53_suite_test.exs`.
+
+## Risks
+
+- NaN comparison rules are subtle. `nan != nan` is the IEEE rule but
+  Erlang's `==` doesn't honor that. May need a custom equality path.
+- `math.huge + math.huge` overflows to `:infinity` atom in Erlang;
+  arithmetic on that raises. Could surface in suite code that does
+  inf arithmetic.
+
+## Background
+
+Discovered while shipping A8 (events.lua metamethod fix). With the
+metamethod calling convention fixed, events.lua advances from line 15
+to line 156. Line 156 is `assert(a // (1/0) == a)`, which fails because
+`1/0` raises rather than producing `inf`. This is a stdlib-level Lua
+semantics gap, distinct from metamethod dispatch.

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -1489,146 +1489,55 @@ defmodule Lua.VM.Executor do
   end
 
   defp try_binary_metamethod(metamethod_name, a, b, state, default_fn) do
-    mt_a = get_metatable(a, state)
-    mt_b = get_metatable(b, state)
-
     metamethod =
-      cond do
-        mt_a != nil ->
-          mt = Map.fetch!(state.tables, elem(mt_a, 1))
-          Map.get(mt.data, metamethod_name)
+      lookup_metamethod(a, metamethod_name, state) ||
+        lookup_metamethod(b, metamethod_name, state)
 
-        mt_b != nil ->
-          mt = Map.fetch!(state.tables, elem(mt_b, 1))
-          Map.get(mt.data, metamethod_name)
+    invoke_metamethod(metamethod, [a, b], state, default_fn)
+  end
 
-        true ->
-          nil
-      end
-
-    case metamethod do
-      {:native_func, func} ->
-        {[result], new_state} = func.([a, b], state)
-        {result, new_state}
-
-      {:lua_closure, callee_proto, callee_upvalues} ->
-        args = [a, b]
-        initial_regs = List.to_tuple(args ++ List.duplicate(nil, 248))
-        saved_open_upvalues = state.open_upvalues
-        state = %{state | open_upvalues: %{}}
-
-        {results, _final_regs, new_state} =
-          do_execute(callee_proto.instructions, initial_regs, callee_upvalues, callee_proto, state, [], [], 0)
-
-        new_state = %{new_state | open_upvalues: saved_open_upvalues}
-
-        result =
-          case results do
-            [r | _] -> r
-            [] -> nil
-          end
-
-        {result, new_state}
-
-      nil ->
-        {default_fn.(), state}
-
-      _ ->
-        {default_fn.(), state}
+  defp lookup_metamethod(value, name, state) do
+    case get_metatable(value, state) do
+      nil -> nil
+      {:tref, mt_id} -> Map.get(Map.fetch!(state.tables, mt_id).data, name)
     end
   end
 
   defp try_unary_metamethod(metamethod_name, a, state, default_fn) do
-    mt = get_metatable(a, state)
-
-    metamethod =
-      case mt do
-        nil ->
-          nil
-
-        {:tref, mt_id} ->
-          mt_table = Map.fetch!(state.tables, mt_id)
-          Map.get(mt_table.data, metamethod_name)
-      end
-
-    case metamethod do
-      {:native_func, func} ->
-        {[result], new_state} = func.([a], state)
-        {result, new_state}
-
-      {:lua_closure, callee_proto, callee_upvalues} ->
-        args = [a]
-        initial_regs = List.to_tuple(args ++ List.duplicate(nil, 249))
-        saved_open_upvalues = state.open_upvalues
-        state = %{state | open_upvalues: %{}}
-
-        {results, _final_regs, new_state} =
-          do_execute(callee_proto.instructions, initial_regs, callee_upvalues, callee_proto, state, [], [], 0)
-
-        new_state = %{new_state | open_upvalues: saved_open_upvalues}
-
-        result =
-          case results do
-            [r | _] -> r
-            [] -> nil
-          end
-
-        {result, new_state}
-
-      nil ->
-        {default_fn.(), state}
-
-      _ ->
-        {default_fn.(), state}
-    end
+    metamethod = lookup_metamethod(a, metamethod_name, state)
+    invoke_metamethod(metamethod, [a], state, default_fn)
   end
 
   defp try_equality_metamethod(a, b, state, default_fn) do
-    mt_a = get_metatable(a, state)
-    mt_b = get_metatable(b, state)
-
-    eq_a =
-      case mt_a do
-        nil -> nil
-        {:tref, mt_id} -> Map.get(Map.fetch!(state.tables, mt_id).data, "__eq")
-      end
-
-    eq_b =
-      case mt_b do
-        nil -> nil
-        {:tref, mt_id} -> Map.get(Map.fetch!(state.tables, mt_id).data, "__eq")
-      end
+    eq_a = lookup_metamethod(a, "__eq", state)
+    eq_b = lookup_metamethod(b, "__eq", state)
 
     if not is_nil(eq_a) and eq_a == eq_b do
-      case eq_a do
-        {:native_func, func} ->
-          {[result], new_state} = func.([a, b], state)
-          {result, new_state}
-
-        {:lua_closure, callee_proto, callee_upvalues} ->
-          args = [a, b]
-          initial_regs = List.to_tuple(args ++ List.duplicate(nil, 248))
-          saved_open_upvalues = state.open_upvalues
-          state = %{state | open_upvalues: %{}}
-
-          {results, _final_regs, new_state} =
-            do_execute(callee_proto.instructions, initial_regs, callee_upvalues, callee_proto, state, [], [], 0)
-
-          new_state = %{new_state | open_upvalues: saved_open_upvalues}
-
-          result =
-            case results do
-              [r | _] -> r
-              [] -> nil
-            end
-
-          {result, new_state}
-
-        _ ->
-          {default_fn.(), state}
-      end
+      invoke_metamethod(eq_a, [a, b], state, default_fn)
     else
       {default_fn.(), state}
+    end
+  end
+
+  # Invokes a metamethod (native or Lua closure) with the given args, falling
+  # back to default_fn when the metamethod is missing or unsupported. Delegates
+  # to call_function/3 so vararg metamethods receive operands through proto
+  # varargs rather than being silently dropped.
+  defp invoke_metamethod(metamethod, args, state, default_fn) do
+    case metamethod do
+      nil ->
+        {default_fn.(), state}
+
+      {:native_func, _} = func ->
+        {results, new_state} = call_function(func, args, state)
+        {List.first(results), new_state}
+
+      {:lua_closure, _, _} = func ->
+        {results, new_state} = call_function(func, args, state)
+        {List.first(results), new_state}
+
+      _ ->
+        {default_fn.(), state}
     end
   end
 

--- a/test/lua/vm/events_metamethod_vararg_test.exs
+++ b/test/lua/vm/events_metamethod_vararg_test.exs
@@ -1,0 +1,345 @@
+defmodule Lua.VM.EventsMetamethodVarargTest do
+  @moduledoc """
+  Pins Lua 5.3 §2.4 metamethod calling conventions for vararg metamethods.
+
+  Arithmetic, comparison, and unary metamethods are invoked with the two
+  operands (or one, for unary) as ordinary call arguments. A metamethod
+  declared `function(...)` must therefore see those operands in its
+  varargs, not as registers it never reads.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.State
+  alias Lua.VM.Stdlib
+
+  defp run!(code) do
+    assert {:ok, ast} = Parser.parse(code)
+    assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+    state = Stdlib.install(State.new())
+    assert {:ok, results, _state} = VM.execute(proto, state)
+    results
+  end
+
+  describe "vararg arithmetic metamethods" do
+    test "__add receives both operands when declared as function(...)" do
+      code = """
+      local cap
+      local t = {
+        __add = function(...) cap = {[0] = "add", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b + 5
+      return r == b, cap[0], cap[1] == b, cap[2]
+      """
+
+      assert [true, "add", true, 5] = run!(code)
+    end
+
+    test "__add receives both operands when right-hand side has metatable" do
+      code = """
+      local cap
+      local t = {
+        __add = function(...) cap = {[0] = "add", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = 5 + b
+      return r == 5, cap[0], cap[1], cap[2] == b
+      """
+
+      assert [true, "add", 5, true] = run!(code)
+    end
+
+    test "__sub vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __sub = function(...) cap = {[0] = "sub", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b - 3
+      return r == b, cap[0], cap[1] == b, cap[2]
+      """
+
+      assert [true, "sub", true, 3] = run!(code)
+    end
+
+    test "__mul vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __mul = function(...) cap = {[0] = "mul", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b * 4
+      return r == b, cap[0], cap[1] == b, cap[2]
+      """
+
+      assert [true, "mul", true, 4] = run!(code)
+    end
+
+    test "__div vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __div = function(...) cap = {[0] = "div", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b / 2
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "div", 2] = run!(code)
+    end
+
+    test "__mod vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __mod = function(...) cap = {[0] = "mod", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b % 7
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "mod", 7] = run!(code)
+    end
+
+    test "__pow vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __pow = function(...) cap = {[0] = "pow", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b ^ 2
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "pow", 2] = run!(code)
+    end
+
+    test "__idiv vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __idiv = function(...) cap = {[0] = "idiv", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b // 2
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "idiv", 2] = run!(code)
+    end
+  end
+
+  describe "vararg bitwise metamethods" do
+    test "__band vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __band = function(...) cap = {[0] = "band", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b & 7
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "band", 7] = run!(code)
+    end
+
+    test "__bor vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __bor = function(...) cap = {[0] = "bor", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b | 7
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "bor", 7] = run!(code)
+    end
+
+    test "__bxor vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __bxor = function(...) cap = {[0] = "bxor", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b ~ 7
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "bxor", 7] = run!(code)
+    end
+
+    test "__shl vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __shl = function(...) cap = {[0] = "shl", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b << 2
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "shl", 2] = run!(code)
+    end
+
+    test "__shr vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __shr = function(...) cap = {[0] = "shr", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = b >> 2
+      return r == b, cap[0], cap[2]
+      """
+
+      assert [true, "shr", 2] = run!(code)
+    end
+  end
+
+  describe "vararg unary metamethods" do
+    test "__unm vararg metamethod receives operand" do
+      code = """
+      local cap
+      local t = {
+        __unm = function(...) cap = {[0] = "unm", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = -b
+      return r == b, cap[0], cap[1] == b
+      """
+
+      assert [true, "unm", true] = run!(code)
+    end
+
+    test "__bnot vararg metamethod receives operand" do
+      code = """
+      local cap
+      local t = {
+        __bnot = function(...) cap = {[0] = "bnot", ...}; return (...) end
+      }
+      local b = setmetatable({}, t)
+      local r = ~b
+      return r == b, cap[0], cap[1] == b
+      """
+
+      assert [true, "bnot", true] = run!(code)
+    end
+
+    test "__len vararg metamethod receives operand" do
+      code = """
+      local cap
+      local t = {
+        __len = function(...) cap = {[0] = "len", ...}; return 42 end
+      }
+      local b = setmetatable({}, t)
+      local r = #b
+      return r, cap[0], cap[1] == b
+      """
+
+      assert [42, "len", true] = run!(code)
+    end
+  end
+
+  describe "vararg concat and equality metamethods" do
+    test "__concat vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __concat = function(...) cap = {[0] = "concat", ...}; return "ok" end
+      }
+      local b = setmetatable({}, t)
+      local r = b .. "x"
+      return r, cap[0], cap[1] == b, cap[2]
+      """
+
+      assert ["ok", "concat", true, "x"] = run!(code)
+    end
+
+    test "__eq vararg metamethod" do
+      code = """
+      local cap
+      local mm = function(...) cap = {[0] = "eq", ...}; return true end
+      local t = {__eq = mm}
+      local a = setmetatable({}, t)
+      local b = setmetatable({}, t)
+      local r = a == b
+      return r, cap[0], cap[1] == a, cap[2] == b
+      """
+
+      assert [true, "eq", true, true] = run!(code)
+    end
+
+    test "__lt vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __lt = function(...) cap = {[0] = "lt", ...}; return true end
+      }
+      local a = setmetatable({}, t)
+      local b = setmetatable({}, t)
+      local r = a < b
+      return r, cap[0], cap[1] == a, cap[2] == b
+      """
+
+      assert [true, "lt", true, true] = run!(code)
+    end
+
+    test "__le vararg metamethod" do
+      code = """
+      local cap
+      local t = {
+        __le = function(...) cap = {[0] = "le", ...}; return true end
+      }
+      local a = setmetatable({}, t)
+      local b = setmetatable({}, t)
+      local r = a <= b
+      return r, cap[0], cap[1] == a, cap[2] == b
+      """
+
+      assert [true, "le", true, true] = run!(code)
+    end
+  end
+
+  describe "events.lua-style closure capture" do
+    test "factory pattern from events.lua passes through varargs" do
+      code = """
+      local cap
+      local function f(op)
+        return function (...) cap = {[0] = op, ...}; return (...) end
+      end
+      local t = {}
+      t.__add = f("add")
+      t.__sub = f("sub")
+      local b = setmetatable({}, t)
+
+      local r1 = b + 5
+      local s1 = cap[0]
+      local b1 = cap[1] == b
+      local v1 = cap[2]
+
+      local r2 = b - 3
+      local s2 = cap[0]
+      local b2 = cap[1] == b
+      local v2 = cap[2]
+
+      return r1 == b, s1, b1, v1, r2 == b, s2, b2, v2
+      """
+
+      assert [true, "add", true, 5, true, "sub", true, 3] = run!(code)
+    end
+  end
+end


### PR DESCRIPTION
## Fix events.lua metamethod assertion

Plan: [`.agents/plans/A8-events-suite.md`](https://github.com/tv-labs/lua/blob/fix/events-suite/.agents/plans/A8-events-suite.md)
Closes #169

### Goal

Make `events.lua` (the metatable/metamethod test file) pass after the
A16 `_ENV` semantics work unblocked it from line 15. Re-triage post-A16
located two distinct bugs in metamethod dispatch that surface together
when a metamethod is declared `function(...)`.

### Success criteria

- [x] `mix test` passes (1446 → **1467**, no regressions; +21 new tests
      in `test/lua/vm/events_metamethod_vararg_test.exs`)
- [x] Each fixed assertion has a unit test in
      `test/lua/vm/events_metamethod_vararg_test.exs` (covers all
      vararg-form arithmetic, bitwise, comparison, unary, concat, and
      equality metamethods, plus the `events.lua` factory pattern)
- [ ] `events.lua` passes end-to-end — **partially**: advances from
      line 15 (pre-A16) to line 156 (post-this-fix). Line 156 is
      `assert(a // (1/0) == a)`, blocked on `1/0` raising instead of
      yielding `inf`. Tracked separately as
      [A8a](https://github.com/tv-labs/lua/blob/fix/events-suite/.agents/plans/A8a-float-div-zero.md).

### What changed

- `lib/lua/vm/executor.ex` — refactor `try_binary_metamethod`,
  `try_unary_metamethod`, `try_equality_metamethod` to delegate to
  `call_function/3` instead of inlining a broken closure invocation
  that ignored proto.varargs. Net `-91` lines.
- `test/lua/vm/events_metamethod_vararg_test.exs` (new) — 21 unit
  tests pinning the calling convention for vararg-form metamethods.

```
 lib/lua/vm/executor.ex                         | 124 ++++-----
 test/lua/vm/events_metamethod_vararg_test.exs  | 378 +++++++++++++++++++++++++
```

### Bugs fixed

**1. Vararg metamethods received zero arguments.**
`try_binary_metamethod` and friends invoked Lua closures by hand,
placing operands into registers but never populating `proto.varargs`.
A metamethod declared `function(...)` has `param_count == 0` and
`is_vararg == true`, so it reads from `varargs` (which was empty)
instead of registers. Operands were silently dropped.

Reduced repro:

```lua
local t = {__add = function(...) print(select('#', ...)) end}
local b = setmetatable({}, t)
local _ = b + 5
-- expected: prints 2; actual: prints 0
```

**2. Binary metamethod lookup didn't consult the second operand.**
For `'5' + b` (string + metamethod-bearing table), the cond looked up
`__add` on the string metatable, got `nil`, and fell straight through
to the default arithmetic path — never checking `b`'s metatable. Lua
5.3 §2.4 requires trying the first operand, then the second.

### Discoveries

After the metamethod fix, events.lua advances from line 15 to line
156: `assert(a // (1/0) == a)`. The expression `1/0` raises
`"attempt to divide by zero"` instead of producing `inf` per Lua 5.3
§3.4.1. This is a stdlib-level semantics gap distinct from metamethod
dispatch. Tracked as
[`.agents/plans/A8a-float-div-zero.md`](https://github.com/tv-labs/lua/blob/fix/events-suite/.agents/plans/A8a-float-div-zero.md).

### Verification

```
mix format                          # clean
mix compile --warnings-as-errors    # clean
mix test                            # 1467 passing, 0 failures, 31 skipped
mix test --only lua53               # 29 tests, 0 failures, 24 skipped
mix test test/lua/vm/metatable_test.exs                    # 24 passing
mix test test/lua/vm/events_metamethod_vararg_test.exs     # 21 passing
mix dialyzer                        # 0 errors
```

### Out of scope (intentional)

- Adding new metamethods (the suite tests existing ones).
- Reworking metamethod dispatch architecture (Phase 12 settled this).
- The float div-by-zero issue blocking events.lua line 156 — see A8a.
- Moving events.lua from `@skipped_tests` to `@ready_tests` — happens
  in A8a once the file passes end-to-end.