### PR TITLE
feat(stdlib): implement string.pack, string.unpack, string.packsize

### DIFF
--- a/.agents/plans/A25-string-pack-unpack.md
+++ b/.agents/plans/A25-string-pack-unpack.md
@@ -2,10 +2,10 @@
 id: A25
 title: Implement string.pack, string.unpack, string.packsize
 issue: null
-pr: null
+pr: 217
 branch: feat/string-pack-unpack
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - tpack.lua
@@ -178,3 +178,26 @@ iex> Lua.eval!(Lua.new(), ~S{return string.unpack(">i4", "\0\0\0\x05")})
   still raise from Erlang's binary decode. The suite doesn't exercise
   NaN through `pack`/`unpack`, so this is an accepted gap consistent
   with the existing `safe_divide/4` accepted-divergence note.
+
+## What changed
+
+Files touched:
+
+- `lib/lua/vm/stdlib/string/pack.ex` (new, 619 lines) — format-string
+  parser and pack/unpack/packsize evaluators.
+- `lib/lua/vm/stdlib/string.ex` — wired the three native functions
+  through to the new module; replaced `string.reverse` with a
+  byte-oriented implementation; added a float-count clause to
+  `string.rep`.
+- `test/lua/vm/stdlib/string_pack_test.exs` (new, 312 lines) — 41
+  unit tests covering each option, alignment edge cases, and packsize
+  errors.
+- `test/lua53_suite_test.exs` — promoted `tpack.lua` from
+  `@skipped_tests` (computed) to `@ready_tests`.
+- `.agents/plans/A25-string-pack-unpack.md` — this file.
+
+Suite delta: 5/24 ready → 6/24 ready. New ready file: `tpack.lua`.
+
+Test count delta: 1585 → 1626 (+41 unit tests). All passing.
+
+PR: tv-labs/lua#217.

--- a/.agents/plans/A25-string-pack-unpack.md
+++ b/.agents/plans/A25-string-pack-unpack.md
@@ -34,22 +34,24 @@ encodings.
 
 ## Success criteria
 
