### PR TITLE
test(suite): document deliberate non-goals in lua53 suite

### DIFF
--- a/.agents/plans/A20-triage-sandbox-refusals.md
+++ b/.agents/plans/A20-triage-sandbox-refusals.md
@@ -2,10 +2,10 @@
 id: A20
 title: Triage cluster — sandbox-refusal suite files
 issue: null
-pr: null
+pr: 216
 branch: triage/sandbox-refusals
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - main.lua
@@ -36,17 +36,22 @@ pretend to have these, or are they explicit non-goals?
 
 ## Success criteria
 
-- [ ] Each of `main.lua`, `verybig.lua`, `files.lua`, `attrib.lua` has
-      a documented decision.
-- [ ] For files marked "skip permanently": `test/lua53_suite_test.exs`
+- [x] Each of `main.lua`, `verybig.lua`, `files.lua`, `attrib.lua` has
+      a documented decision. All four are skip-permanently; reasons
+      live in `test/lua53_suite_test.exs` `@deferred_permanent` map.
+- [x] For files marked "skip permanently": `test/lua53_suite_test.exs`
       gains a comment explaining *why* alongside the `@tag :skip`, and
-      this is reflected in CHANGELOG / README's "supported coverage"
-      section.
-- [ ] For files marked "fix-now": a follow-up plan (`A20a`, `A20b`, …)
+      this is reflected in CHANGELOG and ROADMAP "Deferred" section.
+      (README does not have a "supported coverage" section; ROADMAP is
+      the canonical place — see Discoveries.)
+- [x] For files marked "fix-now": a follow-up plan (`A20a`, `A20b`, …)
       is written under `.agents/plans/` describing the suite-runner
       config or stub strategy, with its own success criteria.
-- [ ] No regression in other suite files. `mix test --include skip`
-      shows the same total pass count or higher.
+      None needed — all four are skip-permanently.
+- [x] No regression in other suite files. `mix test --include skip`
+      shows the same total pass count or higher. Suite test still
+      reports 29 tests, 0 failures, 24 skipped (5 ready). Full
+      `mix test`: 1585 tests, 0 failures, 31 skipped (no change).
 
 ## Implementation notes
 
@@ -97,4 +102,58 @@ the rest of the suite.
 
 ## Discoveries
 
-(populated during triage)
+- The plan's premise that all four files fail with `os.execute()` /
+  `os.tmpname()` / `os.getenv(_)` was correct for `main.lua`,
+  `verybig.lua`, `files.lua`. `attrib.lua` is a *different* sandbox
+  policy: it dies on `require"io"` because there is no `io` global to
+  cache (see A4 plan Discoveries — A4 already noted this). The cluster
+  framing still holds — all four exercise capabilities that conflict
+  with our sandbox role — but the failure mechanism for `attrib.lua` is
+  package/loader-driven, not `os.*`-driven.
+
+- `verybig.lua` is the most interesting of the four. The first ~140
+  lines are testing genuinely useful VM behaviour (RK opcodes, >64K
+  constants, large-table iteration), but they live inside a generated
+  Lua program that gets written to a temp file via `os.tmpname()` /
+  `io.output()` and executed with `dofile()`. A future plan could stub
+  these three primitives in the suite runner only (in-memory file
+  handle + in-memory `dofile`) to unlock that coverage. Not in scope
+  here, but worth recording: roughly 30 lines in
+  `test/support/lua_test_case.ex`, scoped to suite use only.
+
+- The plan asked for a "supported coverage" section in CHANGELOG /
+  README. README has no such section and adding one would duplicate
+  what's already in `ROADMAP.md`'s "Deferred (intentional, not in 1.0)"
+  list. Updated ROADMAP and CHANGELOG instead; the per-file reasons
+  also live inline in `test/lua53_suite_test.exs` so the rationale
+  travels with the test.
+
+- The pre-existing test file structure (single `@skipped_tests` list)
+  conflated "feature not yet implemented" with "deliberate non-goal".
+  Split into `@skipped_tests` (the former, still subject to future
+  plans) and `@deferred_permanent` (the latter, with reasons) so future
+  triage doesn't re-investigate the same four files.
+
+## What changed
+
+Files touched:
+- `test/lua53_suite_test.exs` — split `@skipped_tests` into a two-tier
+  structure: `@deferred_permanent` (a `%{file => reason}` map for the
+  four sandbox-refusal files plus future deliberate non-goals) and
+  `@skipped_tests` (everything else, still addressable). New describe
+  block "Deferred (Intentional Non-Goals)" surfaces the per-file reason
+  in the test name.
+- `ROADMAP.md` — expanded the "Deferred (intentional, not in 1.0)"
+  section with per-file rationale for `main.lua`, `files.lua`,
+  `attrib.lua`, `verybig.lua`. Renamed the existing items into a
+  follow-up "Other deferrals in this milestone" sublist.
+- `CHANGELOG.md` — added an Unreleased entry under Changed describing
+  the new tier and pointing readers at the suite test file and ROADMAP
+  for rationale.
+
+Suite delta: no change (5/29 ready). Coverage classification refined:
+24 skipped → 4 deferred-permanent + 20 missing-feature. Same total.
+
+Tests: 1585 passing, 0 failing, 31 skipped (no change).
+
+PR: https://github.com/tv-labs/lua/pull/216

