### PR TITLE
fix(stdlib): expose io as a table of sandboxed stubs

### DIFF
--- a/.agents/plans/A8b-io-stub-as-table.md
+++ b/.agents/plans/A8b-io-stub-as-table.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: fix/io-stub-as-table
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - events.lua advances past line 188 (`assert(not pcall(rawlen, io.stdin))`)

--- a/.agents/plans/A8b-io-stub-as-table.md
+++ b/.agents/plans/A8b-io-stub-as-table.md
@@ -2,10 +2,10 @@
 id: A8b
 title: "io stdlib should be a table of sandboxed functions, not a single function"
 issue: null
-pr: null
+pr: 210
 branch: fix/io-stub-as-table
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - events.lua advances past line 188 (`assert(not pcall(rawlen, io.stdin))`)
@@ -117,3 +117,43 @@ indexes a function value rather than looking up a key in a table.
 
 This re-scopes A8a's first follow-up: the events.lua failure isn't an
 `__index` dispatch bug, it's a stdlib stub-shape bug.
+
+## What changed
+
+PR: [#210](https://github.com/tv-labs/lua/pull/210)
+
+Files touched:
+
+- `lib/lua.ex` — replaced the single `[:io]` entry in
+  `@default_sandbox` with one path per member (`[:io, :stdin]`,
+  `[:io, :stdout]`, `[:io, :stderr]`, `[:io, :read]`, `[:io, :write]`,
+  `[:io, :open]`, `[:io, :close]`, `[:io, :lines]`, `[:io, :popen]`,
+  `[:io, :tmpfile]`, `[:io, :output]`, `[:io, :input]`, `[:io, :flush]`,
+  `[:io, :type]`). The existing `do_set_nested` helper auto-allocates
+  the `io` table and each member becomes a sandbox stub on its own,
+  matching the shape of `os` and `package`.
+- `lib/lua/vm/stdlib.ex` — fixed `lua_rawlen` to raise for non-table,
+  non-string arguments (was silently returning 0). Empty args raise
+  `"bad argument #1 to 'rawlen' (value expected)"`; other types raise
+  `"bad argument #1 to 'rawlen' (table or string expected, got <type>)"`.
+  Required to unblock events.lua line 188 `pcall(rawlen, io.stdin)`.
+- `test/lua/io_stub_test.exs` — new regression test, 20 tests pinning
+  the io table shape, per-member sandbox messages, and the new
+  `rawlen` error semantics.
+
+Test delta:
+
+- `mix test`: 1524 → 1544 tests, 0 failures, 31 skipped (unchanged).
+- `mix test --only lua53`: 29 tests, 0 failures, 24 skipped — same
+  pass count. `events.lua` remains skipped (see Discoveries).
+
+## Discoveries
+
+- events.lua's next stop after this plan is the `__lt` metamethod
+  dispatch test at ~line 208: `assert(not(Op(1)<Op(1)) ...)` where
+  `Op(x)` returns `setmetatable({x=x}, t)` and `t.__lt` is a function.
+  Comparison operators (`<`, `<=`, `>`, `>=`) don't yet dispatch
+  through `__lt` / `__le` metamethods on table operands; failure is
+  `attempt to compare table with table`. That's a separate VM gap and
+  blocks promoting `events.lua` to `@ready_tests`. Open a follow-up
+  plan (next free id) before re-running the suite for events.lua.

--- a/.agents/plans/A8b-io-stub-as-table.md
+++ b/.agents/plans/A8b-io-stub-as-table.md
@@ -149,11 +149,14 @@ Test delta:
 
 ## Discoveries
 
-- events.lua's next stop after this plan is the `__lt` metamethod
-  dispatch test at ~line 208: `assert(not(Op(1)<Op(1)) ...)` where
-  `Op(x)` returns `setmetatable({x=x}, t)` and `t.__lt` is a function.
-  Comparison operators (`<`, `<=`, `>`, `>=`) don't yet dispatch
-  through `__lt` / `__le` metamethods on table operands; failure is
-  `attempt to compare table with table`. That's a separate VM gap and
-  blocks promoting `events.lua` to `@ready_tests`. Open a follow-up
-  plan (next free id) before re-running the suite for events.lua.
+- events.lua's next stop after this plan is **line 258**:
+  `assert((Set{1,2,3,4} <= Set{1,2,3,4}))`. At that point `t.__lt` is
+  set on `Set`'s metatable but `t.__le` is explicitly `nil`. Per
+  Lua 5.3 §3.4.4, `a <= b` should fall back to `not (b < a)` when
+  `__le` is missing — our VM raises `attempt to compare table with
+  table` instead. `__lt` itself dispatches correctly on table operands
+  (verified with the line 208 pattern in isolation: that assertion
+  passes); only the `__le → not __lt(b, a)` fallback is missing.
+  Tracked in **A8e** (next free id, plan file:
+  `.agents/plans/A8e-le-fallback-not-lt.md`). A8e blocks promoting
+  `events.lua` to `@ready_tests`.

--- a/.agents/plans/A8e-le-fallback-not-lt.md
+++ b/.agents/plans/A8e-le-fallback-not-lt.md
@@ -237,3 +237,39 @@ So the gap is precisely the §3.4.4 fallback — and only that.
 This plan was opened as the documented follow-up from A8b's
 Discoveries section. PR #210 (A8b) carries a Discoveries pointer to
 this plan id.
+
+## Context for the picking agent
+
+A few cross-plan details worth knowing before starting:
+
+- **A8b's first Discoveries entry was wrong and has been corrected.**
+  It originally claimed `__lt` and `__le` don't dispatch on tables.
+  Re-triage proved that's not true — both dispatch correctly when set.
+  Only the `__le` fallback is missing. The corrected entry in
+  `.agents/plans/A8b-io-stub-as-table.md` and PR #210's body now
+  reflect that. Don't be misled by any earlier draft of the A8b
+  description if you read it via cached state.
+
+- **A8d notes "`__lt` / `__le` are already routed through
+  `try_binary_metamethod`."** That's accurate for *direct* dispatch.
+  A8d is silent on the §3.4.4 fallback path, which is what A8e fills
+  in. There's no conflict between A8d and A8e — they touch different
+  code paths in the same opcode family.
+
+- **The picker order is A8c → A8d → A8e.** A8c (floor-div-mod-float-zero)
+  and A8d (`~=` / `__eq` dispatch) are independent of this plan and
+  can ship first or last. None of the three blocks the others. If the
+  user wants A8e prioritised, they can pick it directly by id.
+
+- **events.lua remains in `@skipped_tests`** in
+  `test/lua53_suite_test.exs:18`. After A8e ships, advance the
+  file-probe past line 258, document the next stop in this plan's
+  Discoveries, and decide whether to promote events.lua to
+  `@ready_tests` or open the next follow-up plan. Promotion is
+  out of scope for A8e itself.
+
+- **Reuse the file-probe pattern** from the `triage-suite-failure`
+  skill if you need to find the next stop. The Background section
+  above already names the truncated-with-`do return end` pattern
+  used to bisect line 258. The same pattern picks up where A8e
+  leaves off.

--- a/.agents/plans/A8e-le-fallback-not-lt.md
+++ b/.agents/plans/A8e-le-fallback-not-lt.md
@@ -1,0 +1,239 @@
+---
+id: A8e
+title: "__le falls back to `not (b < a)` when __le is unset"
+issue: null
+pr: null
+branch: fix/le-fallback-not-lt
+base: main
+status: ready
+direction: A
+unlocks:
+  - events.lua advances past line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`)
+  - any user code that defines `__lt` on tables but omits `__le`
+---
+
+## Goal
+
+Make the `:less_equal` opcode fall back to `not (b < a)` when neither
+operand has an `__le` metamethod, per Lua 5.3 §3.4.4. Today,
+`:less_equal` looks up `__le` and — if missing — runs
+`safe_compare_le`, which raises `attempt to compare table with table`
+on table operands. The reference manual is explicit:
+
+> The `<=` operation is translated to `not (b < a)` if there is no
+> `__le` metamethod.
+
+So when `__le` is unset, dispatch should consult `__lt` (with operands
+*swapped*) and negate the result. Only fall through to
+`safe_compare_le` when neither metamethod is defined and the operands
+have a primitive `<=` (numbers, strings).
+
+The same fallback covers the reverse: in the official manual `>=` is
+defined as `b <= a`, so `:greater_equal` already routes through this
+path. Verify in the implementation that fixing `:less_equal` also
+fixes `>=` between tables when `__lt` is the only comparison
+metamethod present.
+
+## Out of scope
+
+- Changing `__lt` itself. Single-direction `__lt` dispatch on table
+  operands already works (verified on main on 2026-05-07: a metatable
+  with only `__lt` makes `Op(1) < Op(2)` return the expected value).
+- The `:not_equal` / `__eq` short-circuit. That is A8d's territory and
+  shipped (or will ship) under its own plan.
+- Strict-mode raw-equality between primitives. §3.4.4's primitive
+  short-circuit already applies and isn't touched here.
+- Promoting `events.lua` to `@ready_tests`. There may be further stops
+  past line 258; advance the file probe and document the next stop in
+  Discoveries before promoting.
+
+## Success criteria
+
+- [ ] `Op(1) <= Op(2)` returns `true` when only `__lt` is set on the
+      metatable (current behaviour: raises `attempt to compare table
+      with table`).
+- [ ] `Op(2) <= Op(1)` returns `false` in the same setup. The fallback
+      uses `__lt(b, a)` and negates: `not (Op(1) < Op(2)) == false`.
+- [ ] `Op(1) <= Op(1)` returns `true` (negation of `not (a < a)`).
+- [ ] `__le` (when set) still wins. The fallback only fires when neither
+      operand exposes `__le`.
+- [ ] `>=` between tables defined only via `__lt` works for the same
+      reason (existing translation `a >= b ⇒ b <= a` chains into the
+      new fallback).
+- [ ] `safe_compare_le` still raises for primitive operands of mixed,
+      non-comparable type (e.g. `1 <= "x"` still raises). The fallback
+      is for *table* operands missing `__le`, not a license to compare
+      mismatched primitives.
+- [ ] events.lua line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`)
+      passes standalone. Document the next stop after line 258 in
+      Discoveries.
+- [ ] Unit tests pinning the new fallback in
+      `test/lua/vm/comparison_metamethod_test.exs` (new file) or as an
+      addition to the existing metatable test file. At minimum:
+      - metatable with `__lt` only, table-table `<=` and `>=`
+      - metatable with `__le` only, table-table `<=` (must still call
+        `__le`, not `__lt`)
+      - metatable with both, `<=` calls `__le` (not `__lt`)
+      - mixed: one operand has `__le`, other doesn't — `__le` from
+        either operand wins (matches existing
+        `try_binary_metamethod` lookup order)
+- [ ] `mix test` passes; no regressions.
+
+## Implementation notes
+
+The fix is local to `lib/lua/vm/executor.ex`. The current
+`:less_equal` opcode is at line 948:
+
+```elixir
+defp do_execute([{:less_equal, dest, a, b} | rest], regs, ...) do
+  val_a = elem(regs, a)
+  val_b = elem(regs, b)
+
+  {result, new_state} =
+    try_binary_metamethod("__le", val_a, val_b, state, fn -> safe_compare_le(val_a, val_b) end)
+  ...
+end
+```
+
+`try_binary_metamethod/5` is at line 1572:
+
+```elixir
+defp try_binary_metamethod(metamethod_name, a, b, state, default_fn) do
+  metamethod =
+    lookup_metamethod(a, metamethod_name, state) ||
+      lookup_metamethod(b, metamethod_name, state)
+
+  invoke_metamethod(metamethod, [a, b], state, default_fn)
+end
+```
+
+The `default_fn` runs when no `__le` is found on either operand. Today
+`default_fn` is `safe_compare_le`, which raises on tables. Replace the
+default with one that:
+
+1. Looks up `__lt` on `b` (then `a`, matching the existing dispatch
+   order).
+2. If `__lt` exists, invoke it with operands **swapped** (`__lt(b, a)`)
+   and negate the result.
+3. If `__lt` is also absent, fall through to `safe_compare_le` (which
+   handles numbers/strings and raises on incompatible types).
+
+Sketch:
+
+```elixir
+defp do_execute([{:less_equal, dest, a, b} | rest], regs, ..., state, ...) do
+  val_a = elem(regs, a)
+  val_b = elem(regs, b)
+
+  {result, new_state} =
+    try_binary_metamethod("__le", val_a, val_b, state, fn ->
+      try_binary_metamethod("__lt", val_b, val_a, state, fn ->
+        safe_compare_le(val_a, val_b)
+      end)
+      |> negate()
+    end)
+  ...
+end
+
+# Helper: negate the {result, state} tuple's first element.
+defp negate({result, state}), do: {not result, state}
+```
+
+Watch for two subtleties:
+
+- `try_binary_metamethod` returns `{result, state}`. The outer
+  `default_fn` must also return `{result, state}` — both because
+  `try_binary_metamethod` calls `default_fn.()` and uses its return
+  directly (look at `invoke_metamethod` line 1607-1614 for the
+  exact contract).
+- The negation must wrap the *whole* `{result, state}` tuple, not
+  just the boolean. The test for "`__le` calls `__le`, not `__lt`"
+  exists specifically to prevent over-eager negation when `__le` is
+  set but happens to delegate to `__lt` somewhere.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+mix test test/lua/vm/comparison_metamethod_test.exs  # new file (if added)
+mix test test/lua/vm/metatable_test.exs              # existing regressions
+```
+
+Repro that should change behaviour:
+
+```lua
+local t = {}
+t.__lt = function(a, b) return a.x < b.x end
+-- t.__le intentionally unset
+local function Op(x) return setmetatable({x=x}, t) end
+print(Op(1) <= Op(2))  -- on main: raises; after A8e: prints true
+```
+
+Repro from events.lua line 258 that should pass standalone:
+
+```lua
+local t = {}
+local function rawSet(x) local s={}; for _,v in ipairs(x) do s[v]=true end; return s end
+local function Set(x) return setmetatable(rawSet(x), t) end
+t.__lt = function (a,b)
+  for k in pairs(a) do
+    if not b[k] then return false end
+    b[k] = nil
+  end
+  return next(b) ~= nil
+end
+t.__le = nil
+assert((Set{1,2,3,4} <= Set{1,2,3,4}))
+```
+
+## Risks
+
+- `:greater_equal` and `:greater_than` may also rely on
+  `safe_compare_*` and need parallel treatment. Check the executor
+  near line 959 onward — if `:greater_equal` is implemented as
+  `:less_equal` with swapped operands, the A8e fix already covers it.
+  If it's a separate opcode, mirror the change.
+- If `try_binary_metamethod` short-circuits on `__le` *before*
+  consulting `__lt`, the fallback is correct. If for any reason a
+  metatable has both `__le` and `__lt` and the user expects only
+  `__le` to fire (which is the spec), the existing lookup order is
+  fine — `__lt` is only consulted when `__le` is nil.
+- Performance: every `<=` between non-numeric, non-string operands
+  now does up to two metatable lookups instead of one. The cost is
+  negligible (metamethod lookup is already in the hot path for any
+  table comparison) but worth flagging if a benchmark regresses.
+
+## Background
+
+Discovered while shipping A8b (`fix/io-stub-as-table`, PR #210).
+After A8b unblocked events.lua line 188 (`pcall(rawlen, io.stdin)`),
+the suite advanced and stopped at line 258. Triage on 2026-05-07 with
+the file-probe pattern from the `triage-suite-failure` skill:
+
+1. Bisected events.lua's truncated-with-`do return end` execution
+   between lines 250 and 280.
+2. Confirmed line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`) is
+   the first hit.
+3. Reduced to:
+
+   ```lua
+   local t = {}
+   t.__lt = function(a, b) return a.x < b.x end
+   local function Op(x) return setmetatable({x=x}, t) end
+   return Op(1) <= Op(2)  -- raises "attempt to compare table with table"
+   ```
+
+4. Verified `__lt` itself dispatches correctly: a metatable with only
+   `__lt` makes `Op(1) < Op(2)` return `true` without raising.
+5. Verified `__le`, when set, dispatches correctly too: a metatable
+   with `__lt` and `__le` makes `Op(1) <= Op(2)` return whatever
+   `__le` returns.
+
+So the gap is precisely the §3.4.4 fallback — and only that.
+
+This plan was opened as the documented follow-up from A8b's
+Discoveries section. PR #210 (A8b) carries a Discoveries pointer to
+this plan id.

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -24,7 +24,20 @@ defmodule Lua do
   defstruct [:state]
 
   @default_sandbox [
-    [:io],
+    [:io, :stdin],
+    [:io, :stdout],
+    [:io, :stderr],
+    [:io, :read],
+    [:io, :write],
+    [:io, :open],
+    [:io, :close],
+    [:io, :lines],
+    [:io, :popen],
+    [:io, :tmpfile],
+    [:io, :output],
+    [:io, :input],
+    [:io, :flush],
+    [:io, :type],
     [:file],
     [:os, :execute],
     [:os, :exit],

--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -256,7 +256,12 @@ defmodule Lua.VM.Stdlib do
     {[tref], state}
   end
 
-  # rawlen(v) — length without metamethods
+  # rawlen(v) — length without metamethods.
+  #
+  # Lua 5.3 reference: rawlen requires a table or string argument and
+  # raises "table or string expected" otherwise. The previous
+  # implementation silently returned 0 for non-table, non-string
+  # values, which broke `pcall(rawlen, ...)` patterns in events.lua.
   defp lua_rawlen([{:tref, id} | _], state) do
     table = Map.fetch!(state.tables, id)
     {[Value.sequence_length(table.data)], state}
@@ -266,7 +271,17 @@ defmodule Lua.VM.Stdlib do
     {[byte_size(v)], state}
   end
 
-  defp lua_rawlen(_, state), do: {[0], state}
+  defp lua_rawlen([], _state) do
+    raise ArgumentError.value_expected("rawlen", 1)
+  end
+
+  defp lua_rawlen([v | _], _state) do
+    raise ArgumentError,
+      function_name: "rawlen",
+      arg_num: 1,
+      expected: "table or string",
+      got: Value.type_name(v)
+  end
 
   # rawequal(a, b) — equality without metamethods
   defp lua_rawequal([a, b | _], state) do

--- a/test/lua/io_stub_test.exs
+++ b/test/lua/io_stub_test.exs
@@ -1,0 +1,121 @@
+defmodule Lua.IoStubTest do
+  @moduledoc """
+  Regression tests pinning the shape of the sandboxed `io` library.
+
+  Reference Lua 5.3 exposes `io` as a table whose keys are functions
+  (and the `stdin`/`stdout`/`stderr` file handles). In a sandboxed VM
+  every entry is a stub that raises on call, but the surrounding
+  table-of-functions shape is preserved so that user code lifting
+  patterns from the wider Lua ecosystem (and our own Lua 5.3 test
+  suite, e.g. `events.lua` line 188 `pcall(rawlen, io.stdin)`) doesn't
+  trip on `attempt to index a function value`.
+  """
+
+  use ExUnit.Case, async: true
+
+  describe "io shape" do
+    test "io is a table, not a function" do
+      assert {["table"], _} = Lua.eval!(Lua.new(), "return type(io)")
+    end
+
+    test "io.stdin, io.stdout, io.stderr are accessible without raising" do
+      # The exact type these resolve to is an implementation detail of
+      # how we sandbox; we only require that indexing them does not
+      # itself raise.
+      assert {[type], _} = Lua.eval!(Lua.new(), "return type(io.stdin)")
+      assert is_binary(type)
+
+      assert {[type], _} = Lua.eval!(Lua.new(), "return type(io.stdout)")
+      assert is_binary(type)
+
+      assert {[type], _} = Lua.eval!(Lua.new(), "return type(io.stderr)")
+      assert is_binary(type)
+    end
+  end
+
+  describe "sandboxed io functions" do
+    test "io.write raises with a sandboxed message mirroring os.execute" do
+      assert_raise Lua.RuntimeException,
+                   "Lua runtime error: io.write(_) is sandboxed",
+                   fn ->
+                     Lua.eval!(Lua.new(), ~S[io.write("x")])
+                   end
+    end
+
+    test "io.read raises with a sandboxed message" do
+      assert_raise Lua.RuntimeException,
+                   "Lua runtime error: io.read() is sandboxed",
+                   fn ->
+                     Lua.eval!(Lua.new(), "io.read()")
+                   end
+    end
+
+    for fn_name <- ~w(open close lines popen tmpfile output input flush type) do
+      test "io.#{fn_name} raises with a sandboxed message" do
+        code = "io.#{unquote(fn_name)}()"
+        message = "Lua runtime error: io.#{unquote(fn_name)}() is sandboxed"
+
+        assert_raise Lua.RuntimeException, message, fn ->
+          Lua.eval!(Lua.new(), code)
+        end
+      end
+    end
+
+    test "pcall(io.write, 'x') returns false plus the sandbox message" do
+      assert {[false, "Lua runtime error: io.write(_) is sandboxed"], _} =
+               Lua.eval!(Lua.new(), ~S[return pcall(io.write, "x")])
+    end
+  end
+
+  describe "rawlen on non-table, non-string values" do
+    # The `events.lua` test suite at line 188 asserts
+    # `not pcall(rawlen, io.stdin)`. For that to evaluate to `true`,
+    # rawlen has to *raise* on a non-table/non-string argument so the
+    # surrounding pcall returns `false, <error>`. Reference Lua 5.3
+    # raises "table or string expected"; the previous implementation
+    # silently returned 0.
+    test "pcall(rawlen, io.stdin) returns false with a type error" do
+      assert {[false, message], _} =
+               Lua.eval!(Lua.new(), "return pcall(rawlen, io.stdin)")
+
+      assert message =~ "rawlen"
+      assert message =~ "table or string expected"
+    end
+
+    test "rawlen on a number raises" do
+      assert {[false, message], _} =
+               Lua.eval!(Lua.new(sandboxed: []), "return pcall(rawlen, 34)")
+
+      assert message =~ "rawlen"
+      assert message =~ "number"
+    end
+
+    test "rawlen with no arguments raises" do
+      assert {[false, message], _} =
+               Lua.eval!(Lua.new(sandboxed: []), "return pcall(rawlen)")
+
+      assert message =~ "rawlen"
+      assert message =~ "value expected"
+    end
+
+    test "rawlen on a function raises" do
+      code = """
+      local f = function() end
+      return pcall(rawlen, f)
+      """
+
+      assert {[false, message], _} = Lua.eval!(Lua.new(sandboxed: []), code)
+      assert message =~ "function"
+    end
+
+    test "rawlen on a table still returns its sequence length" do
+      assert {[3], _} =
+               Lua.eval!(Lua.new(sandboxed: []), "return rawlen({10, 20, 30})")
+    end
+
+    test "rawlen on a string still returns its byte size" do
+      assert {[5], _} =
+               Lua.eval!(Lua.new(sandboxed: []), ~S[return rawlen("hello")])
+    end
+  end
+end


### PR DESCRIPTION
## io stdlib should be a table of sandboxed functions, not a single function

Plan: [`.agents/plans/A8b-io-stub-as-table.md`](.agents/plans/A8b-io-stub-as-table.md)

### Goal

Make the global `io` a *table* whose keys are sandboxed function stubs
(`stdin`, `stdout`, `stderr`, `read`, `write`, `open`, `close`,
`lines`, `popen`, `tmpfile`, `output`, `input`, `flush`, `type`),
matching the shape of the `os` and `package` stubs. Previously `io`
was a single sandboxed function value, so any access like `io.stdin`
raised `attempt to index a function value` instead of returning a
sandboxed function.

### Success criteria

- [x] `type(io)` returns `"table"` (was `"function"`). Verified by
      `Lua.IoStubTest.test "io is a table, not a function"`.
- [x] `io.stdin`, `io.stdout`, `io.stderr` are values that don't raise
      on access. They resolve to sandbox stubs (functions) — calling
      them raises `io.<name>(_) is sandboxed`. Verified by
      `Lua.IoStubTest.test "io.stdin, io.stdout, io.stderr are accessible without raising"`.
- [x] `io.write("x")` raises with `Lua runtime error: io.write(_) is sandboxed`,
      mirroring `os.execute()`.
- [x] `io.read`, `io.open`, `io.close`, `io.lines`, `io.popen`,
      `io.tmpfile`, `io.output`, `io.input`, `io.flush`, `io.type`
      all behave the same (raise sandbox error on call).
- [x] `events.lua` advances past line 188 standalone. New stop is
      **line 258** (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`) — the
      §3.4.4 fallback `a <= b ⇒ not (b < a)` when `__le` is unset.
      Tracked in **A8e** ([`.agents/plans/A8e-le-fallback-not-lt.md`](.agents/plans/A8e-le-fallback-not-lt.md)).
- [x] `pcall(rawlen, io.stdin)` returns `false, "bad argument #1 to
      'rawlen' (table or string expected, got function)"`. This
      required also fixing `rawlen` to raise on non-table/non-string
      args — the previous implementation silently returned 0.
- [x] Unit tests pin the new shape (`test/lua/io_stub_test.exs`,
      20 tests).
- [x] `mix test` passes; no regressions (1524 → 1544 tests, 0 failures).

### Changes

```
 .agents/plans/A8b-io-stub-as-table.md   |  44 +++++++++++++++--
 .agents/plans/A8e-le-fallback-not-lt.md | 239 ++++++++++++++++++++++++++++
 lib/lua.ex                              |  15 ++++-
 lib/lua/vm/stdlib.ex                    |  19 +++++-
 test/lua/io_stub_test.exs               | 121 +++++++++++++++++
```

- `lib/lua.ex` — replace `[:io]` in `@default_sandbox` with one path
  per `io` member (`[:io, :stdin]`, `[:io, :stdout]`, ..., `[:io, :type]`).
  Each member is sandboxed individually, so `io` itself is auto-allocated
  as an intermediate table by the existing `do_set_nested` helper.
- `lib/lua/vm/stdlib.ex` — make `lua_rawlen` raise for non-table,
  non-string arguments (was returning 0). Empty arg list raises
  `"bad argument #1 to 'rawlen' (value expected)"`; other types raise
  `"bad argument #1 to 'rawlen' (table or string expected, got <type>)"`.
- `test/lua/io_stub_test.exs` — new regression test pinning the io
  table shape, the per-member sandbox messages, and the new `rawlen`
  error semantics.
- `.agents/plans/A8e-le-fallback-not-lt.md` — new ready plan for the
  follow-up VM gap discovered while shipping this one (see Discoveries).

### Discoveries

events.lua's next stop after this plan is **line 258**:

```lua
assert((Set{1,2,3,4} <= Set{1,2,3,4}))
```

At that point `t.__lt` is set on `Set`'s metatable but `t.__le` is
explicitly `nil`. Per Lua 5.3 §3.4.4, `a <= b` should fall back to
`not (b < a)` when `__le` is missing — our VM raises `attempt to
compare table with table` instead. `__lt` itself dispatches correctly
on table operands (the line 208 assertion passes standalone); only the
`__le → not __lt(b, a)` fallback is missing.

Tracked in **A8e** ([`.agents/plans/A8e-le-fallback-not-lt.md`](.agents/plans/A8e-le-fallback-not-lt.md)),
status `ready`. A8e blocks promoting `events.lua` to `@ready_tests`.

### Verification

```
mix format             # no changes
mix compile --warnings-as-errors  # clean
mix test               # 52 doctests, 51 properties, 1544 tests, 0 failures, 31 skipped
mix test --only lua53  # 29 tests, 0 failures, 24 skipped
```

### Out of scope (intentional)

- Implementing real I/O. Every `io` entry stays a sandboxed stub.
- Other stdlib gaps in `events.lua` past line 188 — see Discoveries.
- Promoting `events.lua` to `@ready_tests` — blocked on A8e.