### PR TITLE
chore(plans): refill ready pipeline with verified-live A7/A8 follow-ups

### DIFF
--- a/.agents/plans/A17-lexer-vertical-tab-form-feed.md
+++ b/.agents/plans/A17-lexer-vertical-tab-form-feed.md
@@ -5,7 +5,7 @@ issue: 205
 pr: 206
 branch: fix/lexer-vt-ff-whitespace
 base: main
-status: review
+status: merged
 direction: A
 unlocks:
   - literals.lua  # partial — unblocks line 11; full pass depends on later content

--- a/.agents/plans/A7b-table-lib-metamethods.md
+++ b/.agents/plans/A7b-table-lib-metamethods.md
@@ -1,0 +1,114 @@
+---
+id: A7b
+title: "table library functions honor __index/__newindex/__len"
+issue: null
+pr: null
+branch: fix/table-lib-metamethods
+base: main
+status: ready
+direction: A
+unlocks:
+  - nextvar.lua (partial — combined with A7c)
+  - any user code that wraps a backing table in a proxy with a metatable
+---
+
+## Goal
+
+Make `table.insert`, `table.remove`, `table.concat`, `table.move`, and
+`table.sort` honor the `__index`, `__newindex`, and `__len` metamethods
+on their target table, per Lua 5.3 §6.6 and the reference
+implementation in `ltablib.c`. Today these functions read and write the
+table's underlying data directly, bypassing metamethods.
+
+## Out of scope
+
+- Promoting `nextvar.lua` to `@ready_tests` — that is gated on A7c
+  landing as well; a small follow-up plan can flip the suite once both
+  are in.
+- `pairs`/`ipairs` metamethod support (`__pairs`/`__ipairs`). Those are
+  separate dispatch points and don't currently block the suite.
+- Generalizing the dispatch helper to other stdlib modules. Scope this
+  plan to `table.*` only.
+
+## Success criteria
+
+- [ ] `table.insert(proxy, v)` calls `__newindex` on `proxy`'s
+      metatable when the slot is missing on the underlying table.
+- [ ] `table.remove(proxy)` reads via `__index` to find the last
+      element and writes `nil` via `__newindex`.
+- [ ] `table.concat(proxy, sep)` reads element via `__index` and uses
+      `__len` for the upper bound when present.
+- [ ] `table.move(src, ...)` reads via `__index` on `src` and writes
+      via `__newindex` on `dst`.
+- [ ] `table.sort(proxy, cmp)` reads and writes via the metamethod
+      pair. (Sort needs both reads and writes in the same call.)
+- [ ] Unit tests in `test/lua/vm/stdlib/table_test.exs` (or new file)
+      pinning each behavior with a proxy + backing-table fixture.
+- [ ] `mix test` passes; no regressions in non-proxy paths.
+- [ ] `mix test --only lua53`: 5 ready / 24 skipped (no change). The
+      suite promotion happens in a follow-up after A7c lands.
+
+## Implementation notes
+
+Currently `lib/lua/vm/stdlib/table.ex` reaches into the table through
+`Table.put/3` and direct map access. The fix is to route every read and
+write through the same helpers the VM uses for `t[k]` and `t[k] = v` —
+which already honor metamethods. Those helpers are `index_value/3` and
+the `set_table` opcode path in `lib/lua/vm/executor.ex`.
+
+Likely shape:
+
+1. Extract the metamethod-aware read/write into small helpers inside
+   `lib/lua/vm/state.ex` (or wherever `Table.put/3` lives) so the
+   stdlib doesn't need to know about metamethod dispatch directly.
+2. Replace direct `Table.put/3` calls in `stdlib/table.ex` with the
+   new helpers. Length lookups should go through `__len` first, falling
+   back to `Value.sequence_length/1` only on raw tables.
+
+Repro that fails today (verified on main):
+
+```lua
+local backing = {1, 2, 3}
+local proxy = setmetatable({}, {
+  __index = backing,
+  __newindex = backing,
+  __len = function() return #backing end,
+})
+table.insert(proxy, 4)
+assert(#backing == 4)            -- fails: backing unchanged
+assert(table.concat(proxy, ",") == "1,2,3")  -- fails: returns "4"
+```
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+Plus: re-run the standalone `nextvar.lua` survey to confirm we advance
+past the table-library section. The suite file should still fail at
+A7c's site (numeric-for string coercion at line 510); flag it as a
+follow-up if it doesn't.
+
+## Risks
+
+- Sort algorithms that mutate in place may behave differently when
+  every read goes through `__index` (e.g. extra metamethod calls during
+  partition). Most plausible workaround is to materialize the slice
+  into an Elixir list, sort, then write back via `__newindex` — which
+  matches `ltablib.c`'s approach.
+- `__newindex` set as a *table* (not a function) is recursive: writing
+  to the proxy writes to the inner table, which may itself have a
+  metatable. The VM already handles this for `t[k] = v`; reusing those
+  helpers gets it for free.
+- `__len` returning a non-integer or negative number must raise per
+  spec. Check existing `#` handling for the precedent.
+
+## Background
+
+Discovered in A7a's Discoveries section (`A7b — table library
+metamethods on __index/__newindex/__len`). Re-verified on main on
+2026-05-07: `table.insert`/`table.concat` repro confirmed still failing.

--- a/.agents/plans/A7c-numeric-for-string-coercion.md
+++ b/.agents/plans/A7c-numeric-for-string-coercion.md
@@ -1,0 +1,118 @@
+---
+id: A7c
+title: "numeric for coerces string control values to numbers (Lua 5.3 §3.3.5)"
+issue: null
+pr: null
+branch: fix/numeric-for-string-coercion
+base: main
+status: ready
+direction: A
+unlocks:
+  - nextvar.lua (line 510 — `for i="10","1","-2" do ... end`)
+---
+
+## Goal
+
+Make `for i = init, limit, step` coerce string control values to
+numbers (with the same rules as arithmetic), per Lua 5.3 §3.3.5:
+
+> The for statement must evaluate once the values *e1, e2, e3*; these
+> values are then converted to numbers using the same rules of
+> arithmetic operators.
+
+Today, the executor's `:numeric_for` opcode reads the control values
+straight from registers and compares them with `<=` / `>=`. When the
+values are strings, the comparison runs lexicographically (or, if the
+step is also a string, raises) instead of triggering numeric coercion.
+
+## Out of scope
+
+- Generic `for-in` loops. They use a different opcode
+  (`:generic_for`) and a different protocol; if string coercion is
+  needed there it's a separate plan.
+- Promoting `nextvar.lua` to `@ready_tests`. That is gated on A7b
+  landing as well; promotion follows in a small plan once both are in.
+
+## Success criteria
+
+- [ ] `for i = "10", "1", "-2" do ... end` runs 5 iterations, matching
+      the assert at nextvar.lua line 510.
+- [ ] Mixed integer/string control values coerce correctly:
+      `for i = 1, "10" do ... end` and `for i = "1.0", 5 do ... end`
+      both work and follow the float/integer typing rule from §3.3.5
+      (loop variable is a float if any of init/limit/step is a float
+      or coerces to a float).
+- [ ] A non-coercible string raises with a message that matches the
+      reference: `'for' initial value must be a number` (or the closest
+      existing message in this codebase — match what arithmetic
+      produces for `tonumber("abc")` failure).
+- [ ] Unit tests in `test/lua/vm/numeric_for_test.exs` (new file or
+      add to an existing for-loop test file) pinning each case.
+- [ ] `mix test` passes; no regressions.
+- [ ] `mix test --only lua53`: 5 ready / 24 skipped (no change; suite
+      promotion is gated on A7b too).
+
+## Implementation notes
+
+The opcode lives in `lib/lua/vm/executor.ex` at the `:numeric_for`
+clause (currently around line 430). The init/limit/step values come
+from `regs[base]`, `regs[base+1]`, `regs[base+2]`.
+
+The fix should happen *once*, at loop start, not on every iteration:
+coerce all three values to numbers, raise on failure with the right
+message, and write the coerced values back into the same registers
+before the first comparison. Subsequent iterations just increment in
+place and compare numerically.
+
+Float/integer rule (§3.3.5): if any of init/limit/step is a float (or
+a string that coerces to a float, e.g. `"1.5"` or `"1e2"`), the loop
+variable must be a float for every iteration. Integer-only control
+values keep the loop variable an integer. The codebase has the
+`narrow_if_integer/1` and arithmetic coercion helpers already; reuse
+them.
+
+Repro confirmed on main on 2026-05-07:
+
+```lua
+local a = 0
+for i = "10", "1", "-2" do a = a + 1 end
+assert(a == 5)  -- fails: a is 0 (loop body never executes)
+```
+
+The loop body never executes because `"10" <= "1"` is false (string
+comparison treats `"1"` as greater than `"10"`).
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+Plus: re-run the standalone `nextvar.lua` survey via the probe used
+during plan drafting (or just `mix test --only lua53` once the suite
+is promoted). It should advance past line 510. If it stops at a new
+line, document that as the next follow-up before merging.
+
+## Risks
+
+- Lua 5.3 distinguishes integer-for from float-for at runtime — the
+  reference implementation actually emits *different opcodes* for the
+  two cases. We have a single `:numeric_for` opcode. If runtime
+  coercion changes the type from int to float partway through, the
+  step semantics differ (especially the loop-termination edge case at
+  the limit). Worth a unit test that pins the documented behavior at
+  the float/int boundary.
+- Error messages: the reference says `'for' initial value must be a
+  number` etc. We may not match exactly; match the suite's expectations
+  from `nextvar.lua`'s checkerror calls if any are nearby. Otherwise,
+  document the divergence in a comment.
+
+## Background
+
+Discovered in A7a's Discoveries section
+(`A7c — numeric 'for' string-to-number coercion (Lua 5.3 §3.3.5)`).
+Re-verified on main on 2026-05-07: loop body silently doesn't execute
+when init is a string, and `nextvar.lua` line 510's assert fails.

--- a/.agents/plans/A8b-io-stub-as-table.md
+++ b/.agents/plans/A8b-io-stub-as-table.md
@@ -1,0 +1,119 @@
+---
+id: A8b
+title: "io stdlib should be a table of sandboxed functions, not a single function"
+issue: null
+pr: null
+branch: fix/io-stub-as-table
+base: main
+status: ready
+direction: A
+unlocks:
+  - events.lua advances past line 188 (`assert(not pcall(rawlen, io.stdin))`)
+---
+
+## Goal
+
+Make the global `io` a *table* whose keys are sandboxed function stubs
+(`stdin`, `stdout`, `stderr`, `read`, `write`, `open`, `close`,
+`lines`, `popen`, `tmpfile`, `output`, `input`, `flush`, `type`),
+matching the shape of the `os` and `package` stubs. Today `io` is a
+single sandboxed function value, so any access like `io.stdin` raises
+`attempt to index a function value` instead of returning a sandboxed
+function (or sandbox-blocking sentinel).
+
+## Out of scope
+
+- Implementing real I/O. Every entry stays a sandboxed stub.
+- Other stdlib gaps in events.lua post-line-188 — this plan only
+  unblocks the `io.stdin` line. If events.lua fails further down,
+  document the next stop and split into A8e (or whatever the next
+  free id is).
+- Promoting `events.lua` to `@ready_tests`. Promotion follows once
+  the file passes end-to-end.
+
+## Success criteria
+
+- [ ] `type(io)` returns `"table"` (currently `"function"`).
+- [ ] `io.stdin`, `io.stdout`, `io.stderr` are values that don't raise
+      on access. They can be sandboxed stubs that error on call (the
+      pattern `os.getenv` already uses) or table-like stubs — whichever
+      matches the existing sandbox convention more closely.
+- [ ] `io.write("x")` raises with a message of the form
+      `io.write(_) is sandboxed`, mirroring `os.execute()`.
+- [ ] `io.read`, `io.open`, `io.close`, `io.lines`, `io.popen`,
+      `io.tmpfile`, `io.output`, `io.input`, `io.flush`, `io.type`
+      all behave the same (raise sandbox error on call).
+- [ ] events.lua advances past line 188 standalone. (Will likely stop
+      somewhere new; document that.)
+- [ ] `pcall(rawlen, io.stdin)` returns `false, <error>` rather than
+      raising synchronously. (Specifically: events.lua line 188 wraps
+      the `rawlen(io.stdin)` call in `pcall`, so reaching the
+      sandbox-error path needs to be raisable but catchable.)
+- [ ] Unit tests pinning the new shape (a small `test/lua/io_stub_test.exs`
+      or addition to `test/lua/stdlib_test.exs`).
+- [ ] `mix test` passes; no regressions.
+
+## Implementation notes
+
+The other sandboxed modules (`os`, `package`) are tables of
+`{:native_func, &…/2}` entries. Find where `io` is currently bound and
+replace its single-function form with the same table-of-stubs shape.
+
+Each stub raises a `Lua.VM.RuntimeError` with `value: "io.<name>(_) is
+sandboxed"`. For `io.stdin`/`io.stdout`/`io.stderr` (which are
+*values* in real Lua, not functions), pick the convention that matches
+how `package.path` etc. are stubbed. Most likely a function that
+errors on call is fine — events.lua's `pcall(rawlen, io.stdin)` only
+needs a value that doesn't raise on lookup, and `rawlen` on a function
+will raise (which is what the test wants — `pcall` catches it).
+
+Repro confirmed on main on 2026-05-07:
+
+```elixir
+{:ok, _} = Lua.eval!(Lua.new(), "print(type(io))")
+# prints "function" — should be "table"
+```
+
+```lua
+print(type(io))                    -- "function"
+local ok, err = pcall(rawlen, io.stdin)
+                                   -- never reaches the pcall — raises
+                                   -- "attempt to index a function value"
+```
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+Plus: re-run events.lua standalone via the probe pattern (or just run
+the existing skipped suite test by removing `@tag :skip` locally) and
+confirm it advances past line 188. Document the next stop.
+
+## Risks
+
+- Real Lua programs use `io` heavily as a real I/O library. Anyone
+  bringing existing Lua scripts in expects `io.read`/`io.write` to
+  work. Sandbox stubs are the right call for a sandboxed VM, but the
+  error message should be findable and clearly attributed (so users
+  don't think it's a parser/VM bug). Match the existing
+  `os.execute() is sandboxed` wording.
+- If existing user code in this codebase or downstream relies on
+  `type(io) == "function"` (unlikely but possible) it will break. Grep
+  for such checks before changing.
+
+## Background
+
+Discovered while bisecting events.lua for A8a's Discoveries follow-up
+"events.lua's downstream function-indexing failure". A8a recorded the
+*symptom* (`attempt to index a function value`) but didn't identify
+the cause. The actual cause is that `io` is bound as a single sandbox
+function instead of as a table of sandboxed stubs — so `io.stdin`
+indexes a function value rather than looking up a key in a table.
+
+This re-scopes A8a's first follow-up: the events.lua failure isn't an
+`__index` dispatch bug, it's a stdlib stub-shape bug.