--- a/.agents/plans/A20-triage-sandbox-refusals.md
+++ b/.agents/plans/A20-triage-sandbox-refusals.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: triage/sandbox-refusals
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - main.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Lua 5.3 suite test file now distinguishes "missing features" from
+  "deliberate non-goals". Four files (`main.lua`, `files.lua`,
+  `attrib.lua`, `verybig.lua`) are now grouped under "Deferred
+  (Intentional Non-Goals)" with per-file rationale captured in
+  `test/lua53_suite_test.exs` and `ROADMAP.md`. These tests exercise
+  shell-out, file I/O, or filesystem-backed `require` semantics that
+  conflict with this library's role as a sandboxed embedded Lua VM.
+  No behavioural change.
 
 ## [v1.0.0-rc.1] - 2026-05-06
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,9 +86,29 @@ wraps.
 
 ## Deferred (intentional, not in 1.0)
 
+These suite files exercise capabilities that conflict with this library's
+role as a sandboxed embedded Lua VM. They are tracked as deliberate
+non-goals, not "missing features we'd take a PR for". Per-file rationale
+lives alongside the `@deferred_permanent` map in
+`test/lua53_suite_test.exs`.
+
+- **Standalone interpreter** (`main.lua`) — shells out via `os.execute`,
+  writes Lua programs to temp files, invokes `lua` as a subprocess. We
+  are an embedded VM with no shell-out and no standalone interpreter.
+- **File I/O** (`files.lua`) — `io.open`, `io.input`, `io.output`,
+  `io.lines`, `io.read`, `io.write`, `io.tmpfile`, plus `os.getenv`,
+  `os.remove`, `os.rename`. `io.*` is a stub by design.
+- **`require` semantics that need filesystem I/O** (`attrib.lua`) — writes
+  `libs/A.lua`, `libs/B.lua`, etc. to disk and dynamically loads them.
+- **>64K constants harness via tmpfile + dofile** (`verybig.lua`) — the RK/
+  large-constants behaviour is interesting, but the harness writes a
+  generated program with `os.tmpname()`/`io.output()` and `dofile`s it.
+  A future plan could stub these for the suite runner only.
+
+Other deferrals in this milestone:
+
 - **Coroutines** (`coroutine.lua`) — full continuation/process model, weeks of work.
 - **Garbage collection / weak tables** (`gc.lua`).