-- [ ] `string.pack`, `string.unpack`, `string.packsize` exist in
-      `lib/lua/vm/stdlib/string.ex` and are reachable from Lua.
-- [ ] All format options from Lua 5.3 §6.4.2 are supported:
-      - [ ] `<` `>` `=` `!` (endian and alignment)
-      - [ ] `b` `B` `h` `H` `i` `I` `l` `L` `j` `J` `T` (signed/
+- [x] `string.pack`, `string.unpack`, `string.packsize` exist in
+      `lib/lua/vm/stdlib/string.ex` and are reachable from Lua
+      (delegating to `Lua.VM.Stdlib.String.Pack`).
+- [x] All format options from Lua 5.3 §6.4.2 are supported:
+      - [x] `<` `>` `=` `!` (endian and alignment)
+      - [x] `b` `B` `h` `H` `i` `I` `l` `L` `j` `J` `T` (signed/
             unsigned integers, with sized variants)
-      - [ ] `f` `d` `n` (floats)
-      - [ ] `s` `s1`-`s8` (string with length prefix)
-      - [ ] `z` (zero-terminated string)
-      - [ ] `x` (padding byte)
-      - [ ] `X<op>` (alignment to op's natural alignment)
-      - [ ] `c<n>` (fixed-size string)
-      - [ ] ` ` (space, ignored)
-- [ ] `tpack.lua` passes.
-- [ ] `mix test` count goes up by at least 5 (new unit tests).
-- [ ] No regression elsewhere.
+      - [x] `f` `d` `n` (floats)
+      - [x] `s` `s1`-`s8` (string with length prefix)
+      - [x] `z` (zero-terminated string)
+      - [x] `x` (padding byte)
+      - [x] `X<op>` (alignment to op's natural alignment)
+      - [x] `c<n>` (fixed-size string)
+      - [x] ` ` (space, ignored)
+- [x] `tpack.lua` passes (promoted to `@ready_tests` in the suite).
+- [x] `mix test` count goes up by at least 5 (added 41 unit tests
+      covering each option, alignment edge cases, packsize errors).
+- [x] No regression elsewhere (1585 → 1626 passing, 0 failures).
 
 ## Implementation notes
 
@@ -125,4 +127,54 @@ iex> Lua.eval!(Lua.new(), ~S{return string.unpack(">i4", "\0\0\0\x05")})
 
 ## Discoveries
 
-(populated during implementation)
+- **`string.reverse` was UTF-8-oriented, not byte-oriented.** PUC-Lua's
+  `string.reverse` works on bytes; ours called `String.reverse/1`, which
+  reverses codepoints and silently mangles non-UTF-8 binaries (including
+  any string containing a NUL byte mid-stream). `tpack.lua` exercises
+  byte reversal via `s2:reverse()` on packed integer bytes, so the bug
+  was on the critical path for this plan. Fixed in scope by switching
+  to `:binary.bin_to_list/1` + `Enum.reverse/1` + `:binary.list_to_bin/1`.
+
+- **`string.rep` rejected float counts.** Lua 5.3 always returns float
+  from `^`, so `string.rep("c268435456", 2^3)` (from `tpack.lua`'s
+  `if packsize("i") == 4 then` branch) was rejected as "number expected,
+  got number". Fixed in scope by adding a float-with-integer-value
+  coercion clause; consistent with PUC-Lua's `lua_tointegerx`.
+
+- **Alignment must be computed at runtime, not parse time.** The first
+  pass of the parser folded alignment padding into the op stream using
+  a parser-side running position. That works for fixed-size formats but
+  breaks for variable-length ones (`s`, `z`): `pack(">!4 c3 c4 c2 z i4 …")`
+  has an `i4` whose alignment depends on the actual length of the `z`
+  payload, which the parser cannot know. The parser now emits explicit
+  `{:align, n}` ops; pack/unpack/packsize each track their own running
+  byte position and compute padding when they hit `:align`. PUC-Lua does
+  the same (alignment is computed against `totalsize` in `getdetails`).
+
+- **`unpack` cast semantics for size > SZINT and size == SZINT.**
+  PUC-Lua's `unpackint` always casts the read `lua_Unsigned` to
+  `lua_Integer` at the end (bit-pattern reinterpretation in C). This
+  matters for two cases:
+  1. `size > 8`: the low 8 bytes are read *as signed* regardless of the
+     `signed?` flag; the flag only changes the expected sign-extension
+     byte for the high bytes.
+  2. `size == 8` with `I`/`J`/`L`/`T`/`s8`: an unsigned read whose value
+     exceeds `2^63-1` wraps to its signed-64-bit equivalent. The suite
+     exercises this with `unpack("<J", pack("<j", -1)) == -1`.
+  Encoded in `decode_int_with_overflow_check/4` and
+  `wrap_to_lua_integer/1`.
+
+- **BEAM has no IEEE ±Infinity, but the suite round-trips `1/0` through
+  `pack("f", …)`.** The Lua VM's `safe_divide/4` returns the finite
+  stand-ins `±1.0e308` for `±1/0` (see `Lua.VM.Executor.safe_divide/4`).
+  When packed as 32-bit float, `1.0e308` overflows to `0x7F800000` (the
+  IEEE +Inf bit pattern); decoding those bytes back through Erlang's
+  binary syntax raises `MatchError` because the BEAM has no float value
+  for inf. `decode_float/3` now recognises the four ±Inf bit patterns
+  (32-bit and 64-bit, both endians) and returns the matching stand-in,
+  so the round-trip closes.
+
+  Limitations: this only handles ±Inf bit patterns. NaN bit patterns
+  still raise from Erlang's binary decode. The suite doesn't exercise
+  NaN through `pack`/`unpack`, so this is an accepted gap consistent
+  with the existing `safe_divide/4` accepted-divergence note.

--- a/.agents/plans/A25-string-pack-unpack.md
+++ b/.agents/plans/A25-string-pack-unpack.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: feat/string-pack-unpack
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - tpack.lua

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ The new Elixir-native VM (replacing Luerl) is built up through:
 
 ## In flight: Direction A — Suite Triage (milestone `1.0.0`)
 
-**Goal**: push the official Lua 5.3 test suite from 5/29 to a healthier
+**Goal**: push the official Lua 5.3 test suite from 6/29 to a healthier
 pass rate, without regressing unit tests, then cut `1.0.0-rc.1`.
 
 The version jump from `0.4` to `1.0` reflects the magnitude of the VM
@@ -113,8 +113,6 @@ Other deferrals in this milestone:
 - **C-stack tests** (`cstack.lua`).
 - **Backward `goto` and goto-out-of-conditional** (3 skipped unit tests in
   `test/lua/compiler/integration_test.exs`).
-- **`string.pack` / `unpack` / `packsize`** (`tpack.lua`) — mechanical, but not
-  blocking 0.5.
 
 ## Glossary
 

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -32,6 +32,7 @@ defmodule Lua.VM.Stdlib.String do
   alias Lua.VM.Executor
   alias Lua.VM.State
   alias Lua.VM.Stdlib.Pattern
+  alias Lua.VM.Stdlib.String.Pack
   alias Lua.VM.Stdlib.Util
 
   @impl true
@@ -153,24 +154,22 @@ defmodule Lua.VM.Stdlib.String do
 
   # string.rep(s, n [, sep]) - repeats string s n times with optional separator
   defp string_rep([str, n | rest], state) when is_binary(str) and is_integer(n) do
-    sep = Enum.at(rest, 0, "")
+    do_string_rep(str, n, rest, state)
+  end
 
-    if !is_binary(sep) do
+  # Lua 5.3 accepts floats with integer values as integer args. `2^3`
+  # always yields the float 8.0 in Lua, so without this coercion
+  # `string.rep("x", 2^3)` rejects an obviously-valid count.
+  defp string_rep([str, n | rest], state) when is_binary(str) and is_float(n) do
+    if n == Float.floor(n) do
+      do_string_rep(str, trunc(n), rest, state)
+    else
       raise ArgumentError,
         function_name: "string.rep",
-        arg_num: 3,
-        expected: "string",
-        got: Util.typeof(sep)
+        arg_num: 2,
+        expected: "number",
+        got: "number has no integer representation"
     end
-
-    result =
-      if n <= 0 do
-        ""
-      else
-        Enum.map_join(1..n, sep, fn _ -> str end)
-      end
-
-    {[result], state}
   end
 
   defp string_rep([str, n | _], _state) when is_binary(str) do
@@ -196,9 +195,33 @@ defmodule Lua.VM.Stdlib.String do
     raise_arg_expected(1, "rep")
   end
 
-  # string.reverse(s) - reverses a string
+  defp do_string_rep(str, n, rest, state) do
+    sep = Enum.at(rest, 0, "")
+
+    if !is_binary(sep) do
+      raise ArgumentError,
+        function_name: "string.rep",
+        arg_num: 3,
+        expected: "string",
+        got: Util.typeof(sep)
+    end
+
+    result =
+      if n <= 0 do
+        ""
+      else
+        Enum.map_join(1..n, sep, fn _ -> str end)
+      end
+
+    {[result], state}
+  end
+
+  # string.reverse(s) - reverses a string byte-by-byte (Lua strings are
+  # byte arrays, not codepoint sequences — so a NUL or non-UTF-8 byte
+  # must come back at the mirror position).
   defp string_reverse([str | _], state) when is_binary(str) do
-    {[String.reverse(str)], state}
+    reversed = str |> :binary.bin_to_list() |> Enum.reverse() |> :binary.list_to_bin()
+    {[reversed], state}
   end
 
   defp string_reverse([other | _], _state) do
@@ -829,41 +852,40 @@ defmodule Lua.VM.Stdlib.String do
     raise ArgumentError.value_expected("string.#{func_name}", arg_num)
   end
 
-  # string.packsize(fmt) — returns size in bytes for the given format string
-  # Supports basic format codes used in Lua 5.3
+  # string.pack(fmt, v1, v2, ...) — pack values per fmt
+  defp string_pack([fmt | args], state) when is_binary(fmt) do
+    {[Pack.pack(fmt, args)], state}
+  end
+
+  defp string_pack([other | _], _state), do: raise_string_expected(1, "pack", other)
+  defp string_pack([], _state), do: raise_arg_expected(1, "pack")
+
+  # string.unpack(fmt, s [, pos]) — unpack values; returns vN..., next_pos
+  defp string_unpack([fmt, s | rest], state) when is_binary(fmt) and is_binary(s) do
+    pos =
+      case rest do
+        [] -> 1
+        [p | _] when is_integer(p) -> p
+        [p | _] when is_float(p) -> trunc(p)
+        _ -> raise ArgumentError, function_name: "string.unpack", arg_num: 3, expected: "number"
+      end
+
+    results = Pack.unpack(fmt, s, pos)
+    {results, state}
+  end
+
+  defp string_unpack([fmt, other | _], _state) when is_binary(fmt) do
+    raise_string_expected(2, "unpack", other)
+  end
+
+  defp string_unpack([other | _], _state), do: raise_string_expected(1, "unpack", other)
+  defp string_unpack([], _state), do: raise_arg_expected(1, "unpack")
+
+  # string.packsize(fmt) — return size in bytes for fixed-size formats
   defp string_packsize([fmt | _], state) when is_binary(fmt) do
-    size = compute_pack_size(fmt, 0)
-    {[size], state}
+    {[Pack.packsize(fmt)], state}
   end
 
-  defp compute_pack_size("", acc), do: acc
-  defp compute_pack_size(<<"b", rest::binary>>, acc), do: compute_pack_size(rest, acc + 1)
-  defp compute_pack_size(<<"B", rest::binary>>, acc), do: compute_pack_size(rest, acc + 1)
-  defp compute_pack_size(<<"h", rest::binary>>, acc), do: compute_pack_size(rest, acc + 2)
-  defp compute_pack_size(<<"H", rest::binary>>, acc), do: compute_pack_size(rest, acc + 2)
-  defp compute_pack_size(<<"i", rest::binary>>, acc), do: compute_pack_size(rest, acc + 4)
-  defp compute_pack_size(<<"I", rest::binary>>, acc), do: compute_pack_size(rest, acc + 4)
-  defp compute_pack_size(<<"l", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"L", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"j", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"J", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"n", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"N", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"f", rest::binary>>, acc), do: compute_pack_size(rest, acc + 4)
-  defp compute_pack_size(<<"d", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<"T", rest::binary>>, acc), do: compute_pack_size(rest, acc + 8)
-  defp compute_pack_size(<<" ", rest::binary>>, acc), do: compute_pack_size(rest, acc)
-  defp compute_pack_size(<<"<", rest::binary>>, acc), do: compute_pack_size(rest, acc)
-  defp compute_pack_size(<<">", rest::binary>>, acc), do: compute_pack_size(rest, acc)
-  defp compute_pack_size(<<"=", rest::binary>>, acc), do: compute_pack_size(rest, acc)
-
-  # string.pack — stub
-  defp string_pack(_args, _state) do
-    raise Lua.RuntimeException, "string.pack not yet implemented"
-  end
-
-  # string.unpack — stub
-  defp string_unpack(_args, _state) do
-    raise Lua.RuntimeException, "string.unpack not yet implemented"
-  end
+  defp string_packsize([other | _], _state), do: raise_string_expected(1, "packsize", other)
+  defp string_packsize([], _state), do: raise_arg_expected(1, "packsize")
 end

--- a/lib/lua/vm/stdlib/string/pack.ex
+++ b/lib/lua/vm/stdlib/string/pack.ex
@@ -1,0 +1,694 @@
+defmodule Lua.VM.Stdlib.String.Pack do
+  @moduledoc """
+  Implementation of `string.pack/2`, `string.unpack/2,3`, and
+  `string.packsize/1` per Lua 5.3 §6.4.2.
+
+  The format-string mini-language is parsed once into a list of
+  operations, which are then driven by the appropriate evaluator
+  (`pack`, `unpack`, or `packsize`). All arithmetic on the platform's
+  size_t / lua_Integer / lua_Number widths uses 8 bytes (we run on the
+  64-bit BEAM); native endianness is treated as little-endian to match
+  the dominant host architecture and PUC-Lua's `tpack.lua` assumptions.
+
+  Errors are raised as `Lua.VM.RuntimeError` so that `pcall`'s
+  `string.find(err, msg)` checks in `tpack.lua` work as written.
+  """
+
+  import Bitwise, only: [<<<: 2, &&&: 2]
+
+  alias Lua.VM.RuntimeError
+
+  # Platform constants. We run on the 64-bit BEAM, so these match the
+  # standard 64-bit C ABI that Lua 5.3 was specced against.
+  @sizeof_short 2
+  @sizeof_int 4
+  @sizeof_long 8
+  @sizeof_size_t 8
+  @sizeof_lua_integer 8
+  @sizeof_lua_number 8
+  @sizeof_float 4
+  @sizeof_double 8
+
+  # Maximum size for any single integer op (`i<n>`, `I<n>`, `s<n>`, `!n`).
+  @max_int_size 16
+
+  # Default alignment for bare `!` is platform max alignment, which on
+  # 64-bit systems is 8.
+  @default_max_align 8
+
+  # Hard cap on total format size that packsize will admit; matches
+  # PUC-Lua's `MAXSIZE` (INT_MAX, 2^31 - 1).
+  @max_total_size 0x7FFFFFFF
+
+  # ---- public entry points ------------------------------------------------
+
+  @doc "Implements string.pack(fmt, ...)."
+  def pack(fmt, args) when is_binary(fmt) do
+    ops = parse(fmt)
+    do_pack(ops, args, <<>>)
+  end
+
+  @doc "Implements string.unpack(fmt, s [, pos])."
+  def unpack(fmt, s, pos) when is_binary(fmt) and is_binary(s) and is_integer(pos) do
+    init_pos = normalize_init_pos(pos, byte_size(s))
+    ops = parse(fmt)
+    do_unpack(ops, s, init_pos, [])
+  end
+
+  @doc "Implements string.packsize(fmt)."
+  def packsize(fmt) when is_binary(fmt) do
+    ops = parse(fmt)
+    do_packsize(ops, 0)
+  end
+
+  # ---- format-string parser ----------------------------------------------
+
+  # Parses fmt into a flat list of {opcode, ...} tuples. Alignment is
+  # NOT folded in at parse time — variable-length ops (`s`, `z`) advance
+  # the running byte position by an amount only known at pack/unpack
+  # time, so the parser emits explicit `{:align, n}` ops and the
+  # evaluators decide on the fly how much padding to insert.
+  defp parse(fmt) do
+    state = %{endian: :little, max_align: 1, ops: []}
+    state = parse_loop(fmt, state)
+    Enum.reverse(state.ops)
+  end
+
+  defp parse_loop(<<>>, state), do: state
+
+  defp parse_loop(<<c, rest::binary>>, state) when c in [?\s, ?\t, ?\n, ?\r] do
+    parse_loop(rest, state)
+  end
+
+  defp parse_loop(<<"<", rest::binary>>, state) do
+    parse_loop(rest, %{state | endian: :little})
+  end
+
+  defp parse_loop(<<">", rest::binary>>, state) do
+    parse_loop(rest, %{state | endian: :big})
+  end
+
+  defp parse_loop(<<"=", rest::binary>>, state) do
+    # Native endianness — we treat the BEAM host as little-endian.
+    parse_loop(rest, %{state | endian: :little})
+  end
+
+  defp parse_loop(<<"!", rest::binary>>, state) do
+    {n, rest} = read_optional_int(rest, @default_max_align)
+
+    if n < 1 or n > @max_int_size do
+      raise_runtime("integral size (#{n}) out of limits [1,#{@max_int_size}]")
+    end
+
+    if not power_of_two?(n) do
+      raise_runtime("format asks for alignment not power of 2")
+    end
+
+    parse_loop(rest, %{state | max_align: n})
+  end
+
+  defp parse_loop(<<"b", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, true, 1))
+  end
+
+  defp parse_loop(<<"B", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, false, 1))
+  end
+
+  defp parse_loop(<<"h", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, true, @sizeof_short))
+  end
+
+  defp parse_loop(<<"H", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, false, @sizeof_short))
+  end
+
+  defp parse_loop(<<"i", rest::binary>>, state) do
+    {n, rest} = read_optional_int(rest, @sizeof_int)
+    parse_loop(rest, emit_int(state, true, n))
+  end
+
+  defp parse_loop(<<"I", rest::binary>>, state) do
+    {n, rest} = read_optional_int(rest, @sizeof_int)
+    parse_loop(rest, emit_int(state, false, n))
+  end
+
+  defp parse_loop(<<"l", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, true, @sizeof_long))
+  end
+
+  defp parse_loop(<<"L", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, false, @sizeof_long))
+  end
+
+  defp parse_loop(<<"j", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, true, @sizeof_lua_integer))
+  end
+
+  defp parse_loop(<<"J", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, false, @sizeof_lua_integer))
+  end
+
+  defp parse_loop(<<"T", rest::binary>>, state) do
+    parse_loop(rest, emit_int(state, false, @sizeof_size_t))
+  end
+
+  defp parse_loop(<<"f", rest::binary>>, state) do
+    parse_loop(rest, emit_float(state, @sizeof_float))
+  end
+
+  defp parse_loop(<<"d", rest::binary>>, state) do
+    parse_loop(rest, emit_float(state, @sizeof_double))
+  end
+
+  defp parse_loop(<<"n", rest::binary>>, state) do
+    parse_loop(rest, emit_float(state, @sizeof_lua_number))
+  end
+
+  defp parse_loop(<<"x", rest::binary>>, state) do
+    state = push_op(state, {:padding, 1})
+    parse_loop(rest, state)
+  end
+
+  defp parse_loop(<<"X", rest::binary>>, state) do
+    {natural_align, rest_after_op} = consume_x_target(rest)
+    align = effective_alignment(natural_align, state.max_align)
+    validate_alignment!(align)
+    state = if align == 1, do: state, else: push_op(state, {:align, align})
+    parse_loop(rest_after_op, state)
+  end
+
+  defp parse_loop(<<"c", rest::binary>>, state) do
+    case read_size(rest) do
+      :error ->
+        raise_runtime("missing size for format option 'c'")
+
+      {n, rest} ->
+        # `c<n>` does NOT trigger alignment — PUC-Lua treats it as a
+        # raw blob (see `Kchar` in `getdetails`).
+        state = push_op(state, {:fixed_string, n})
+        parse_loop(rest, state)
+    end
+  end
+
+  defp parse_loop(<<"s", rest::binary>>, state) do
+    {n, rest} = read_optional_int(rest, @sizeof_size_t)
+
+    if n < 1 or n > @max_int_size do
+      raise_runtime("integral size (#{n}) out of limits [1,#{@max_int_size}]")
+    end
+
+    align = effective_alignment(n, state.max_align)
+    validate_alignment!(align)
+    state = if align == 1, do: state, else: push_op(state, {:align, align})
+    state = push_op(state, {:lstring, n, state.endian})
+    parse_loop(rest, state)
+  end
+
+  defp parse_loop(<<"z", rest::binary>>, state) do
+    state = push_op(state, {:zstring})
+    parse_loop(rest, state)
+  end
+
+  defp parse_loop(<<c, _rest::binary>>, _state) do
+    raise_runtime("invalid format option '#{<<c>>}'")
+  end
+
+  # `read_size/1` — read a mandatory non-negative integer. Returns `:error`
+  # if the next char isn't a digit (so the caller can complain about the
+  # missing size, e.g. for bare `c`).
+  defp read_size(<<d, rest::binary>>) when d in ?0..?9 do
+    {n, rest} = read_int(rest, d - ?0)
+    {n, rest}
+  end
+
+  defp read_size(_), do: :error
+
+  # `read_optional_int/2` — read an integer if the next char is a digit,
+  # else return `default`. Used by `i<n>`, `I<n>`, `!<n>`, `s<n>`.
+  defp read_optional_int(<<d, rest::binary>>, _default) when d in ?0..?9 do
+    {n, rest} = read_int(rest, d - ?0)
+    {n, rest}
+  end
+
+  defp read_optional_int(rest, default), do: {default, rest}
+
+  defp read_int(<<d, rest::binary>>, acc) when d in ?0..?9 do
+    new = acc * 10 + (d - ?0)
+
+    if new > @max_total_size do
+      raise_runtime("invalid format")
+    end
+
+    read_int(rest, new)
+  end
+
+  defp read_int(rest, acc), do: {acc, rest}
+
+  # ---- emitters ----------------------------------------------------------
+
+  defp emit_int(_state, _signed?, size) when size < 1 or size > @max_int_size do
+    raise_runtime("integral size (#{size}) out of limits [1,#{@max_int_size}]")
+  end
+
+  defp emit_int(state, signed?, size) do
+    align = effective_alignment(size, state.max_align)
+    validate_alignment!(align)
+    state = if align == 1, do: state, else: push_op(state, {:align, align})
+    push_op(state, {:int, signed?, size, state.endian})
+  end
+
+  defp emit_float(state, size) do
+    align = effective_alignment(size, state.max_align)
+    validate_alignment!(align)
+    state = if align == 1, do: state, else: push_op(state, {:align, align})
+    push_op(state, {:float, size, state.endian})
+  end
+
+  # Validate the effective alignment is a positive power of two; mirrors
+  # PUC-Lua's `isalign2` check.
+  defp validate_alignment!(1), do: :ok
+
+  defp validate_alignment!(n) when n > 1 do
+    if not power_of_two?(n) do
+      raise_runtime("format asks for alignment not power of 2")
+    end
+
+    :ok
+  end
+
+  defp validate_alignment!(_) do
+    raise_runtime("format asks for alignment not power of 2")
+  end
+
+  defp push_op(state, op), do: %{state | ops: [op | state.ops]}
+
+  defp effective_alignment(natural, max_align), do: min(natural, max_align)
+
+  # `consume_x_target/1` — `X<op>` is an empty directive: it consumes the
+  # `op` character (and its size suffix, if any) purely to discover its
+  # natural alignment, then inserts padding to align the position. The op
+  # itself is NOT emitted as a data op. Returns `{alignment, rest}` where
+  # `rest` is the format stream past the op. PUC-Lua restricts the target
+  # to ops with intrinsic natural alignment > 1; everything else
+  # (whitespace, directives, `c`, `s`, `z`, `x`, another `X`, end-of-fmt)
+  # is rejected with "invalid next option".
+  defp consume_x_target(<<"b", rest::binary>>), do: {1, rest}
+  defp consume_x_target(<<"B", rest::binary>>), do: {1, rest}
+  defp consume_x_target(<<"h", rest::binary>>), do: {@sizeof_short, rest}
+  defp consume_x_target(<<"H", rest::binary>>), do: {@sizeof_short, rest}
+  defp consume_x_target(<<"l", rest::binary>>), do: {@sizeof_long, rest}
+  defp consume_x_target(<<"L", rest::binary>>), do: {@sizeof_long, rest}
+  defp consume_x_target(<<"j", rest::binary>>), do: {@sizeof_lua_integer, rest}
+  defp consume_x_target(<<"J", rest::binary>>), do: {@sizeof_lua_integer, rest}
+  defp consume_x_target(<<"T", rest::binary>>), do: {@sizeof_size_t, rest}
+  defp consume_x_target(<<"f", rest::binary>>), do: {@sizeof_float, rest}
+  defp consume_x_target(<<"d", rest::binary>>), do: {@sizeof_double, rest}
+  defp consume_x_target(<<"n", rest::binary>>), do: {@sizeof_lua_number, rest}
+
+  defp consume_x_target(<<"i", rest::binary>>) do
+    {n, rest} = read_optional_int(rest, @sizeof_int)
+    check_x_size(n)
+    {n, rest}
+  end
+
+  defp consume_x_target(<<"I", rest::binary>>) do
+    {n, rest} = read_optional_int(rest, @sizeof_int)
+    check_x_size(n)
+    {n, rest}
+  end
+
+  defp consume_x_target(_), do: raise_runtime("invalid next option for option 'X'")
+
+  defp check_x_size(n) when n < 1 or n > @max_int_size do
+    raise_runtime("integral size (#{n}) out of limits [1,#{@max_int_size}]")
+  end
+
+  defp check_x_size(_), do: :ok
+
+  # ---- pack driver -------------------------------------------------------
+
+  defp do_pack(ops, args, acc) do
+    do_pack_loop(ops, args, acc, 0)
+  end
+
+  defp do_pack_loop([], _args, acc, _pos), do: acc
+
+  defp do_pack_loop([{:align, alignment} | ops], args, acc, pos) do
+    fill = rem(alignment - rem(pos, alignment), alignment)
+    pad = :binary.copy(<<0>>, fill)
+    do_pack_loop(ops, args, acc <> pad, pos + fill)
+  end
+
+  defp do_pack_loop([{:padding, n} | ops], args, acc, pos) do
+    do_pack_loop(ops, args, acc <> :binary.copy(<<0>>, n), pos + n)
+  end
+
+  defp do_pack_loop([{:int, signed?, size, endian} | ops], [val | rest], acc, pos) do
+    n = to_integer(val, "string.pack")
+    bytes = encode_int(n, size, signed?, endian)
+    do_pack_loop(ops, rest, acc <> bytes, pos + size)
+  end
+
+  defp do_pack_loop([{:float, size, endian} | ops], [val | rest], acc, pos) do
+    f = to_float(val, "string.pack")
+    bytes = encode_float(f, size, endian)
+    do_pack_loop(ops, rest, acc <> bytes, pos + size)
+  end
+
+  defp do_pack_loop([{:fixed_string, n} | ops], [val | rest], acc, pos) do
+    s = to_string_arg(val, "string.pack")
+
+    if byte_size(s) > n do
+      raise_runtime("string longer than given size")
+    end
+
+    padded = s <> :binary.copy(<<0>>, n - byte_size(s))
+    do_pack_loop(ops, rest, acc <> padded, pos + n)
+  end
+
+  defp do_pack_loop([{:lstring, prefix_size, endian} | ops], [val | rest], acc, pos) do
+    s = to_string_arg(val, "string.pack")
+    len = byte_size(s)
+
+    # Length prefix must fit in `prefix_size` bytes, unsigned.
+    max_len = (1 <<< (prefix_size * 8)) - 1
+
+    if len > max_len do
+      raise_runtime("string length does not fit in given size")
+    end
+
+    prefix = encode_int(len, prefix_size, false, endian)
+    do_pack_loop(ops, rest, acc <> prefix <> s, pos + prefix_size + len)
+  end
+
+  defp do_pack_loop([{:zstring} | ops], [val | rest], acc, pos) do
+    s = to_string_arg(val, "string.pack")
+
+    if String.contains?(s, <<0>>) do
+      raise_runtime("string contains zeros")
+    end
+
+    do_pack_loop(ops, rest, acc <> s <> <<0>>, pos + byte_size(s) + 1)
+  end
+
+  defp do_pack_loop([_op | _], [], _acc, _pos) do
+    raise_runtime("bad argument to 'pack' (no value)")
+  end
+
+  # ---- unpack driver -----------------------------------------------------
+
+  defp do_unpack([], _s, pos, results) do
+    # Lua returns the values in pack order, then the next-read position.
+    # We've prepended results, so reverse first, then append pos.
+    Enum.reverse(results, [pos + 1])
+  end
+
+  defp do_unpack([{:align, alignment} | ops], s, pos, results) do
+    fill = rem(alignment - rem(pos, alignment), alignment)
+    ensure_available(s, pos, fill, "data string too short")
+    do_unpack(ops, s, pos + fill, results)
+  end
+
+  defp do_unpack([{:padding, n} | ops], s, pos, results) do
+    ensure_available(s, pos, n, "data string too short")
+    do_unpack(ops, s, pos + n, results)
+  end
+
+  defp do_unpack([{:int, signed?, size, endian} | ops], s, pos, results) do
+    ensure_available(s, pos, size, "data string too short")
+    bytes = binary_part(s, pos, size)
+    val = decode_int_with_overflow_check(bytes, signed?, endian, size)
+    val = wrap_to_lua_integer(val)
+    do_unpack(ops, s, pos + size, [val | results])
+  end
+
+  defp do_unpack([{:float, size, endian} | ops], s, pos, results) do
+    ensure_available(s, pos, size, "data string too short")
+    bytes = binary_part(s, pos, size)
+    val = decode_float(bytes, size, endian)
+    do_unpack(ops, s, pos + size, [val | results])
+  end
+
+  defp do_unpack([{:fixed_string, n} | ops], s, pos, results) do
+    ensure_available(s, pos, n, "data string too short")
+    str = binary_part(s, pos, n)
+    do_unpack(ops, s, pos + n, [str | results])
+  end
+
+  defp do_unpack([{:lstring, prefix_size, endian} | ops], s, pos, results) do
+    ensure_available(s, pos, prefix_size, "data string too short")
+    prefix = binary_part(s, pos, prefix_size)
+    len = decode_int(prefix, false, endian)
+    body_start = pos + prefix_size
+    ensure_available(s, body_start, len, "data string too short")
+    str = binary_part(s, body_start, len)
+    do_unpack(ops, s, body_start + len, [str | results])
+  end
+
+  defp do_unpack([{:zstring} | ops], s, pos, results) do
+    case :binary.match(s, <<0>>, scope: {pos, byte_size(s) - pos}) do
+      {nul_pos, 1} ->
+        str = binary_part(s, pos, nul_pos - pos)
+        do_unpack(ops, s, nul_pos + 1, [str | results])
+
+      :nomatch ->
+        raise_runtime("unfinished string for format 'z'")
+    end
+  end
+
+  defp ensure_available(s, pos, size, msg) do
+    if pos + size > byte_size(s) do
+      raise_runtime(msg)
+    end
+  end
+
+  # ---- packsize driver ---------------------------------------------------
+
+  defp do_packsize([], acc), do: acc
+
+  defp do_packsize([{:align, alignment} | ops], acc) do
+    fill = rem(alignment - rem(acc, alignment), alignment)
+    new_acc = acc + fill
+
+    if new_acc > @max_total_size do
+      raise_runtime("format result too large")
+    end
+
+    do_packsize(ops, new_acc)
+  end
+
+  defp do_packsize([{:padding, n} | ops], acc), do: bump(ops, acc, n)
+  defp do_packsize([{:int, _, size, _} | ops], acc), do: bump(ops, acc, size)
+  defp do_packsize([{:float, size, _} | ops], acc), do: bump(ops, acc, size)
+  defp do_packsize([{:fixed_string, n} | ops], acc), do: bump(ops, acc, n)
+
+  defp do_packsize([{:lstring, _, _} | _], _acc) do
+    raise_runtime("variable-length format in packsize")
+  end
+
+  defp do_packsize([{:zstring} | _], _acc) do
+    raise_runtime("variable-length format in packsize")
+  end
+
+  defp bump(ops, acc, n) do
+    new_acc = acc + n
+
+    if new_acc > @max_total_size do
+      raise_runtime("format result too large")
+    end
+
+    do_packsize(ops, new_acc)
+  end
+
+  # ---- integer encoding/decoding -----------------------------------------
+
+  defp encode_int(n, size, signed?, endian) do
+    {min_v, max_v} = int_range(size, signed?)
+
+    if n < min_v or n > max_v do
+      raise_runtime("integer overflow")
+    end
+
+    # Convert to unsigned representation in `size` bytes.
+    unsigned = if n < 0, do: n + (1 <<< (size * 8)), else: n
+    bits = size * 8
+
+    case endian do
+      :little -> <<unsigned::little-unsigned-integer-size(bits)>>
+      :big -> <<unsigned::big-unsigned-integer-size(bits)>>
+    end
+  end
+
+  defp decode_int(bytes, signed?, endian) do
+    bits = byte_size(bytes) * 8
+
+    unsigned =
+      case endian do
+        :little -> :binary.decode_unsigned(bytes, :little)
+        :big -> :binary.decode_unsigned(bytes, :big)
+      end
+
+    if signed? and unsigned >= 1 <<< (bits - 1) do
+      unsigned - (1 <<< bits)
+    else
+      unsigned
+    end
+  end
+
+  # PUC-Lua's `unpackint`: when the source size exceeds lua_Integer width,
+  # always read the low `SZINT` bytes as a *signed* lua_Integer (mirroring
+  # the C `(lua_Integer)res` cast), then validate the high bytes match the
+  # sign-extension byte (0x00 for unsigned or non-negative signed; 0xFF
+  # only for negative signed). Mismatches raise the
+  # "<size>-byte integer does not fit into Lua Integer" error.
+  defp decode_int_with_overflow_check(bytes, signed?, endian, size) when size <= @sizeof_lua_integer do
+    decode_int(bytes, signed?, endian)
+  end
+
+  defp decode_int_with_overflow_check(bytes, signed?, endian, size) do
+    {value_bytes, extra_bytes} = split_value_extra(bytes, endian, @sizeof_lua_integer)
+    val = decode_int(value_bytes, true, endian)
+    expected = if signed? and val < 0, do: 0xFF, else: 0x00
+
+    if Enum.any?(:binary.bin_to_list(extra_bytes), fn b -> b != expected end) do
+      raise_runtime("#{size}-byte integer does not fit into Lua Integer")
+    end
+
+    val
+  end
+
+  # Split `bytes` into the low-order `keep` bytes and the high-order
+  # remainder. Layout depends on endianness: little-endian keeps the
+  # leading bytes, big-endian keeps the trailing bytes.
+  defp split_value_extra(bytes, :little, keep) do
+    <<value::binary-size(keep), extra::binary>> = bytes
+    {value, extra}
+  end
+
+  defp split_value_extra(bytes, :big, keep) do
+    skip = byte_size(bytes) - keep
+    <<extra::binary-size(skip), value::binary>> = bytes
+    {value, extra}
+  end
+
+  defp int_range(size, true) do
+    half = 1 <<< (size * 8 - 1)
+    {-half, half - 1}
+  end
+
+  defp int_range(size, false), do: {0, (1 <<< (size * 8)) - 1}
+
+  # PUC-Lua's `(lua_Integer)res` reinterprets the bit pattern: an 8-byte
+  # unsigned value above 2^63-1 wraps to its signed-64-bit equivalent.
+  # `unpack("<J", "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF") == -1` exercises
+  # this. Smaller sizes never hit the threshold (their max is 2^56-1).
+  defp wrap_to_lua_integer(val) when val > (1 <<< 63) - 1 and val < 1 <<< 64 do
+    val - (1 <<< 64)
+  end
+
+  defp wrap_to_lua_integer(val), do: val
+
+  # ---- float encoding/decoding -------------------------------------------
+  #
+  # BEAM floats can't represent IEEE ±Infinity or NaN. The Lua VM's
+  # `safe_divide/4` uses `±1.0e308` and the `:nan` sentinel atom as
+  # stand-ins (see `Lua.VM.Executor.safe_divide/4`). For pack/unpack to
+  # round-trip these consistently — `unpack("f", pack("f", 1/0)) == 1/0`
+  # is asserted in `tpack.lua` — we detect IEEE infinity bit patterns on
+  # decode and remap them to the same stand-ins. Encoding side already
+  # works because BEAM's binary syntax silently coerces values that
+  # overflow the float width to ±Infinity bit patterns.
+
+  # IEEE 754 single-precision +inf / -inf bit patterns.
+  @inf_bits_32 0x7F800000
+  @neg_inf_bits_32 0xFF800000
+  # Double-precision: BEAM doubles can hold values up to ~1.8e308, so
+  # `1.0e308` packs to a finite double bit pattern, not infinity. We
+  # still guard the round-trip in case future code paths produce true
+  # IEEE infinity for 64-bit floats.
+  @inf_bits_64 0x7FF0000000000000
+  @neg_inf_bits_64 0xFFF0000000000000
+
+  defp encode_float(f, 4, :little), do: <<f::little-float-size(32)>>
+  defp encode_float(f, 4, :big), do: <<f::big-float-size(32)>>
+  defp encode_float(f, 8, :little), do: <<f::little-float-size(64)>>
+  defp encode_float(f, 8, :big), do: <<f::big-float-size(64)>>
+
+  defp decode_float(bytes, 4, endian) do
+    case unsigned_bits(bytes, endian) do
+      @inf_bits_32 -> 1.0e308
+      @neg_inf_bits_32 -> -1.0e308
+      _ -> raw_decode_float(bytes, 4, endian)
+    end
+  end
+
+  defp decode_float(bytes, 8, endian) do
+    case unsigned_bits(bytes, endian) do
+      @inf_bits_64 -> 1.0e308
+      @neg_inf_bits_64 -> -1.0e308
+      _ -> raw_decode_float(bytes, 8, endian)
+    end
+  end
+
+  defp raw_decode_float(<<f::little-float-size(32)>>, 4, :little), do: f
+  defp raw_decode_float(<<f::big-float-size(32)>>, 4, :big), do: f
+  defp raw_decode_float(<<f::little-float-size(64)>>, 8, :little), do: f
+  defp raw_decode_float(<<f::big-float-size(64)>>, 8, :big), do: f
+
+  defp unsigned_bits(bytes, :little), do: :binary.decode_unsigned(bytes, :little)
+  defp unsigned_bits(bytes, :big), do: :binary.decode_unsigned(bytes, :big)
+
+  # ---- argument coercion -------------------------------------------------
+
+  defp to_integer(n, _) when is_integer(n), do: n
+
+  defp to_integer(n, _) when is_float(n) do
+    if n == Float.floor(n) and n >= -(1 <<< 63) and n <= (1 <<< 63) - 1 do
+      trunc(n)
+    else
+      raise_runtime("number has no integer representation")
+    end
+  end
+
+  defp to_integer(s, _) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, ""} -> n
+      _ -> raise_runtime("bad argument (number expected)")
+    end
+  end
+
+  defp to_integer(_, fname), do: raise_runtime("bad argument to '#{fname}' (number expected)")
+
+  defp to_float(n, _) when is_number(n), do: n / 1
+  defp to_float(_, fname), do: raise_runtime("bad argument to '#{fname}' (number expected)")
+
+  defp to_string_arg(s, _) when is_binary(s), do: s
+  defp to_string_arg(n, _) when is_integer(n), do: Integer.to_string(n)
+  defp to_string_arg(n, _) when is_float(n), do: Float.to_string(n)
+  defp to_string_arg(_, fname), do: raise_runtime("bad argument to '#{fname}' (string expected)")
+
+  # ---- pos normalization for unpack -------------------------------------
+
+  defp normalize_init_pos(pos, len) when pos < 0 do
+    p = len + pos + 1
+    if p < 1, do: raise_runtime("initial position out of string"), else: p - 1
+  end
+
+  defp normalize_init_pos(pos, _len) when pos < 1 do
+    raise_runtime("initial position out of string")
+  end
+
+  defp normalize_init_pos(pos, len) when pos > len + 1 do
+    raise_runtime("initial position out of string")
+  end
+
+  defp normalize_init_pos(pos, _len), do: pos - 1
+
+  # ---- helpers -----------------------------------------------------------
+
+  defp power_of_two?(n) when n >= 1, do: (n &&& n - 1) == 0
+  defp power_of_two?(_), do: false
+
+  defp raise_runtime(msg), do: raise(RuntimeError, value: msg)
+end

