### PR TITLE
fix(vm): route ~= opcode through __eq metamethod

### DIFF
--- a/.agents/plans/A8d-not-equal-eq-metamethod.md
+++ b/.agents/plans/A8d-not-equal-eq-metamethod.md
@@ -2,10 +2,10 @@
 id: A8d
 title: "~= opcode dispatches through __eq metamethod"
 issue: null
-pr: null
+pr: 212
 branch: fix/not-equal-eq-metamethod
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - any code that compares two metamethod-wrapped values with ~=
@@ -107,3 +107,28 @@ mix test --only lua53
 Discovered in A8a's PR Discoveries section as follow-up #3:
 "`~=` opcode bypasses `__eq` metamethod dispatch (separate plan)."
 Re-verified on main on 2026-05-07: the repro above still fails.
+
+## What changed
+
+PR: https://github.com/tv-labs/lua/pull/212
+
+Files touched:
+
+- `lib/lua/vm/executor.ex` — `:not_equal` clause now reuses
+  `try_equality_metamethod/4` (the same helper `:equal` uses) with
+  `lua_equal/2` as the default, and negates the result. State is threaded
+  through correctly via the helper's existing return shape.
+- `test/lua/vm/metatable_test.exs` — 4 new tests under the
+  `comparison metamethods` describe block:
+  - `~= dispatches through __eq metamethod`
+  - `~= calls __eq exactly once per evaluation`
+  - `~= short-circuits primitive equality without consulting __eq`
+  - `~= falls back to raw inequality when metamethods differ`
+
+Test counts:
+
+- `mix test`: 1560 → 1564 tests, 0 failures.
+- `mix test --only lua53`: 29 tests, 0 failures (no change — no
+  metamethod-using suite file is currently in the passing set).
+
+No follow-up issues opened; plan repro now passes end-to-end.