-- **File I/O** (`files.lua`).
 - **Full debug library** (`db.lua`).
 - **C-stack tests** (`cstack.lua`).
 - **Backward `goto` and goto-out-of-conditional** (3 skipped unit tests in

--- a/test/lua53_suite_test.exs
+++ b/test/lua53_suite_test.exs
@@ -7,19 +7,52 @@ defmodule Lua.Lua53SuiteTest do
 
   @test_dir "test/lua53_tests"
 
-  # Dynamically generate test cases for all .lua files in the test directory
-  # This ensures we don't miss any tests as the suite evolves
+  # Dynamically generate test cases for all .lua files in the test directory.
+  # This ensures we don't miss any tests as the suite evolves.
   @lua_files @test_dir
              |> File.ls!()
              |> Enum.filter(&String.ends_with?(&1, ".lua"))
              |> Enum.sort()
 
-  # Tests that are ready to run (not skipped)
+  # Tests that are ready to run (not skipped).
   @ready_tests ["simple_test.lua", "api.lua", "bitwise.lua", "code.lua", "vararg.lua"]
 
-  # Tests that require features not yet implemented
-  # As we implement features, move tests from here to @ready_tests
-  @skipped_tests @lua_files -- @ready_tests
+  # Suite files that we have deliberately decided not to support.
+  #
+  # These are *not* "missing features we'd take a PR for" — they exercise
+  # capabilities that conflict with this library's role as a sandboxed
+  # embedded Lua VM. Each entry pairs the file with a one-line reason.
+  # See ROADMAP.md "Deferred (intentional, not in 1.0)" for the full
+  # rationale.
+  @deferred_permanent %{
+    # Tests the standalone Lua interpreter binary: shells out via
+    # os.execute(), writes Lua programs to temp files, invokes `lua` as
+    # a subprocess. We are an embedded VM with no shell-out and no
+    # standalone interpreter.
+    "main.lua" => "tests standalone interpreter (os.execute, subprocess invocation)",
+
+    # Tests file I/O end-to-end: io.open/input/output/lines/read/write,
+    # io.tmpfile, plus os.getenv("PATH"), os.remove, os.rename. We do
+    # not ship filesystem I/O — io.* is a stub by design.
+    "files.lua" => "tests filesystem I/O (io.open, os.getenv, os.remove)",
+
+    # Tests `require` semantics that depend on writing files to disk
+    # and dynamically loading them (libs/A.lua, libs/B.lua, etc.), plus
+    # equality checks like `require"io" == io` that require io/os/
+    # coroutine globals we do not stub. See A4 plan Discoveries.
+    "attrib.lua" => "tests require semantics that depend on filesystem I/O",
+
+    # Tests RK opcodes and >64K constants by writing a generated Lua
+    # program to a temp file via os.tmpname()/io.output() and dofile()-
+    # ing it. The compiler/VM behaviour being exercised is interesting,
+    # but the test harness requires file I/O. A future plan could stub
+    # tmpname/io/dofile for the suite runner only; not in scope here.
+    "verybig.lua" => "tests dofile()-of-tmpfile harness for >64K constants"
+  }
+
+  # Tests that require features not yet implemented. As we implement
+  # features, move tests from here to @ready_tests.
+  @skipped_tests (@lua_files -- @ready_tests) -- Map.keys(@deferred_permanent)
 
   describe "Lua 5.3 Test Suite - Ready Tests" do
     for test_file <- @ready_tests do
@@ -35,6 +68,18 @@ defmodule Lua.Lua53SuiteTest do
       @test_file test_file
       @tag :skip
       test test_file do
+        run_lua_file(Path.join(@test_dir, @test_file))
+      end
+    end
+  end
+
+  describe "Lua 5.3 Test Suite - Deferred (Intentional Non-Goals)" do
+    for {test_file, reason} <- @deferred_permanent do
+      @test_file test_file
+      @reason reason
+      @tag :skip
+      @tag :deferred_permanent
+      test "#{test_file} — #{reason}" do
         run_lua_file(Path.join(@test_dir, @test_file))
       end
     end


### PR DESCRIPTION
## Triage cluster — sandbox-refusal suite files

Plan: [`.agents/plans/A20-triage-sandbox-refusals.md`](https://github.com/tv-labs/lua/blob/triage/sandbox-refusals/.agents/plans/A20-triage-sandbox-refusals.md)

### Goal

Decide, per file, whether each of `main.lua`, `verybig.lua`, `files.lua`,
`attrib.lua` is a permanent non-goal (skip with explanatory tag) or whether
the suite runner should be configured to stub `os.execute` / `os.tmpname` /
`os.getenv` so the file completes. Produce per-file follow-up plans or skip
annotations.

**Decision: all four are skip-permanently.** Each exercises capabilities
that conflict with this library's role as a sandboxed embedded Lua VM.

### Per-file decisions

| File | Failure | Decision | Reason |
|---|---|---|---|
| `main.lua` | `os.execute() is sandboxed` | skip-permanently | Tests the standalone Lua interpreter binary: shells out, writes Lua programs to temp files, invokes `lua` as a subprocess. We are an embedded VM with no shell-out. |
| `files.lua` | `os.getenv(_) is sandboxed` | skip-permanently | Tests filesystem I/O end-to-end. `io.*` is a stub by design. |
| `attrib.lua` | `module 'io' not found` | skip-permanently | Tests `require` semantics that depend on writing files to disk and dynamically loading them. |
| `verybig.lua` | `os.tmpname() is sandboxed` | skip-permanently | Tests RK opcodes / >64K constants via a `os.tmpname()` + `io.output()` + `dofile()` harness. The VM behaviour is interesting; the harness is not. A future plan could stub these for the suite runner only — not in scope here. |

### Success criteria

- [x] Each of the four files has a documented decision. All four are
      skip-permanently; reasons live in `test/lua53_suite_test.exs`
      `@deferred_permanent` map.
- [x] `test/lua53_suite_test.exs` gains a comment alongside the
      `@tag :skip` for each of the four, and this is reflected in
      `CHANGELOG.md` (Unreleased) and `ROADMAP.md` (Deferred section).
- [x] No fix-now follow-up plans needed. (See Discoveries — `verybig.lua`
      could justify a future stub-for-suite plan, but it is recorded as a
      possibility, not a commitment.)
- [x] No regression. `mix test` reports 1585 tests, 0 failures, 31 skipped
      (same as pre-flight). Suite test reports 29 tests, 0 failures, 24
      skipped (5 ready / 4 deferred-permanent / 20 missing-feature).

### Changes

```
 .agents/plans/A20-triage-sandbox-refusals.md |  2 +-
 CHANGELOG.md                                 |  9 +++++
 ROADMAP.md                                   | 22 ++++++++++-
 test/lua53_suite_test.exs                    | 57 +++++++++++++++++++++++++---
 4 files changed, 82 insertions(+), 8 deletions(-)
```

Key change in `test/lua53_suite_test.exs`: split the single `@skipped_tests`
list into `@skipped_tests` (missing features, future plans welcome) and
`@deferred_permanent` (a `%{file => reason}` map for deliberate non-goals).
The deferred-permanent tests get their own describe block with the reason
embedded in the test name and a `@tag :deferred_permanent` for filtering.

### Discoveries

- The plan's premise that all four files fail with `os.execute()` /
  `os.tmpname()` / `os.getenv(_)` was correct for three of them.
  `attrib.lua` is a *different* sandbox policy: it dies on `require"io"`
  because there is no `io` global to cache. The cluster framing still
  holds — all four exercise capabilities that conflict with our sandbox
  role — but the failure mechanism for `attrib.lua` is package/loader-
  driven, not `os.*`-driven.
- `verybig.lua` is the most interesting of the four. The first ~140 lines
  test genuinely useful VM behaviour (RK opcodes, >64K constants), but
  they live inside a generated Lua program written to a temp file and
  executed with `dofile()`. A future plan could stub these primitives in
  the suite runner only to unlock that coverage. Recorded as a
  possibility, not a commitment.
- README has no "supported coverage" section. Adding one would duplicate
  what's already in `ROADMAP.md`'s "Deferred" list. Updated ROADMAP and
  CHANGELOG instead.

### Verification

```
mix format
mix compile --warnings-as-errors
mix test
```

```
52 doctests, 51 properties, 1585 tests, 0 failures, 31 skipped
```

### Out of scope (intentional)

- Implementing `os.execute` etc. for general consumption.
- Changing the public sandbox API.
- Stubbing `os.tmpname`/`io.output`/`dofile` for the suite runner —
  recorded as a possible future plan, not shipped here.
- Suite files outside this cluster.