### PR TITLE
fix(vm): make <= and >= fall back through __lt per Lua 5.3 §3.4.4

### DIFF
--- a/.agents/plans/A8e-le-fallback-not-lt.md
+++ b/.agents/plans/A8e-le-fallback-not-lt.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: fix/le-fallback-not-lt
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - events.lua advances past line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`)

--- a/.agents/plans/A8e-le-fallback-not-lt.md
+++ b/.agents/plans/A8e-le-fallback-not-lt.md
@@ -2,10 +2,10 @@
 id: A8e
 title: "__le falls back to `not (b < a)` when __le is unset"
 issue: null
-pr: null
+pr: 213
 branch: fix/le-fallback-not-lt
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - events.lua advances past line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`)
@@ -273,3 +273,49 @@ A few cross-plan details worth knowing before starting:
   above already names the truncated-with-`do return end` pattern
   used to bisect line 258. The same pattern picks up where A8e
   leaves off.
+
+## What changed
+
+PR: https://github.com/tv-labs/lua/pull/213
+
+Files touched:
+
+- `lib/lua/vm/executor.ex`: added `compare_le/3` helper implementing
+  the §3.4.4 fallback (`__le` → `__lt(b, a)` negated → primitive
+  `<=`). Routed `:less_equal` through it. Also routed `:greater_equal`
+  through `compare_le(b, a, state)` per `a >= b ⇔ b <= a`, and
+  `:greater_than` through `try_binary_metamethod("__lt", b, a, ...)`
+  per `a > b ⇔ b < a`. Removed now-unreferenced `safe_compare_gt` and
+  `safe_compare_ge`.
+- `test/lua/vm/metatable_test.exs`: 6 new tests pinning the fallback
+  semantics across `<=`, `>=`, `>`, the precedence rules, and the
+  primitive-raise edge case.
+
+Test delta: 1564 → 1570 (+6 new tests), 0 failures, 31 skipped.
+Lua 5.3 suite unchanged: 4/24 ready, 24 skipped.
+
+## Discoveries
+
+- **`:greater_than` skipped metamethod dispatch entirely.** Anticipated
+  in the plan's Risks section. Fixing it was necessary in scope:
+  events.lua's `test()` function calls `Op(1) > Op(1)` etc., which
+  triggered the same "attempt to compare table with table" failure
+  even with `__lt` set. Per spec `a > b ⇔ b < a`, so `:greater_than`
+  now routes through `__lt(b, a)`.
+
+- **`:greater_equal` is a separate opcode, not a desugaring.** Codegen
+  at `lib/lua/compiler/codegen.ex:929` emits `:greater_equal` for `>=`.
+  So mirroring the `:less_equal` fix to `:greater_equal` was required
+  for success criterion #5.
+
+- **events.lua next stop: line 285.** With A8e shipped and A8b
+  patched out (still in review on main), the file probes cleanly
+  through line 284. Line 285 is `assert(Set{1,3,5,1} ==
+  rawSet{3,5,1})` — comparing a table with `__eq` to a raw table.
+  Per Lua 5.3 §3.4.4 this should consult `__eq`. Adjacent to A8d's
+  `~=` / `__eq` dispatch territory; a separate follow-up plan can
+  pick it up. events.lua remains in `@skipped_tests`.
+
+- **events.lua line 188 (`pcall(rawlen, io.stdin)`) still blocks the
+  file** because A8b is in review and not yet merged on main. Once
+  A8b ships, the file should advance through to line 285 in one go.

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -949,23 +949,33 @@ defmodule Lua.VM.Executor do
     val_a = elem(regs, a)
     val_b = elem(regs, b)
 