--- a/test/lua/vm/stdlib/string_pack_test.exs
+++ b/test/lua/vm/stdlib/string_pack_test.exs
@@ -1,0 +1,296 @@
+defmodule Lua.VM.Stdlib.StringPackTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.RuntimeError
+  alias Lua.VM.State
+  alias Lua.VM.Stdlib
+
+  # Run the given Lua source against a fresh stdlib-installed VM and
+  # return whatever the chunk returned.
+  defp lua!(code) do
+    {:ok, ast} = Parser.parse(code)
+    {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+    state = Stdlib.install(State.new())
+    {:ok, results, _state} = VM.execute(proto, state)
+    results
+  end
+
+  describe "string.packsize/1" do
+    test "fixed-size integer formats" do
+      assert lua!("return string.packsize('b')") == [1]
+      assert lua!("return string.packsize('B')") == [1]
+      assert lua!("return string.packsize('h')") == [2]
+      assert lua!("return string.packsize('H')") == [2]
+      assert lua!("return string.packsize('i')") == [4]
+      assert lua!("return string.packsize('I')") == [4]
+      assert lua!("return string.packsize('l')") == [8]
+      assert lua!("return string.packsize('L')") == [8]
+      assert lua!("return string.packsize('j')") == [8]
+      assert lua!("return string.packsize('J')") == [8]
+      assert lua!("return string.packsize('T')") == [8]
+    end
+
+    test "sized integer formats" do
+      assert lua!("return string.packsize('i1')") == [1]
+      assert lua!("return string.packsize('i3')") == [3]
+      assert lua!("return string.packsize('i16')") == [16]
+      assert lua!("return string.packsize('I7')") == [7]
+    end
+
+    test "float formats" do
+      assert lua!("return string.packsize('f')") == [4]
+      assert lua!("return string.packsize('d')") == [8]
+      assert lua!("return string.packsize('n')") == [8]
+    end
+
+    test "fixed-size string formats" do
+      assert lua!("return string.packsize('c0')") == [0]
+      assert lua!("return string.packsize('c10')") == [10]
+    end
+
+    test "padding and whitespace" do
+      assert lua!("return string.packsize('x')") == [1]
+      assert lua!("return string.packsize(' b ')") == [1]
+    end
+
+    test "alignment with !" do
+      # Default alignment is 1, so no padding.
+      assert lua!("return string.packsize('bi4')") == [5]
+      # !4 forces 4-byte alignment for i4.
+      assert lua!("return string.packsize('!4 b i4')") == [8]
+      # !8 with x then Xi8 gives 8-byte total (1 + 7 padding).
+      assert lua!("return string.packsize('!8 xXi8')") == [8]
+      assert lua!("return string.packsize('!2 xXi8')") == [2]
+      assert lua!("return string.packsize('!2 xXi2')") == [2]
+    end
+
+    test "mixed types" do
+      # b(1) + h(2) + b(1) + f(4) + d(8) + f(4) + n(8) + i(4) = 32
+      assert lua!("return string.packsize('<b h b f d f n i')") == [32]
+    end
+
+    test "raises on variable-length formats" do
+      assert_raise RuntimeError, ~r/variable-length format/, fn ->
+        lua!("return string.packsize('s')")
+      end
+
+      assert_raise RuntimeError, ~r/variable-length format/, fn ->
+        lua!("return string.packsize('z')")
+      end
+    end
+
+    test "raises on out-of-range integer size" do
+      assert_raise RuntimeError, ~r/out of limits/, fn ->
+        lua!("return string.packsize('i0')")
+      end
+
+      assert_raise RuntimeError, ~r/out of limits/, fn ->
+        lua!("return string.packsize('i17')")
+      end
+    end
+
+    test "raises on missing 'c' size" do
+      assert_raise RuntimeError, ~r/missing size/, fn ->
+        lua!("return string.packsize('c')")
+      end
+    end
+
+    test "raises on bad alignment" do
+      assert_raise RuntimeError, ~r/not power of 2/, fn ->
+        lua!("return string.packsize('!4 i3')")
+      end
+    end
+
+    test "raises on unknown option" do
+      assert_raise RuntimeError, ~r/invalid format option/, fn ->
+        lua!("return string.packsize('r')")
+      end
+    end
+  end
+
+  describe "string.pack/2 — integer formats" do
+    test "round-trips signed and unsigned bytes" do
+      assert lua!("return string.unpack('B', string.pack('B', 0xff))") == [0xFF, 2]
+      assert lua!("return string.unpack('b', string.pack('b', 0x7f))") == [0x7F, 2]
+      assert lua!("return string.unpack('b', string.pack('b', -0x80))") == [-0x80, 2]
+    end
+
+    test "round-trips short, int, long" do
+      assert lua!("return string.unpack('H', string.pack('H', 0xffff))") == [0xFFFF, 3]
+      assert lua!("return string.unpack('L', string.pack('L', 0xffffffff))") == [0xFFFFFFFF, 9]
+    end
+
+    test "endianness controls byte order" do
+      # >i4 of 1 is 00 00 00 01.
+      assert lua!(~S{return string.pack('>i4', 1)}) == [<<0, 0, 0, 1>>]
+      # <i4 of 1 is 01 00 00 00.
+      assert lua!(~S{return string.pack('<i4', 1)}) == [<<1, 0, 0, 0>>]
+      # = is native, which we treat as little.
+      assert lua!(~S{return string.pack('=i4', 1)}) == [<<1, 0, 0, 0>>]
+    end
+
+    test "sign-extension on small signed sizes" do
+      # i3 of -1 = FF FF FF (3 bytes of 0xFF).
+      assert lua!(~S{return string.pack('i3', -1)}) == [<<0xFF, 0xFF, 0xFF>>]
+    end
+
+    test "raises on integer overflow for signed size" do
+      assert_raise RuntimeError, ~r/overflow/, fn ->
+        # i1 max = 127.
+        lua!("return string.pack('<i1', 128)")
+      end
+    end
+
+    test "raises on integer overflow for unsigned size" do
+      assert_raise RuntimeError, ~r/overflow/, fn ->
+        # I1 max = 255; -1 is not representable.
+        lua!("return string.pack('<I1', -1)")
+      end
+    end
+  end
+
+  describe "string.pack/2 — float formats" do
+    test "round-trips doubles via n/d" do
+      assert lua!("return string.unpack('n', string.pack('n', 3.5))") == [3.5, 9]
+      assert lua!("return string.unpack('d', string.pack('d', -1.25))") == [-1.25, 9]
+    end
+
+    test "round-trips f for round-numbered floats" do
+      assert lua!("return string.unpack('<f', string.pack('<f', 24.0))") == [24.0, 5]
+      assert lua!("return string.unpack('>f', string.pack('>f', 24.0))") == [24.0, 5]
+    end
+  end
+
+  describe "string.pack/2 — string formats" do
+    test "fixed-size c<n> pads with zeros" do
+      assert lua!(~S{return string.pack('c5', 'abc')}) == [<<"abc", 0, 0>>]
+    end
+
+    test "fixed-size c<n> errors when string too long" do
+      assert_raise RuntimeError, ~r/longer than/, fn ->
+        lua!("return string.pack('c3', '1234')")
+      end
+    end
+
+    test "z is zero-terminated" do
+      assert lua!(~S{return string.pack('z', 'abc')}) == [<<"abc", 0>>]
+    end
+
+    test "z errors on embedded zero" do
+      assert_raise RuntimeError, ~r/contains zeros/, fn ->
+        lua!(~S{return string.pack('z', 'a\0b')})
+      end
+    end
+
+    test "s prefixes with size_t-byte length" do
+      # Default s = s8 (size_t). Length prefix is 8 little-endian bytes.
+      assert lua!(~S{return string.pack('<s', 'ab')}) ==
+               [<<2, 0, 0, 0, 0, 0, 0, 0, "ab">>]
+    end
+
+    test "s1 errors when length doesn't fit" do
+      assert_raise RuntimeError, ~r/does not fit/, fn ->
+        lua!(~S{return string.pack('s1', string.rep('a', 256))})
+      end
+    end
+
+    test "s100 errors with out-of-limits" do
+      assert_raise RuntimeError, ~r/out of limits/, fn ->
+        lua!(~S{return string.pack('s100', 'a')})
+      end
+    end
+  end
+
+  describe "string.pack/2 — alignment" do
+    test "X pads to natural alignment of next op (X is empty directive)" do
+      # !8 b Xi8 = 1 byte (b=1), then 7 padding to reach 8-byte boundary.
+      # Xi8 is an empty alignment directive — it does NOT emit i8 data.
+      result = lua!(~S{return string.pack('!8 b Xi8', 1)})
+      assert result == [<<1, 0, 0, 0, 0, 0, 0, 0>>]
+    end
+
+    test "X without valid follow-on errors" do
+      assert_raise RuntimeError, ~r/invalid next option/, fn ->
+        lua!(~S{return string.pack('X')})
+      end
+
+      assert_raise RuntimeError, ~r/invalid next option/, fn ->
+        lua!(~S{return string.pack('Xc1')})
+      end
+    end
+
+    test "no alignment by default" do
+      # i1 i2 packs as 3 bytes, no padding.
+      assert lua!(~S{return string.pack('<i1 i2', 2, 3)}) == [<<2, 3, 0>>]
+    end
+  end
+
+  describe "string.unpack/2,3" do
+    test "returns next read position as last value" do
+      assert lua!(~S{return string.unpack('b', '\5')}) == [5, 2]
+    end
+
+    test "supports initial position argument" do
+      assert lua!(~S{return string.unpack('b', '\1\2\3', 2)}) == [2, 3]
+    end
+
+    test "supports negative initial position" do
+      assert lua!(~S{return string.unpack('b', '\1\2\3', -1)}) == [3, 4]
+    end
+
+    test "errors on initial position out of range" do
+      assert_raise RuntimeError, ~r/out of string/, fn ->
+        lua!(~S{return string.unpack('b', 'abc', 0)})
+      end
+
+      assert_raise RuntimeError, ~r/out of string/, fn ->
+        lua!(~S{return string.unpack('b', 'abc', 5)})
+      end
+    end
+
+    test "errors when source string is too short" do
+      assert_raise RuntimeError, ~r/too short/, fn ->
+        lua!(~S{return string.unpack('i4', 'ab')})
+      end
+    end
+
+    test "c<n> reads exactly n bytes" do
+      assert lua!(~S{return string.unpack('c3', 'abcdef')}) == ["abc", 4]
+    end
+
+    test "z reads up to NUL" do
+      assert lua!(~S{return string.unpack('z', 'hello\0world')}) == ["hello", 7]
+    end
+
+    test "errors on unfinished z" do
+      assert_raise RuntimeError, ~r/unfinished string|too short/, fn ->
+        lua!(~S{return string.unpack('z', 'abc')})
+      end
+    end
+
+    test "i16 errors when value can't fit in lua_Integer" do
+      assert_raise RuntimeError, ~r/16-byte integer/, fn ->
+        lua!(~S{return string.unpack('i16', string.rep('\3', 16))})
+      end
+    end
+  end
+
+  describe "string.pack/2 — combined" do
+    test "mixed sequence packs and unpacks correctly" do
+      code = ~S"""
+      local s = string.pack('<b h b f d f n i', 1, 2, 3, 4, 5, 6, 7, 8)
+      local a, b, c, d, e, f, g, h = string.unpack('<b h b f d f n i', s)
+      return a, b, c, d, e, f, g, h
+      """
+
+      assert lua!(code) == [1, 2, 3, 4.0, 5.0, 6.0, 7.0, 8]
+    end
+
+    test "mixed endianness in single format" do
+      assert lua!(~S{return string.pack('>i2 <i2', 10, 20)}) == [<<0, 10, 20, 0>>]
+    end
+  end
+end

--- a/test/lua53_suite_test.exs
+++ b/test/lua53_suite_test.exs
@@ -15,7 +15,7 @@ defmodule Lua.Lua53SuiteTest do
              |> Enum.sort()
 
   # Tests that are ready to run (not skipped).
-  @ready_tests ["simple_test.lua", "api.lua", "bitwise.lua", "code.lua", "vararg.lua"]
+  @ready_tests ["simple_test.lua", "api.lua", "bitwise.lua", "code.lua", "tpack.lua", "vararg.lua"]
 
   # Suite files that we have deliberately decided not to support.
   #


### PR DESCRIPTION
## Implement string.pack, string.unpack, string.packsize

Plan: [`.agents/plans/A25-string-pack-unpack.md`](https://github.com/tv-labs/lua/blob/feat/string-pack-unpack/.agents/plans/A25-string-pack-unpack.md)

### Goal

Implement `string.pack/2`, `string.unpack/2,3`, and `string.packsize/1`
per Lua 5.3 §6.4.2. These are the only stdlib functions that previously
raised `string.pack not yet implemented`, blocking `tpack.lua` and
parts of `strings.lua`.

### Success criteria

- [x] `string.pack`, `string.unpack`, `string.packsize` exist in
      `lib/lua/vm/stdlib/string.ex` and are reachable from Lua
      (delegating to `Lua.VM.Stdlib.String.Pack`)
- [x] All format options from Lua 5.3 §6.4.2 supported:
      - [x] `<` `>` `=` `!` (endian and alignment)
      - [x] `b B h H i I l L j J T` (signed/unsigned ints, sized variants)
      - [x] `f d n` (floats)
      - [x] `s` `s1`-`s8` (length-prefixed string)
      - [x] `z` (zero-terminated string)
      - [x] `x` (padding byte)
      - [x] `X<op>` (alignment to op's natural alignment)
      - [x] `c<n>` (fixed-size string)
      - [x] ` ` (space, ignored)
- [x] `tpack.lua` passes (promoted to `@ready_tests`; suite count 5/24 → 6/24)
- [x] `mix test` count goes up by at least 5 (added 41 new unit tests in
      `test/lua/vm/stdlib/string_pack_test.exs`)
- [x] No regression elsewhere (1585 → 1626 passing, 0 failures)

### Changes

```
.agents/plans/A25-string-pack-unpack.md |  77 ++++-
lib/lua/vm/stdlib/string.ex             | 124 +++--
lib/lua/vm/stdlib/string/pack.ex        | 619 +++++++++++++++++++++++++ (new)
test/lua/vm/stdlib/string_pack_test.exs | 312 +++++++++++++ (new)
test/lua53_suite_test.exs               |   2 +-
```

The bulk of the implementation is in the new `Lua.VM.Stdlib.String.Pack`
module. The format-string parser walks the format once and emits a list
of operations (`{:int, …}`, `{:float, …}`, `{:fixed_string, n}`,
`{:lstring, …}`, `{:zstring}`, `{:padding, n}`, `{:align, n}`); the
pack/unpack/packsize drivers then evaluate that list while tracking
their own running byte position. This split is necessary because
variable-length ops (`s`, `z`) advance the position by an amount only
known at evaluation time, and subsequent alignment requirements depend
on that runtime position (matches PUC-Lua's `getdetails` /
`totalsize` design).

### Discoveries

Documented in the plan file under `## Discoveries`. Briefly:

1. **`string.reverse` was UTF-8-oriented, not byte-oriented.** Fixed
   in scope — `tpack.lua` exercises byte reversal of packed integer
   bytes via `s2:reverse()`, so the bug was on the critical path.
2. **`string.rep` rejected float counts.** Lua 5.3's `^` always returns
   a float, so `string.rep("c…", 2^3)` was rejected as "number expected,
   got number". Fixed in scope by accepting floats with integer values.
3. **Alignment had to move from parse-time to runtime** to handle
   variable-length ops (`s`, `z`).
4. **`unpack` cast semantics for size > SZINT and size == SZINT** match
   PUC-Lua's `(lua_Integer)res` bit-pattern reinterpretation. Notably,
   `unpack("<J", pack("<j", -1)) == -1` requires wrapping unsigned 8-byte
   values above 2^63-1 to their signed-64-bit equivalents.
5. **BEAM has no IEEE ±Infinity**, but the suite round-trips `1/0`
   through `pack("f", …)`. Handled by detecting the four ±Inf bit
   patterns on decode and remapping them to the Lua VM's `±1.0e308`
   stand-ins (consistent with `Lua.VM.Executor.safe_divide/4`).

### Verification

```bash
mix format --check-formatted          # clean
mix compile --warnings-as-errors      # clean
mix test                               # 1626 passing, 0 failing, 30 skipped
mix test --only lua53                  # 6/24 ready: simple_test, api,
                                       #   bitwise, code, tpack (new), vararg
```

### Out of scope (intentional)

- `string.format` improvements
- `string.pack` extensions beyond Lua 5.3 §6.4.2 (no custom format options)
- Performance optimisation beyond "passes the suite without timing out"
- Full IEEE NaN bit-pattern round-tripping (the suite doesn't exercise
  NaN through pack/unpack; consistent with the existing
  `safe_divide/4` accepted-divergence note)