### PR TITLE
fix(vm): float division by zero yields ±math.huge, not raise

### DIFF
--- a/.agents/plans/A8a-float-div-zero.md
+++ b/.agents/plans/A8a-float-div-zero.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: fix/float-div-zero
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - events.lua (line 156: `assert(a // (1/0) == a)`)

--- a/.agents/plans/A8a-float-div-zero.md
+++ b/.agents/plans/A8a-float-div-zero.md
@@ -2,10 +2,10 @@
 id: A8a
 title: Float division by zero must yield ±inf, not raise
 issue: null
-pr: null
+pr: 204
 branch: fix/float-div-zero
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - events.lua (line 156: `assert(a // (1/0) == a)`)
@@ -86,3 +86,30 @@ metamethod calling convention fixed, events.lua advances from line 15
 to line 156. Line 156 is `assert(a // (1/0) == a)`, which fails because
 `1/0` raises rather than producing `inf`. This is a stdlib-level Lua
 semantics gap, distinct from metamethod dispatch.
+
+## What changed
+
+PR: https://github.com/tv-labs/lua/pull/204
+
+Files touched:
+- `lib/lua/vm/executor.ex`: `safe_divide/2` returns `1.0e308`/`-1.0e308`/`:nan`
+  instead of raising; new `lua_equal/2` helper handles NaN inequality;
+  `equal` and `not_equal` opcodes routed through it.
+- `test/lua/vm/float_div_zero_test.exs`: new file, 14 tests pinning the
+  Lua 5.3 §3.4.1 contract.
+- `test/lua/vm/arithmetic_test.exs`: updated two pre-existing tests that
+  asserted `5/0` and `-5/0` raise (with a comment acknowledging the
+  divergence) to assert the new contract.
+
+Test deltas:
+- `mix test`: 1467 → 1481 passing (+14 new), 0 failures.
+- `mix test --only lua53`: 5 ready / 24 skipped (no change in suite count;
+  events.lua advances past line 156 but does not pass end-to-end).
+
+events.lua remains in `@skipped_tests` — it now fails further down at
+"attempt to index a function value", a separate downstream issue.
+
+Follow-ups noted in the PR Discoveries section:
+1. events.lua's downstream function-indexing failure (separate plan).
+2. `//` and `%` with float-zero divisor still raise (separate plan).
+3. `~=` opcode bypasses `__eq` metamethod dispatch (separate plan).

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -917,7 +917,7 @@ defmodule Lua.VM.Executor do
     val_b = elem(regs, b)
 
     {result, new_state} =
-      try_equality_metamethod(val_a, val_b, state, fn -> val_a == val_b end)
+      try_equality_metamethod(val_a, val_b, state, fn -> lua_equal(val_a, val_b) end)
 
     regs = put_elem(regs, dest, result)
     do_execute(rest, regs, upvalues, proto, new_state, cont, frames, line)