-    {result, new_state} =
-      try_binary_metamethod("__le", val_a, val_b, state, fn -> safe_compare_le(val_a, val_b) end)
+    {result, new_state} = compare_le(val_a, val_b, state)
 
     regs = put_elem(regs, dest, result)
     do_execute(rest, regs, upvalues, proto, new_state, cont, frames, line)
   end
 
   defp do_execute([{:greater_than, dest, a, b} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    result = safe_compare_gt(elem(regs, a), elem(regs, b))
+    val_a = elem(regs, a)
+    val_b = elem(regs, b)
+
+    # Lua 5.3 §3.4.4: a > b is translated to b < a, which dispatches __lt.
+    {result, new_state} =
+      try_binary_metamethod("__lt", val_b, val_a, state, fn -> safe_compare_lt(val_b, val_a) end)
+
     regs = put_elem(regs, dest, result)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+    do_execute(rest, regs, upvalues, proto, new_state, cont, frames, line)
   end
 
   defp do_execute([{:greater_equal, dest, a, b} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    result = safe_compare_ge(elem(regs, a), elem(regs, b))
+    val_a = elem(regs, a)
+    val_b = elem(regs, b)
+
+    # Lua 5.3 §3.4.4: a >= b is translated to b <= a.
+    {result, new_state} = compare_le(val_b, val_a, state)
+
     regs = put_elem(regs, dest, result)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+    do_execute(rest, regs, upvalues, proto, new_state, cont, frames, line)
   end
 
   defp do_execute([{:not_equal, dest, a, b} | rest], regs, upvalues, proto, state, cont, frames, line) do
@@ -1582,6 +1592,31 @@ defmodule Lua.VM.Executor do
     invoke_metamethod(metamethod, [a, b], state, default_fn)
   end
 
+  # Lua 5.3 §3.4.4: a <= b is dispatched to __le when present on either
+  # operand. If neither operand has __le, the operation falls back to
+  # `not (b < a)` — i.e. it consults __lt with the operands swapped and
+  # negates the result. Only when neither metamethod is defined does it
+  # fall through to the primitive comparison (which raises on
+  # incompatible types).
+  defp compare_le(a, b, state) do
+    case lookup_metamethod(a, "__le", state) || lookup_metamethod(b, "__le", state) do
+      nil ->
+        case lookup_metamethod(b, "__lt", state) || lookup_metamethod(a, "__lt", state) do
+          nil ->
+            {safe_compare_le(a, b), state}
+
+          lt ->
+            {lt_result, new_state} =
+              invoke_metamethod(lt, [b, a], state, fn -> safe_compare_lt(b, a) end)
+
+            {not Value.truthy?(lt_result), new_state}
+        end
+
+      le ->
+        invoke_metamethod(le, [a, b], state, fn -> safe_compare_le(a, b) end)
+    end
+  end
+
   defp lookup_metamethod(value, name, state) do
     case get_metatable(value, state) do
       nil -> nil
@@ -1842,38 +1877,6 @@ defmodule Lua.VM.Executor do
 
       is_binary(a) and is_binary(b) ->
         a <= b
-
-      true ->
-        raise TypeError,
-          value: "attempt to compare #{Value.type_name(a)} with #{Value.type_name(b)}",
-          error_kind: :compare_incompatible_types,
-          value_type: value_type(a)
-    end
-  end
-
-  defp safe_compare_gt(a, b) do
-    cond do
-      is_number(a) and is_number(b) ->
-        a > b
-
-      is_binary(a) and is_binary(b) ->
-        a > b
-
-      true ->
-        raise TypeError,
-          value: "attempt to compare #{Value.type_name(a)} with #{Value.type_name(b)}",
-          error_kind: :compare_incompatible_types,
-          value_type: value_type(a)
-    end
-  end
-
-  defp safe_compare_ge(a, b) do
-    cond do
-      is_number(a) and is_number(b) ->
-        a >= b
-
-      is_binary(a) and is_binary(b) ->
-        a >= b
 
       true ->
         raise TypeError,

--- a/test/lua/vm/metatable_test.exs
+++ b/test/lua/vm/metatable_test.exs
@@ -449,6 +449,115 @@ defmodule Lua.VM.MetatableTest do
 
       assert {:ok, [true, true, false], _state} = VM.execute(proto, state)
     end
+
+    test "<= falls back to `not (b < a)` when only __lt is defined" do
+      code = """
+      local mt = {
+        __lt = function(a, b) return a.x < b.x end,
+      }
+      local function Op(x) return setmetatable({x = x}, mt) end
+      return Op(1) <= Op(2), Op(2) <= Op(1), Op(1) <= Op(1)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true, false, true], _state} = VM.execute(proto, state)
+    end
+
+    test ">= falls back via __lt when only __lt is defined" do
+      # a >= b is translated to b <= a, which then falls back to
+      # `not (a < b)` when __le is missing. This exercises the same
+      # path as <= via the :greater_equal opcode.
+      code = """
+      local mt = {
+        __lt = function(a, b) return a.x < b.x end,
+      }
+      local function Op(x) return setmetatable({x = x}, mt) end
+      return Op(2) >= Op(1), Op(1) >= Op(2), Op(1) >= Op(1)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true, false, true], _state} = VM.execute(proto, state)
+    end
+
+    test "__le is preferred over __lt when both are defined" do
+      # When __le is set it must fire — the fallback to __lt only kicks
+      # in when __le is absent on both operands.
+      code = """
+      local mt = {
+        __lt = function(a, b) error("__lt should not fire") end,
+        __le = function(a, b) return true end,
+      }
+      local function Op(x) return setmetatable({x = x}, mt) end
+      return Op(1) <= Op(2)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true], _state} = VM.execute(proto, state)
+    end
+
+    test "__le on either operand wins over __lt fallback" do
+      # Only b has __le; a has no metatable. The lookup order in
+      # try_binary_metamethod / compare_le checks a then b, so b's
+      # __le must fire rather than falling back to __lt.
+      code = """
+      local mt_le = {
+        __le = function(x, y) return true end,
+        __lt = function(x, y) error("__lt should not fire") end,
+      }
+      local a = {x = 1}
+      local b = setmetatable({x = 2}, mt_le)
+      return a <= b
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true], _state} = VM.execute(proto, state)
+    end
+
+    test "> dispatches __lt with operands swapped" do
+      # Lua 5.3 §3.4.4 translates `a > b` to `b < a`, so `>` between
+      # tables with __lt set must call __lt(b, a).
+      code = """
+      local mt = {
+        __lt = function(a, b) return a.x < b.x end,
+      }
+      local function Op(x) return setmetatable({x = x}, mt) end
+      return Op(2) > Op(1), Op(1) > Op(2), Op(1) > Op(1)
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true, false, false], _state} = VM.execute(proto, state)
+    end
+
+    test "<= on incompatible primitive types still raises" do
+      # The fallback to __lt only fires for table operands. Mismatched
+      # primitives must still raise — `1 <= "x"` is an error in Lua.
+      code = """
+      return 1 <= "x"
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert_raise Lua.VM.TypeError, ~r/attempt to compare/, fn ->
+        VM.execute(proto, state)
+      end
+    end
   end
 
   describe "other metamethods" do