--- a/.agents/plans/A8d-not-equal-eq-metamethod.md
+++ b/.agents/plans/A8d-not-equal-eq-metamethod.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: fix/not-equal-eq-metamethod
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - any code that compares two metamethod-wrapped values with ~=

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -969,9 +969,14 @@ defmodule Lua.VM.Executor do
   end
 
   defp do_execute([{:not_equal, dest, a, b} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    result = not lua_equal(elem(regs, a), elem(regs, b))
-    regs = put_elem(regs, dest, result)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+    val_a = elem(regs, a)
+    val_b = elem(regs, b)
+
+    {eq_result, new_state} =
+      try_equality_metamethod(val_a, val_b, state, fn -> lua_equal(val_a, val_b) end)
+
+    regs = put_elem(regs, dest, not eq_result)
+    do_execute(rest, regs, upvalues, proto, new_state, cont, frames, line)
   end
 
   # ── Unary operations ───────────────────────────────────────────────────────

--- a/test/lua/vm/metatable_test.exs
+++ b/test/lua/vm/metatable_test.exs
@@ -321,6 +321,91 @@ defmodule Lua.VM.MetatableTest do
       assert {:ok, [false], _state} = VM.execute(proto, state)
     end
 
+    test "~= dispatches through __eq metamethod" do
+      code = """
+      local a = {value = 10}
+      local b = {value = 10}
+      local c = {value = 20}
+      local mt = {
+        __eq = function(x, y)
+          return x.value == y.value
+        end
+      }
+      setmetatable(a, mt)
+      setmetatable(b, mt)
+      setmetatable(c, mt)
+      return a ~= b, a ~= c
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      # a ~= b → __eq returns true → ~= is false
+      # a ~= c → __eq returns false → ~= is true
+      assert {:ok, [false, true], _state} = VM.execute(proto, state)
+    end
+
+    test "~= calls __eq exactly once per evaluation" do
+      code = """
+      local count = 0
+      local mt = {
+        __eq = function(x, y)
+          count = count + 1
+          return true
+        end
+      }
+      local a = setmetatable({}, mt)
+      local b = setmetatable({}, mt)
+      local result = a ~= b
+      return result, count
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      # __eq returns true once, ~= negates to false
+      assert {:ok, [false, 1], _state} = VM.execute(proto, state)
+    end
+
+    test "~= short-circuits primitive equality without consulting __eq" do
+      # Per Lua 5.3 §3.4.4, raw-equal primitive values skip __eq.
+      # 1 ~= 1 is false; nil ~= nil is false; "a" ~= "a" is false.
+      # No metamethod can be installed on these primitives, so this
+      # mainly verifies the code path doesn't break for non-table operands.
+      code = """
+      return 1 ~= 1, 1 ~= 2, "a" ~= "a", "a" ~= "b", nil ~= nil, nil ~= false
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [false, true, false, true, false, true], _state} =
+               VM.execute(proto, state)
+    end
+
+    test "~= falls back to raw inequality when metamethods differ" do
+      code = """
+      local a = {value = 10}
+      local b = {value = 10}
+      local mt1 = { __eq = function() return true end }
+      local mt2 = { __eq = function() return true end }
+      setmetatable(a, mt1)
+      setmetatable(b, mt2)
+      -- Different __eq metamethods → fall back to raw equality.
+      -- Two distinct tables are raw-unequal, so ~= is true.
+      return a ~= b
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true], _state} = VM.execute(proto, state)
+    end
+
     test "__lt metamethod" do
       code = """
       local a = {value = 5}


### PR DESCRIPTION
## ~= opcode dispatches through __eq metamethod

Plan: [`.agents/plans/A8d-not-equal-eq-metamethod.md`](https://github.com/tv-labs/lua/blob/fix/not-equal-eq-metamethod/.agents/plans/A8d-not-equal-eq-metamethod.md)

### Goal

Make the `:not_equal` opcode go through the `__eq` metamethod the same way
`:equal` does, then negate the result. Today `:not_equal` is implemented as
`not lua_equal(a, b)`, which compares the raw values directly and bypasses
metamethod dispatch entirely.

Per Lua 5.3 §3.4.4, `a ~= b` is *defined* as `not (a == b)`, and `==` runs
the `__eq` metamethod. So `~=` should run `__eq` and negate.

### Success criteria

- [x] Two values whose `__eq` returns `true` compare as `~= false`, not `~= true`
      — covered by `~= dispatches through __eq metamethod` in
      `test/lua/vm/metatable_test.exs`.
- [x] Two values whose `__eq` returns `false` compare as `~= true` — same test.
- [x] `__eq` is called once per `~=` evaluation (not zero, not twice) —
      covered by `~= calls __eq exactly once per evaluation`, which counts
      invocations via a closure side-effect.
- [x] Lua 5.3 §3.4.4 raw-equality short-circuit still applies for primitives
      (`1 ~= 1` → `false`, `nil ~= nil` → `false`, `"a" ~= "a"` → `false`) —
      covered by `~= short-circuits primitive equality without consulting __eq`.
- [x] Unit tests added in `test/lua/vm/metatable_test.exs` (the file that
      already pins `__eq` for `:equal`) — 4 new tests.
- [x] `mix test` passes; no regressions (1560 → 1564 tests, 0 failures).

### Changes

```
 lib/lua/vm/executor.ex       | 11 +++++--
 test/lua/vm/metatable_test.exs | 85 ++++++++++++++++++++++++++++++++++++
 2 files changed, 93 insertions(+), 3 deletions(-)
```

The fix is local to `lib/lua/vm/executor.ex`. The `:not_equal` clause now
mirrors `:equal`: it looks up the operands, calls `try_equality_metamethod/4`
(the same helper `:equal` uses) with `lua_equal/2` as the default, and
negates the result. State is threaded through correctly because the helper
already supports it from the `:equal` call site.

### Verification

```
mix format
mix compile --warnings-as-errors    # clean
mix test                            # 1564 tests, 0 failures
mix test --only lua53               # 29 tests, 0 failures, 24 skipped
```

Plan repro now passes:

```lua
local mt = { __eq = function() return true end }
local a = setmetatable({}, mt)
local b = setmetatable({}, mt)
assert(a == b)             -- true (already worked)
assert((a ~= b) == false)  -- now true (previously failed)
```

### Out of scope (intentional)

- Other comparison operators. `__lt` / `__le` are already routed through
  `try_binary_metamethod`. `<=` and `>=`/`>` already work.
- Equality semantics changes (e.g. table identity vs. value equality). This
  PR is purely about routing the existing `__eq` dispatch through the
  negated form.