@@ -958,7 +958,7 @@ defmodule Lua.VM.Executor do
   end
 
   defp do_execute([{:not_equal, dest, a, b} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    result = elem(regs, a) != elem(regs, b)
+    result = not lua_equal(elem(regs, a), elem(regs, b))
     regs = put_elem(regs, dest, result)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
@@ -1582,11 +1582,29 @@ defmodule Lua.VM.Executor do
     end
   end
 
+  # Lua 5.3 §3.4.1: `/` is always float division and never raises. Division
+  # by zero produces ±inf or NaN. The BEAM has no IEEE float infinity or NaN
+  # (Erlang raises `:badarith` on `1.0 / 0.0`), so we use finite stand-ins
+  # consistent with `math.huge = 1.0e308`:
+  #
+  #   * `1/0`  → `+1.0e308`
+  #   * `-1/0` → `-1.0e308`
+  #   * `0/0`  → `:nan` (sentinel atom)
+  #
+  # Sign of an inf result follows sign of the numerator. Equality on `:nan`
+  # is overridden in `lua_equal/2` so the canonical `nan ~= nan` test holds.
+  # Arithmetic on `:nan` will surface a TypeError via `to_number/1`; that's
+  # an accepted divergence from real IEEE 754, since the suite tests we
+  # care about don't propagate NaN through further arithmetic.
   defp safe_divide(a, b) do
     with {:ok, na} <- to_number(a),
          {:ok, nb} <- to_number(b) do
       if nb == 0 or nb == 0.0 do
-        raise RuntimeError, value: "attempt to divide by zero"
+        cond do
+          na == 0 or na == 0.0 -> :nan
+          na > 0 -> 1.0e308
+          true -> -1.0e308
+        end
       else
         na / nb
       end
@@ -1680,6 +1698,15 @@ defmodule Lua.VM.Executor do
   # leaves alone.
   defp narrow_if_integer(n) when is_integer(n), do: Numeric.to_signed_int64(n)
   defp narrow_if_integer(n), do: n
+
+  # ── Equality ───────────────────────────────────────────────────────────────
+
+  # Lua-level value equality. Mirrors Erlang `==` for ordinary values, but
+  # honors the IEEE 754 rule that `nan ~= nan` for the `:nan` sentinel
+  # produced by `0/0`. See `safe_divide/2` for the rationale.
+  defp lua_equal(:nan, _), do: false
+  defp lua_equal(_, :nan), do: false
+  defp lua_equal(a, b), do: a == b
 
   # ── Type-safe comparison ───────────────────────────────────────────────────
 

--- a/test/lua/vm/arithmetic_test.exs
+++ b/test/lua/vm/arithmetic_test.exs
@@ -111,28 +111,23 @@ defmodule Lua.VM.ArithmeticTest do
   end
 
   describe "division by zero" do
-    test "float division by zero raises error" do
+    test "float division by zero yields +math.huge (Lua 5.3 §3.4.1)" do
+      # Lua 5.3 §3.4.1: `/` is always float division and never raises. The
+      # BEAM has no IEEE +inf, so we use the same finite stand-in as
+      # `math.huge = 1.0e308`.
       code = "return 5 / 0"
       assert {:ok, ast} = Parser.parse(code)
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = State.new()
-
-      # Note: Standard Lua 5.3 returns inf for this case, but we raise an error
-      # because Elixir doesn't easily support creating inf/nan values
-      assert_raise RuntimeError, ~r/divide by zero/, fn ->
-        VM.execute(proto, state)
-      end
+      assert {:ok, [1.0e308], _state} = VM.execute(proto, state)
     end
 
-    test "float division of negative by zero raises error" do
+    test "float division of negative by zero yields -math.huge" do
       code = "return -5 / 0"
       assert {:ok, ast} = Parser.parse(code)
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = State.new()
-
-      assert_raise RuntimeError, ~r/divide by zero/, fn ->
-        VM.execute(proto, state)
-      end
+      assert {:ok, [-1.0e308], _state} = VM.execute(proto, state)
     end
 
     test "floor division by zero raises error" do

--- a/test/lua/vm/float_div_zero_test.exs
+++ b/test/lua/vm/float_div_zero_test.exs
@@ -1,0 +1,94 @@
+defmodule Lua.VM.FloatDivZeroTest do
+  @moduledoc """
+  Pins the float-division-by-zero semantics required by Lua 5.3 §3.4.1.
+
+  `/` is always float division and never raises. Zero divisors produce
+  ±inf or NaN. The BEAM has no IEEE float infinity or NaN, so we use
+  finite stand-ins consistent with `math.huge = 1.0e308`:
+
+    * `1/0`  → `+1.0e308`
+    * `-1/0` → `-1.0e308`
+    * `0/0`  → `:nan` sentinel atom, which compares unequal to itself
+
+  Only `//` and `%` raise on integer-zero divisors (covered elsewhere);
+  this module locks down the `/` contract.
+  """
+
+  use ExUnit.Case, async: true
+
+  defp run!(code) do
+    {results, _state} = Lua.eval!(Lua.new(), code)
+    results
+  end
+
+  describe "positive infinity" do
+    test "1/0 equals math.huge" do
+      assert run!("return 1/0 == math.huge") == [true]
+    end
+
+    test "1/0 is positive" do
+      assert run!("return 1/0 > 0") == [true]
+    end
+
+    test "any positive numerator over zero is +inf" do
+      assert run!("return 42/0 == math.huge") == [true]
+    end
+
+    test "math.huge + 1 == math.huge survives" do
+      # Float precision swallows the +1 at this magnitude; assert it does.
+      assert run!("return math.huge + 1 == math.huge") == [true]
+    end
+  end
+
+  describe "negative infinity" do
+    test "-1/0 equals -math.huge" do
+      assert run!("return -1/0 == -math.huge") == [true]
+    end
+
+    test "-1/0 is negative" do
+      assert run!("return -1/0 < 0") == [true]
+    end
+
+    test "any negative numerator over zero is -inf" do
+      assert run!("return -42/0 == -math.huge") == [true]
+    end
+  end
+
+  describe "NaN (0/0)" do
+    test "0/0 ~= 0/0 — the canonical NaN inequality" do
+      assert run!("return 0/0 ~= 0/0") == [true]
+    end
+
+    test "0/0 == 0/0 is false" do
+      assert run!("return 0/0 == 0/0") == [false]
+    end
+
+    test "NaN compared to a number is unequal" do
+      assert run!("return 0/0 == 1") == [false]
+    end
+  end
+
+  describe "non-zero divisors still divide normally" do
+    test "ordinary float division is unaffected" do
+      assert run!("return 6/2") == [3.0]
+    end
+
+    test "negative-result division is unaffected" do
+      assert run!("return -6/2") == [-3.0]
+    end
+  end
+
+  describe "floor div and modulo with integer-zero divisor still raise" do
+    test "1 // 0 raises" do
+      assert_raise Lua.RuntimeException, ~r/divide by zero/, fn ->
+        Lua.eval!(Lua.new(), "return 1 // 0")
+      end
+    end
+
+    test "1 % 0 raises" do
+      assert_raise Lua.RuntimeException, ~r/modulo by zero/, fn ->
+        Lua.eval!(Lua.new(), "return 1 % 0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Float division by zero must yield ±inf, not raise

Plan: [`.agents/plans/A8a-float-div-zero.md`](https://github.com/tv-labs/lua/blob/fix/float-div-zero/.agents/plans/A8a-float-div-zero.md)

### Goal

Make `1/0`, `-1/0`, and `0/0` evaluate to `+inf`, `-inf`, and `NaN` respectively, per Lua 5.3 §3.4.1, instead of raising `"attempt to divide by zero"`. Only `//` and `%` should raise on integer-zero divisors; plain `/` is always float division and never raises.

### Implementation

The BEAM raises `:badarith` on `1.0 / 0.0` and has no IEEE float infinity or NaN. Per the plan's recommended option 2, we use finite stand-ins consistent with `math.huge = 1.0e308`:

- `1/0`  → `+1.0e308`
- `-1/0` → `-1.0e308`
- `0/0`  → `:nan` (sentinel atom)

Equality on `:nan` is handled by a new `lua_equal/2` helper so the canonical `nan ~= nan` test holds. The `equal` and `not_equal` opcodes route through it; `not_equal` previously bypassed metamethod dispatch entirely (it still does — that's a separate concern, see Discoveries), but now at least honors NaN semantics.

`//` and `%` continue to raise on integer-zero divisors per §3.4.1.

### Success criteria
- [x] `1/0 == math.huge` — verified by new unit test (`float_div_zero_test.exs:25`)
- [x] `-1/0 == -math.huge` — verified by new unit test (`float_div_zero_test.exs:43`)
- [x] `0/0 ~= 0/0` (canonical NaN inequality) — verified by new unit test (`float_div_zero_test.exs:60`)
- [x] `math.huge + 1 == math.huge` survives — verified by new unit test (`float_div_zero_test.exs:38`); float precision swallows the `+1` at this magnitude
- [x] events.lua advances past line 156 — confirmed locally; previously failed AT line 156, now fails further down at a different (out-of-scope) issue
- [x] No regressions in `mix test` — 1467 → 1481 passing (added 14 new tests, 0 failures)

### Changes
```
 lib/lua/vm/executor.ex          | 33 ++++++++++++++++++++++++++++++---
 test/lua/vm/arithmetic_test.exs | 19 +++++++------------
 test/lua/vm/float_div_zero_test.exs | 95 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 131 insertions(+), 15 deletions(-)
```

Two pre-existing tests in `arithmetic_test.exs` that asserted `5/0` and `-5/0` raise (with a comment explicitly acknowledging the divergence from Lua 5.3) were updated to assert the new contract.

### Discoveries

1. **events.lua does not pass end-to-end after this fix.** It advances past line 156 (the metatable test for `__idiv` with `1/0`), then fails further down at "attempt to index a function value." That's a separate downstream issue, out of scope for A8a. events.lua stays in `@skipped_tests`. A follow-up plan would investigate the function-indexing failure.

2. **`//` and `%` with float-zero divisor still raise.** Per Lua 5.3, floor-div and modulo with a float zero divisor (and at least one float operand) should also yield ±inf or NaN. The current code raises for both integer-zero AND float-zero divisors in those operators. The plan explicitly scoped this out, but it's worth a follow-up.

3. **`not_equal` opcode bypasses `__eq` metamethod dispatch.** Pre-existing: `~=` is implemented as direct Erlang `!=`, not as `not (a == b)` through `try_equality_metamethod`. This PR widens it to honor NaN via `lua_equal/2` but does not add metamethod dispatch. A follow-up plan should route `~=` through the same path as `==`.

### Verification
```
mix format
mix compile --warnings-as-errors  # clean
mix test                          # 1481 tests, 0 failures, 31 skipped
mix test --only lua53             # 5 ready, 24 skipped (no regression)
mix test test/lua/vm/float_div_zero_test.exs  # 14 tests, 0 failures
```

events.lua re-run: previously failed AT line 156 with "attempt to divide by zero"; now advances past line 156 and fails at a different (out-of-scope) downstream issue. Confirms the fix achieves the documented progress.

### Out of scope (intentional)

- Changing `//` or `%` behavior beyond the existing integer-zero raise.
- Implementing a full IEEE 754 float type.
- Promoting events.lua to `@ready_tests` (does not pass end-to-end).
- Adding `__eq` metamethod dispatch to `~=`.