### PR DESCRIPTION
## __le falls back to `not (b < a)` when __le is unset

Plan: [`.agents/plans/A8e-le-fallback-not-lt.md`](https://github.com/tv-labs/lua/blob/fix/le-fallback-not-lt/.agents/plans/A8e-le-fallback-not-lt.md)

### Goal

Make the `:less_equal` opcode fall back to `not (b < a)` when neither
operand has an `__le` metamethod, per Lua 5.3 §3.4.4. Today
`:less_equal` looks up `__le` and — if missing — runs
`safe_compare_le`, which raises on table operands. The reference
manual is explicit:

> The `<=` operation is translated to `not (b < a)` if there is no `__le` metamethod.

So when `__le` is unset, dispatch should consult `__lt` (with operands
*swapped*) and negate the result. Only fall through to
`safe_compare_le` when neither metamethod is defined and the operands
have a primitive `<=` (numbers, strings).

### Success criteria

- [x] `Op(1) <= Op(2)` returns `true` when only `__lt` is set on the
      metatable (was: `attempt to compare table with table`). Pinned by
      the new `<= falls back to not (b < a) when only __lt is defined`
      test.
- [x] `Op(2) <= Op(1)` returns `false` in the same setup. Pinned by
      the same test.
- [x] `Op(1) <= Op(1)` returns `true` (negation of `not (a < a)`).
      Pinned by the same test.
- [x] `__le` (when set) still wins. Pinned by `__le is preferred over
      __lt when both are defined` (raises if `__lt` fires) and `__le on
      either operand wins over __lt fallback`.
- [x] `>=` between tables defined only via `__lt` works (translated
      `a >= b ⇒ b <= a` chains into the new fallback). Pinned by `>=
      falls back via __lt when only __lt is defined`.
- [x] `safe_compare_le` still raises for primitive operands of mixed,
      non-comparable type (`1 <= "x"` still raises). Pinned by `<= on
      incompatible primitive types still raises`.
- [x] events.lua line 258 (`assert((Set{1,2,3,4} <= Set{1,2,3,4}))`)
      passes standalone. Verified via the file-probe pattern (with line
      188-190 patched out, since that's A8b's territory and A8b is in
      review). Next stop after the fix is **line 285**:
      `assert(Set{1,3,5,1} == rawSet{3,5,1})` — table-with-`__eq`
      compared against a raw table; that's A8d-adjacent (`==` /
      `__eq`), out of scope here.