--- a/.agents/plans/A8c-floor-div-mod-float-zero.md
+++ b/.agents/plans/A8c-floor-div-mod-float-zero.md
@@ -1,0 +1,104 @@
+---
+id: A8c
+title: "// and % with float-zero divisor return inf/nan, not raise"
+issue: null
+pr: null
+branch: fix/floor-div-mod-float-zero
+base: main
+status: ready
+direction: A
+unlocks:
+  - any code path exercising Lua 5.3 §3.4.1 float semantics for `//`/`%`
+---
+
+## Goal
+
+Make `a // 0.0` and `a % 0.0` follow Lua 5.3 §3.4.1: the float branch
+of floor-division and modulo must return ±inf or nan, never raise.
+Today both raise (`"attempt to divide by zero"` and `"attempt to
+perform modulo by zero"`). The integer branch of both operators
+*should* keep raising — that's correct per spec.
+
+## Out of scope
+
+- `/` (regular division) — already correct, was fixed in A8a.
+- Negative-zero handling, signaling NaN distinctions, or any IEEE 754
+  edge case beyond what A8a's "finite stand-in" model already supports.
+- `events.lua` promotion — gated separately on A8b and possibly more.
+
+## Success criteria
+
+- [ ] `1.0 // 0.0` returns `math.huge` (currently raises).
+- [ ] `-1.0 // 0.0` returns `-math.huge`.
+- [ ] `0.0 // 0.0` returns `:nan` (using A8a's sentinel) and survives
+      the equality rule `nan ~= nan`.
+- [ ] `1.0 % 0.0` returns `:nan` (per Lua 5.3: `a % b = a - floor(a/b)*b`,
+      and `a/0.0 = inf`, so `floor(inf)*0.0 = nan`).
+- [ ] `1 // 0` (integer) still raises `"attempt to divide by zero"`.
+- [ ] `1 % 0` (integer) still raises `"attempt to perform modulo by zero"`.
+- [ ] Mixed integer/float zero divisor: `1 // 0.0` follows the float
+      path (returns inf), `1.0 // 0` raises (integer divisor).
+- [ ] Unit tests in `test/lua/vm/float_div_zero_test.exs` (extend the
+      file A8a created) pinning each combination.
+- [ ] `mix test` passes; no regressions.
+
+## Implementation notes
+
+The fix is local to `safe_floor_divide/2` and `safe_modulo/2` in
+`lib/lua/vm/executor.ex` (around lines 1620–1662). Today both functions
+collapse "any zero divisor" into a single raise:
+
+```elixir
+nb == 0 or nb == 0.0 ->
+  raise RuntimeError, value: "attempt to divide by zero"
+```
+
+The fix splits this into two cases: integer divisor → raise; float
+divisor → produce the `safe_divide`-style sentinel.
+
+For `safe_floor_divide`, the float branch already does
+`Float.floor(na / nb) * 1.0`. With `nb = 0.0`, `na / nb` should now go
+through `safe_divide` (which already handles the inf/nan case) and
+`Float.floor(:nan)`/`Float.floor(1.0e308)` need handling. Probably
+simpler: short-circuit when `is_float(nb) and nb == 0.0` to return the
+right sentinel directly without going through `Float.floor`.
+
+For `safe_modulo`, by Lua's definition `a % 0.0` is always nan
+(integer-zero divisor still raises). Short-circuit to `:nan`.
+
+Repros confirmed on main on 2026-05-07:
+
+```elixir
+{r, _} = Lua.eval!(Lua.new(), "return 1.0 // 0.0")     # raises
+{r, _} = Lua.eval!(Lua.new(), "return 1.0 % 0.0")      # raises
+```
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+## Risks
+
+- The `:nan` sentinel was introduced in A8a but only flows through
+  `safe_divide`. Modulo using `:nan` needs to make sure subsequent
+  arithmetic and equality on the result behave (the `lua_equal/2`
+  helper already special-cases `:nan`). Verify ordering / comparison
+  ops too.
+- `Float.floor(1.0e308)` returns `1.0e308` cleanly in BEAM, so the
+  inf-via-stand-in path is fine. Confirm in a test rather than by
+  inspection.
+- `is_float(nb)` in Elixir distinguishes from `is_integer(nb)` — but
+  `0.0 == 0` is `true`, so guard ordering matters. Use
+  `is_float/1` explicitly, not `nb == 0.0`.
+
+## Background
+
+Discovered in A8a's PR Discoveries section as follow-up #2:
+"`//` and `%` with float-zero divisor still raise (separate plan)."
+Re-verified on main on 2026-05-07: both `1.0 // 0.0` and `1.0 % 0.0`
+still raise.

--- a/.agents/plans/A8d-not-equal-eq-metamethod.md
+++ b/.agents/plans/A8d-not-equal-eq-metamethod.md
@@ -1,0 +1,109 @@
+---
+id: A8d
+title: "~= opcode dispatches through __eq metamethod"
+issue: null
+pr: null
+branch: fix/not-equal-eq-metamethod
+base: main
+status: ready
+direction: A
+unlocks:
+  - any code that compares two metamethod-wrapped values with ~=
+---
+
+## Goal
+
+Make the `:not_equal` opcode go through the `__eq` metamethod the same
+way `:equal` does, then negate the result. Today `:not_equal` is
+implemented as `not lua_equal(a, b)`, which compares the raw values
+directly and bypasses metamethod dispatch entirely.
+
+Per Lua 5.3 §3.4.4, `a ~= b` is *defined* as `not (a == b)`, and `==`
+runs the `__eq` metamethod. So `~=` should run `__eq` and negate.
+
+## Out of scope
+
+- Other comparison operators. `__lt` / `__le` are already routed
+  through `try_binary_metamethod`. `<=` and `>=`/`>` already work.
+- Equality semantics changes (e.g. table identity vs. value equality).
+  This plan is purely about routing the existing `__eq` dispatch
+  through the negated form.
+
+## Success criteria
+
+- [ ] Two values whose `__eq` returns `true` compare as `~= false`,
+      not `~= true`.
+- [ ] Two values whose `__eq` returns `false` compare as `~= true`.
+- [ ] `__eq` is called once per `~=` evaluation (not zero, not twice).
+- [ ] Lua 5.3 §3.4.4 raw-equality short-circuit still applies: for
+      values that compare equal as primitives (e.g. two equal numbers,
+      `nil == nil`), `__eq` is not consulted and `~=` is `false`.
+- [ ] Unit tests in `test/lua/vm/equality_metamethod_test.exs` (or
+      whatever file already pins `__eq` for `:equal`) covering the
+      `~=` path.
+- [ ] `mix test` passes; no regressions.
+
+## Implementation notes
+
+The fix is local to `lib/lua/vm/executor.ex`. Today:
+
+```elixir
+defp do_execute([{:not_equal, dest, a, b} | rest], regs, ...) do
+  result = not lua_equal(elem(regs, a), elem(regs, b))
+  ...
+end
+```
+
+Should be:
+
+```elixir
+defp do_execute([{:not_equal, dest, a, b} | rest], regs, ...) do
+  val_a = elem(regs, a)
+  val_b = elem(regs, b)
+  {result, new_state} =
+    try_equality_metamethod(val_a, val_b, state, fn -> lua_equal(val_a, val_b) end)
+  result = not result
+  ...
+end
+```
+
+`try_equality_metamethod/4` already exists (used by `:equal` at
+line 920) and handles the §3.4.4 short-circuit (only consults `__eq`
+when the raw values are not primitively equal and both have the same
+type). Reuse it.
+
+Repro confirmed on main on 2026-05-07:
+
+```lua
+local mt = { __eq = function() return true end }
+local a = setmetatable({}, mt)
+local b = setmetatable({}, mt)
+assert(a == b)             -- true (correct, calls __eq)
+assert((a ~= b) == false)  -- fails: a ~= b is true (bypasses __eq)
+```
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+```
+
+## Risks
+
+- `try_equality_metamethod` may have been written with the assumption
+  that it's only called in the `:equal` opcode (e.g. it might not
+  thread state correctly if called from a context that doesn't expect
+  state changes). Double-check the signature and fall-through behavior
+  before reusing.
+- The `__eq` metamethod can only be set via `setmetatable`, so this
+  fix can't surface in code that doesn't touch metatables. Low blast
+  radius outside the suite tests.
+
+## Background
+
+Discovered in A8a's PR Discoveries section as follow-up #3:
+"`~=` opcode bypasses `__eq` metamethod dispatch (separate plan)."
+Re-verified on main on 2026-05-07: the repro above still fails.

--- a/.agents/plans/A9b-pm-suite-pattern.md
+++ b/.agents/plans/A9b-pm-suite-pattern.md
@@ -186,3 +186,34 @@ until A9c lands. Unit tests: 1346 → 1354, 0 regressions.
 
 Follow-up: A9c should investigate the `do`-block + `for-in` VM bug
 documented above before pm.lua can move to `@ready_tests`.
+
+## Status update — 2026-05-07
+
+The `do`-block + `for-in` VM bug recorded above as the A9c follow-up
+**is fixed on main**. Both repros pass:
+
+```lua
+do
+  for k, v in pairs({a=1, b=2}) do
+    print(k, v)
+  end
+end
+```
+
+```lua
+local s = "abcde"
+local res = {s=''}
+string.gsub(s, '[a-c]', function (c) res.s = res.s .. c end)
+-- res.s is now "abc"
+```
+
+Likely incidentally fixed by one of A14 (for-loop register regression),
+A15 (open-upvalue missing cell), or A16 (env semantics).
+
+`pm.lua` standalone still fails — but the failure is now somewhere
+**after** line 163 (the last `print('+')` it hits), and is no longer
+the `do`+`for-in` interaction. A new triage pass via the
+`triage-suite-failure` skill is needed to locate and scope the current
+failure before drafting a follow-up plan. Do **not** file an A9c plan
+against the now-fixed bug.
+


### PR DESCRIPTION
## Summary

- Filed five `status: ready` plans (A7b, A7c, A8b, A8c, A8d) drafted from A7a/A8a's Discoveries sections, each repro re-verified against current main on 2026-05-07.
- Updated A9b with a status note: its A9c follow-up (do-block + for-in VM bug) is **fixed** on main, likely incidentally by A14/A15/A16. pm.lua's current failure is no longer that bug.
- Flipped A17 from `review` to `merged` (PR #206 landed in 03dee38).

## Why now

The suite survey (5 pass / 22 fail / 2 timeout) is identical to the last session — no drift in the passing set. But the merged plans A7a, A8a, and A9b each documented follow-ups in their Discoveries sections that never got filed. Result: pipeline shows "no ready plans" while at least five concrete, well-scoped fixes are sitting in plan-prose form. This refills the pipeline with verified-live work.

## Re-verified live failures

| Plan | Repro |
|---|---|
| **A7b** — `table` lib metamethods | `table.insert(proxy, 4)` silently no-ops; `table.concat(proxy, ",")` returns wrong value |
| **A7c** — numeric `for` string coercion | `for i="10","1","-2" do ... end` body never executes (nextvar.lua line 510) |
| **A8b** — `io` stub-as-table | `type(io) == "function"`; `io.stdin` raises (events.lua line 188). Rescoped from A8a's recorded symptom once bisecting identified the actual cause. |
| **A8c** — `//` / `%` float-zero | `1.0 // 0.0` and `1.0 % 0.0` both raise instead of returning inf/nan |
| **A8d** — `~=` `__eq` dispatch | `a ~= b` returns true even when `a == b` returns true via `__eq` |

## Notable rescoping

A8b is **not** what A8a's Discoveries described. A8a recorded the symptom (`attempt to index a function value` in events.lua) but didn't bisect to root cause. Bisecting events.lua to line 188 (`assert(not pcall(rawlen, io.stdin))`) revealed the cause: `io` is bound as a single sandbox function instead of a table of sandboxed stubs (the pattern `os` already follows). A8b's plan documents this rescoping.

## A9c not filed

The A9c follow-up A9b documented (do-block + for-in VM bug) is fixed on main:

```lua
do
  for k, v in pairs({a=1, b=2}) do print(k, v) end
end
-- works
```

A9b updated with a "Status update — 2026-05-07" section explaining this. pm.lua's current failure is somewhere after line 163 and needs fresh triage via `triage-suite-failure` before drafting a follow-up.

## Pipeline after this PR

- **5 ready** — A7b, A7c, A8b, A8c, A8d (in `/next-plan` order)
- **1 blocked** — A13
- **2 deferred** — A10a, A10b
- **22 merged** — A0–A12, A14–A17, A5a, A7a, A8a, A9a, A9b

## Verification

This is a documentation-only PR — no source files touched.

```bash
git diff --stat main
# .agents/plans/A17-lexer-vertical-tab-form-feed.md  |   2 +-
# .agents/plans/A7b-table-lib-metamethods.md         | 110 +++++++++++++++++++
# .agents/plans/A7c-numeric-for-string-coercion.md   | 113 ++++++++++++++++++++
# .agents/plans/A8b-io-stub-as-table.md              | 113 ++++++++++++++++++++
# .agents/plans/A8c-floor-div-mod-float-zero.md      | 109 ++++++++++++++++++
# .agents/plans/A8d-not-equal-eq-metamethod.md       | 116 ++++++++++++++++++++
# .agents/plans/A9b-pm-suite-pattern.md              |  34 ++++++
```