- [x] Unit tests cover all four required cases plus the `>` and `>=`
      paths.
- [x] `mix test` passes; no regressions. 1564 → 1570 (+6 new tests),
      0 failures.

### Changes

- `lib/lua/vm/executor.ex`:
  - New `compare_le/3` helper implements the §3.4.4 fallback chain:
    `__le` → `__lt(b, a)` negated → primitive `<=`.
  - `:less_equal` now delegates to `compare_le`.
  - `:greater_equal` now delegates to `compare_le(b, a, state)`,
    matching the spec's `a >= b ⇔ b <= a` translation. Previously
    `:greater_equal` skipped metamethod dispatch entirely and went
    straight to `safe_compare_ge`.
  - `:greater_than` now goes through `try_binary_metamethod("__lt",
    b, a, ...)`, matching `a > b ⇔ b < a`. Previously `:greater_than`
    also skipped metamethod dispatch. The plan's Risks section flagged
    this asymmetry; fixing it was needed to advance events.lua past
    the `test()` block at line 222 (which exercises `>`).
  - `safe_compare_gt` and `safe_compare_ge` removed (no longer
    referenced; `safe_compare_lt` and `safe_compare_le` cover all four
    directions through operand swapping).
- `test/lua/vm/metatable_test.exs`: 6 new tests pinning the fallback
  semantics for `<=`, `>=`, `>`, the `__le`-wins precedence, the
  `__le`-on-either-operand path, and the primitive raise.

```
 lib/lua/vm/executor.ex         |  79 ++++++++++++--------------
 test/lua/vm/metatable_test.exs | 109 +++++++++++++++++++++++++++++++++++
 2 files changed, 150 insertions(+), 38 deletions(-)
```

### Discoveries

- **`:greater_than` skipped metamethod dispatch entirely on main.** The
  plan's Risks section anticipated this (`safe_compare_*` may need
  parallel treatment). Fixing it was necessary in scope: events.lua's
  `test()` function at line 207-220 calls `Op(1) > Op(1)` etc., which
  triggered `attempt to compare table with table` on main even though
  `__lt` was set. Per spec `a > b ⇔ b < a`, so the fix routes
  `:greater_than` through `__lt(b, a)`. This also brings parity to
  the four comparison opcodes.

- **`:greater_equal` was already a separate opcode, not a desugaring.**
  Codegen at `lib/lua/compiler/codegen.ex:929` emits `:greater_equal`
  for `>=`. So the plan's "verify in the implementation that fixing
  `:less_equal` also fixes `>=`" required mirroring the change to
  `:greater_equal`. Done.

- **events.lua next stop: line 285.** With this fix and A8b's stub
  patched out, the file probes cleanly through line 284. Line 285 is
  `assert(Set{1,3,5,1} == rawSet{3,5,1})` — comparing a table with
  `__eq` to a raw table. Per Lua 5.3 §3.4.4 this should consult
  `__eq`. That's adjacent to A8d (`~=` / `__eq` dispatch); a separate
  follow-up plan can pick it up. events.lua remains in
  `@skipped_tests`.

### Verification

```
mix format
mix compile --warnings-as-errors  # clean
mix test                          # 52 doctests, 51 properties, 1570 tests, 0 failures, 31 skipped
mix test --only lua53             # 29 tests, 0 failures, 24 skipped
```

Repros from the plan (both pass):

```lua
-- Standalone __lt-only fallback
local t = {}
t.__lt = function(a, b) return a.x < b.x end
local function Op(x) return setmetatable({x=x}, t) end
return Op(1) <= Op(2)  -- true (was: raise)

-- events.lua line 258 reduction
local t = {}
local function rawSet(x) local s={}; for _,v in ipairs(x) do s[v]=true end; return s end
local function Set(x) return setmetatable(rawSet(x), t) end
t.__lt = function (a,b) ... end
t.__le = nil
return (Set{1,2,3,4} <= Set{1,2,3,4})  -- true (was: raise)
```

### Out of scope (intentional)

- Promoting events.lua to `@ready_tests`. Line 285 still blocks the
  full file; that's a separate plan.
- The `__eq` short-circuit at events.lua line 285. That's A8d-adjacent.
- `__lt` itself (already correct). Verified `Op(1) < Op(2)` works on
  main with only `__lt` set.