### PR TITLE
feat(vm): inspect protocol for VM values via boundary display structs

### DIFF
--- a/.agents/plans/A27-inspect-protocol.md
+++ b/.agents/plans/A27-inspect-protocol.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: dx/inspect-protocol
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - readable iex output for Lua values

--- a/.agents/plans/A27-inspect-protocol.md
+++ b/.agents/plans/A27-inspect-protocol.md
@@ -41,20 +41,25 @@ Targets:
 
 ## Success criteria
 
-- [ ] In `iex`, `Lua.eval!(Lua.new(), "return {1, 2, 3}")` shows the
-      table contents (e.g. `#Lua.Table<id: 1, [1, 2, 3]>` or similar)
-      instead of `{:tref, 1}`.
-- [ ] Calling `inspect/1` on a `{:lua_closure, ...}` shows
-      `#Lua.Closure<source: "demo.lua", line: 5, arity: 2>` (or
-      similar shape).
-- [ ] Calling `inspect/1` on a `{:native_func, &Mod.fun/2}` shows
-      `#Lua.NativeFunc<&Mod.fun/2>`.
-- [ ] Calling `inspect/1` on a `{:udref, 3}` shows the wrapped term
-      (e.g. `#Lua.Userdata<id: 3, term: %MyStruct{...}>`).
+- [ ] In `iex`, `Lua.eval!(Lua.new(), "return {1, 2, 3}", decode: false)`
+      shows table contents (e.g. `#Lua.Table<id: 1, [1, 2, 3]>` or
+      similar) instead of `{:tref, 1}`.
+- [ ] In `iex`, the return value of
+      `Lua.eval!(Lua.new(), "return function() end")` (default
+      `decode: true`) shows `#Lua.Closure<...>` instead of
+      `{:lua_closure, _, _}`. Same for native funcs:
+      `#Lua.NativeFunc<...>` instead of `{:native_func, _}`.
+- [ ] In `iex`, `Lua.eval!(Lua.new(), "return userdata", decode: false)`
+      shows `#Lua.Userdata<id: 3, term: %MyStruct{...}>` instead of
+      `{:udref, 3}`. (Default decode currently returns
+      `{:userdata, term}` and continues to do so — out of scope.)
 - [ ] Inspect output respects the `Inspect.Opts` (limit, pretty,
       width).
-- [ ] No regression: existing pattern matches on `{:tref, _}` etc.
-      still work — we add `Inspect` impls, not new structs.
+- [ ] No regression in default-decode (`decode: true`) shape: tables
+      still come back as a list of `{key, value}` tuples; `userdata`
+      still comes back as `{:userdata, term}`. The wrap layer only
+      changes `decode: false` shape (for tref/udref) and the
+      always-leaked `lua_closure`/`native_func` tags.
 - [ ] `mix test` passes; new tests cover each impl in
       `test/lua/inspect_test.exs`.
 
@@ -85,8 +90,8 @@ Problem: this clobbers `Inspect` for *all* tuples globally. Bad.
 ### Option B — wrap on the boundary (recommended)
 
 When a Lua value crosses out to Elixir (`Lua.eval!` return value),
-wrap each VM tag in a thin struct: `%Lua.Table{id: id, peek: ...}`,
-`%Lua.Closure{...}`, etc. The struct exists *only* for outbound
+wrap each VM tag in a thin struct: `%Lua.VM.Display.Table{id: id, peek: ...}`,
+`%Lua.VM.Display.Closure{...}`, etc. The struct exists *only* for outbound
 display; internally we still use the tuple.
 
 This is cleaner because:
@@ -99,14 +104,49 @@ The wrap happens in `Lua.eval/2` and `Lua.eval!/2` return paths
 (`encode/decode`-ish). It does *not* happen for values stored in
 state or for native-function arguments.
 
+### Decode behaviour
+
+The wrap layer in `eval/eval!` is conditional on which value tag is
+crossing the boundary AND on `decode:`:
+
+| Tag                  | `decode: true` (default)                          | `decode: false`                          |
+|----------------------|---------------------------------------------------|------------------------------------------|
+| `{:tref, _}`         | list of `{k, v}` tuples (UNCHANGED — preserves API) | `%Lua.VM.Display.Table{}` (NEW)         |
+| `{:udref, _}`        | `{:userdata, term}` (UNCHANGED — preserves API)   | `%Lua.VM.Display.Userdata{}` (NEW)      |
+| `{:lua_closure, _, _}` | `%Lua.VM.Display.Closure{}` (NEW)               | `%Lua.VM.Display.Closure{}` (NEW)       |
+| `{:native_func, _}`  | `%Lua.VM.Display.NativeFunc{}` (NEW)             | `%Lua.VM.Display.NativeFunc{}` (NEW)    |
+
+This minimises the API break: tables/userdata in default decode mode
+keep their list-of-tuples / `{:userdata, term}` shape, so existing
+tests and downstream `deflua` consumers don't change. Only `decode: false`
+callers see new shapes for tables/userdata, and closures/native_funcs
+become friendlier in every mode (because they're *already* leaking raw
+tuples in default decode mode today).
+
+### Naming
+
+`Lua.Table` is already taken (it's a public utility module for
+treating decoded tables as lists/maps). Display structs live under
+`Lua.VM.Display.*` to make the namespace clear and avoid collisions:
+
+- `Lua.VM.Display.Table` — `[:id, :peek]`
+- `Lua.VM.Display.Closure` — `[:source, :line, :arity, :ref]`
+- `Lua.VM.Display.NativeFunc` — `[:fun]`
+- `Lua.VM.Display.Userdata` — `[:id, :term]`
+
+Inspect output uses the short forms (`#Lua.Table<...>`,
+`#Lua.Closure<...>`, etc.) regardless of full module path.
+
 ### Files
 
-- `lib/lua/table.ex` (new) — `defstruct [:id, :peek]` + `Inspect`.
-- `lib/lua/closure.ex` (new) — `defstruct [:source, :line, :arity]`.
-- `lib/lua/native_func.ex` (new) — `defstruct [:fun]`.
-- `lib/lua/userdata.ex` (new) — `defstruct [:id, :term]`.
-- `lib/lua.ex` — wrap on `eval/2`/`eval!/2` return.
-- `test/lua/inspect_test.exs` (new) — covers each impl.
+- `lib/lua/vm/display.ex` (new) — boundary wrap helpers
+  (`wrap_for_eval/3`).
+- `lib/lua/vm/display/table.ex` (new) — `defstruct [:id, :peek]` + `Inspect`.
+- `lib/lua/vm/display/closure.ex` (new) — `defstruct [:source, :line, :arity, :ref]`.
+- `lib/lua/vm/display/native_func.ex` (new) — `defstruct [:fun]`.
+- `lib/lua/vm/display/userdata.ex` (new) — `defstruct [:id, :term]`.
+- `lib/lua.ex` — call `Display.wrap_for_eval/3` on `eval/2`/`eval!/2` return.
+- `test/lua/vm/display_test.exs` (new) — covers each impl + boundary wrap.
 
 ## Verification
 
@@ -119,20 +159,46 @@ mix test
 Manual:
 
 ```elixir
-iex> {[t], _} = Lua.eval(Lua.new(), "return {a = 1, b = 2}")
+# Default decode: tables stay as decoded list-of-tuples
+iex> {[t], _} = Lua.eval!(Lua.new(), "return {a = 1, b = 2}")
+iex> t
+[{"a", 1}, {"b", 2}]
+
+# decode: false: tables wrap as display struct
+iex> {[t], _} = Lua.eval!(Lua.new(), "return {a = 1, b = 2}", decode: false)
 iex> t
 #Lua.Table<id: 1, %{"a" => 1, "b" => 2}>
+
+# Closures wrap in either mode
+iex> {[c], _} = Lua.eval!(Lua.new(), "return function(x) return x * 2 end")
+iex> c
+#Lua.Closure<source: "<eval>", line: 1, arity: 1>
+
+# Native funcs wrap in either mode
+iex> {[f], _} = Lua.eval!(Lua.new(), "return string.lower")
+iex> f
+#Lua.NativeFunc<...>
 ```
 
 ## Risks
 
-- Wrapping return values is a small but observable API change. Code
-  that pattern-matched on `{:tref, _}` from `Lua.eval/2` results
-  would break. Mitigation: this is `1.0.0-rc.1`, this is the time to
-  make this change. Document in CHANGELOG and consider a public
-  helper `Lua.unwrap/1` if anyone needs the raw tuple.
-- Table peek can be expensive for large tables. Limit to `Inspect.Opts.limit`
-  entries.
+- API surface change: `decode: false` callers that pattern-match on
+  `{:tref, _}` or `{:udref, _}` from `eval` results will break.
+  `decode: true` callers (the vast majority — including all
+  `deflua` flows and the existing doctests) are unaffected. This is
+  `1.0.0-rc.1`, the right window for this change.
+- Closure / native_func shape changes in BOTH decode modes (because
+  default decode passed them through as raw tuples already). Code
+  that pattern-matches on `{:lua_closure, _, _}` or `{:native_func, _}`
+  in eval results will break. Internal pattern matches inside the VM
+  are unaffected because the wrap is at the eval boundary, not in
+  state.
+- Table peek can be expensive for very large tables. Cap the peek at
+  `Inspect.Opts.limit` entries and show `…` if truncated.
+- Closure refs need stable display for the success criterion that
+  shows `source: "demo.lua", line: 5, arity: 2`. The Lua proto
+  carries this info; the wrap layer reads from `proto.source`,
+  `proto.line` (or first instruction's line), and `proto.param_count`.
 
 ## Discoveries
 

--- a/.agents/plans/A27-inspect-protocol.md
+++ b/.agents/plans/A27-inspect-protocol.md
@@ -2,10 +2,10 @@
 id: A27
 title: Inspect protocol for VM values
 issue: null
-pr: null
+pr: 218
 branch: dx/inspect-protocol
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - readable iex output for Lua values
@@ -202,4 +202,46 @@ iex> f
 
 ## Discoveries
 
-(populated during implementation)
+- `Lua.Table` already exists as a public utility module (for casting
+  decoded tables to lists/maps). Display structs live under
+  `Lua.VM.Display.*` to avoid the collision; the inspect output still
+  uses the short forms (`#Lua.Table<...>`, etc.).
+- Closures need source/line/arity at display time. The existing
+  `Lua.Compiler.Prototype` struct carries `:source`, `:lines`,
+  `:param_count`, and `:is_vararg` — no proto changes needed.
+- Round-trip support (`Lua.set!/3`, `Lua.encode!/2`, `Lua.decode!/2`,
+  `Lua.call_function/3`) had to be added to keep the wrap transparent
+  for existing flows. Each entry point calls `Display.unwrap/1`. A
+  public `Lua.unwrap/1` is also exposed for callers that need the raw
+  VM tag directly.
+- `Lua.encode!/2` got an opportunistic `Util.encoded?/1` shortcut so
+  unwrapping a table struct (whose `:ref` is `{:tref, _}`, already
+  encoded) does not try to re-encode through `Value.encode/2`.
+- Two pre-existing tests pattern-matched on `{:tref, _}` from
+  `decode: false` (`test/lua/util_test.exs` and `test/lua_test.exs`).
+  Both updated to match the new `%Lua.VM.Display.Table{}` shape and
+  exercise `Lua.unwrap/1`. No other downstream pattern matches in
+  the suite.
+
+## What changed
+
+PR: [#218](https://github.com/tv-labs/lua/pull/218)
+
+Files touched:
+
+- `lib/lua/vm/display.ex` (new)
+- `lib/lua/vm/display/table.ex` (new)
+- `lib/lua/vm/display/closure.ex` (new)
+- `lib/lua/vm/display/native_func.ex` (new)
+- `lib/lua/vm/display/userdata.ex` (new)
+- `lib/lua.ex` — wraps results on `eval/eval!` return; unwraps on
+  `set!`, `encode!`, `decode!`, `call_function`; adds public
+  `Lua.unwrap/1`.
+- `test/lua/vm/display_test.exs` (new) — 28 tests covering each
+  Inspect impl, the boundary wrap, round-tripping, and decode-mode
+  invariants.
+- `test/lua/util_test.exs`, `test/lua_test.exs` — updated to match
+  the new `decode: false` wrap shape.
+
+Suite delta: 1626 → 1654 tests, 0 failures (no Lua 5.3 suite
+regressions).

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -8,6 +8,7 @@ defmodule Lua do
 
   alias Lua.Util
   alias Lua.VM.AssertionError
+  alias Lua.VM.Display
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Table
@@ -276,6 +277,7 @@ defmodule Lua do
 
   def set!(%__MODULE__{} = lua, keys, value) do
     keys = keys |> List.wrap() |> Enum.map(&to_lua_key/1)
+    value = Display.unwrap(value)
 
     {encoded, state} =
       if Util.encoded?(value) do
@@ -463,6 +465,8 @@ defmodule Lua do
                 results
               end
 
+            results = Display.wrap_results(results, new_state, opts[:decode])
+
             {results, %{lua | state: new_state}}
 
           {:error, msg} ->
@@ -497,6 +501,8 @@ defmodule Lua do
       else
         results
       end
+
+    results = Display.wrap_results(results, new_state, opts[:decode])
 
     {results, %{lua | state: new_state}}
   rescue
@@ -597,6 +603,14 @@ defmodule Lua do
       42
 
   """
+  def call_function(%__MODULE__{} = lua, %Display.Closure{ref: ref}, args) do
+    call_function(lua, ref, args)
+  end
+
+  def call_function(%__MODULE__{} = lua, %Display.NativeFunc{ref: ref}, args) do
+    call_function(lua, ref, args)
+  end
+
   def call_function(%__MODULE__{state: state} = lua, func, args) when is_tuple(func) do
     case do_call_function(func, args, state) do
       {:ok, results, new_state} -> {:ok, results, %{lua | state: new_state}}
@@ -679,6 +693,30 @@ defmodule Lua do
   end
 
   @doc """
+  Returns the underlying VM tag tuple for a display struct returned by
+  `Lua.eval/2` / `Lua.eval!/2` in `decode: false` mode. Returns
+  values unchanged if they are not display structs, so it is safe to
+  apply unconditionally to any value flowing back from `eval`.
+
+      iex> {[t], _lua} = Lua.eval!(Lua.new(), "return {1, 2, 3}", decode: false)
+      iex> match?({:tref, _}, Lua.unwrap(t))
+      true
+
+      iex> {[c], _} = Lua.eval!(Lua.new(), "return function() end")
+      iex> match?({:lua_closure, _, _}, Lua.unwrap(c))
+      true
+
+      iex> Lua.unwrap(42)
+      42
+
+  Useful when you need to pass an `eval`-returned closure or table
+  reference to a tool that expects the raw VM tag (for example, an
+  internal helper or a custom `deflua`).
+  """
+  @spec unwrap(term()) :: term()
+  defdelegate unwrap(value), to: Display
+
+  @doc """
   Encodes a Lua value into its internal form
 
       <!-- Old Luerl implementation returned specific tref IDs: {encoded, _} = Lua.encode!(Lua.new(), %{a: 1}); encoded => {:tref, 14} -->
@@ -692,8 +730,14 @@ defmodule Lua do
   end
 
   def encode!(%__MODULE__{state: state} = lua, value) do
-    {encoded, state} = Value.encode(value, state)
-    {encoded, %{lua | state: state}}
+    value = Display.unwrap(value)
+
+    if Util.encoded?(value) do
+      {value, lua}
+    else
+      {encoded, state} = Value.encode(value, state)
+      {encoded, %{lua | state: state}}
+    end
   rescue
     _e in [ArgumentError] ->
       reraise Lua.RuntimeException, "Failed to encode #{inspect(value)}", __STACKTRACE__
@@ -722,6 +766,8 @@ defmodule Lua do
 
   """
   def decode!(%__MODULE__{state: state}, value) do
+    value = Display.unwrap(value)
+
     if not Util.encoded?(value) do
       raise Lua.RuntimeException, "Failed to decode #{inspect(value)}"
     end

--- a/lib/lua/vm/display.ex
+++ b/lib/lua/vm/display.ex
@@ -1,0 +1,159 @@
+defmodule Lua.VM.Display do
+  @moduledoc """
+  Boundary wrappers that turn opaque VM value tags into display
+  structs at the `Lua.eval/2` / `Lua.eval!/2` return path.
+
+  The internal VM continues to use the tagged-tuple representation
+  (`{:tref, id}`, `{:lua_closure, proto, upvalues}`,
+  `{:native_func, fun}`, `{:udref, id}`). These wrappers exist
+  purely so that values that surface to user code in `iex` render
+  legibly instead of as opaque tuples.
+
+  See `Lua.VM.Display.Table`, `Lua.VM.Display.Closure`,
+  `Lua.VM.Display.NativeFunc`, and `Lua.VM.Display.Userdata` for
+  the per-tag display structs and their `Inspect` impls.
+
+  ## Decode behaviour
+
+  | Tag                    | `decode: true`                   | `decode: false`              |
+  |------------------------|----------------------------------|------------------------------|
+  | `{:tref, _}`           | list of `{k, v}` (unchanged)     | wraps to `Display.Table`     |
+  | `{:udref, _}`          | `{:userdata, term}` (unchanged)  | wraps to `Display.Userdata`  |
+  | `{:lua_closure, _, _}` | wraps to `Display.Closure`       | wraps to `Display.Closure`   |
+  | `{:native_func, _}`    | wraps to `Display.NativeFunc`    | wraps to `Display.NativeFunc`|
+
+  Default-decode tables and userdata are left in their existing
+  Elixir-friendly shape so `deflua` flows and downstream consumers
+  do not need to change.
+  """
+
+  alias Lua.VM.Display.Closure
+  alias Lua.VM.Display.NativeFunc
+  alias Lua.VM.Display.Table, as: DTable
+  alias Lua.VM.Display.Userdata
+  alias Lua.VM.State
+
+  @typedoc "Any of the four display structs produced at the eval boundary."
+  @type display_struct ::
+          DTable.t()
+          | Closure.t()
+          | NativeFunc.t()
+          | Userdata.t()
+
+  @doc """
+  Wraps each value in a list of eval results for display, given the
+  state at boundary-cross time and the `decode:` option.
+
+  When `decode: true` (the default), tables and userdata are passed
+  through unchanged because they have already been decoded into
+  Elixir-friendly shapes (list of tuples and `{:userdata, term}`).
+  Closures and native funcs are wrapped in either mode.
+
+  When `decode: false`, all four tag kinds are wrapped; nested values
+  inside tables are also wrapped via `wrap_value/2`.
+  """
+  @spec wrap_results([term()], State.t(), boolean()) :: [term()]
+  def wrap_results(values, state, decode?) when is_list(values) do
+    Enum.map(values, &wrap_value(&1, state, decode?))
+  end
+
+  @doc """
+  Returns true when the value is one of the four display structs.
+
+  Used by API entry points (`Lua.set!/3`, `Lua.encode!/2`, etc.) to
+  detect a wrapped-for-display value that should be unwrapped back
+  to its underlying VM tag before further processing.
+  """
+  @spec display_struct?(term()) :: boolean()
+  def display_struct?(%DTable{}), do: true
+  def display_struct?(%Closure{}), do: true
+  def display_struct?(%NativeFunc{}), do: true
+  def display_struct?(%Userdata{}), do: true
+  def display_struct?(_), do: false
+
+  @doc """
+  Unwraps a display struct back to its underlying VM tag tuple.
+
+  Returns the value unchanged if it is not a display struct.
+  """
+  @spec unwrap(term()) :: term()
+  def unwrap(%DTable{ref: ref}), do: ref
+  def unwrap(%Closure{ref: ref}), do: ref
+  def unwrap(%NativeFunc{ref: ref}), do: ref
+  def unwrap(%Userdata{ref: ref}), do: ref
+  def unwrap(other), do: other
+
+  @doc """
+  Wraps a single eval-result value for display.
+
+  See `wrap_results/3` for the decode-mode matrix.
+  """
+  @spec wrap_value(term(), State.t(), boolean()) :: term()
+  def wrap_value(value, state, decode?)
+
+  # decode: true — only wrap closures/native; tables and userdata
+  # have already been decoded and are passed through unchanged.
+  def wrap_value({:lua_closure, _, _} = ref, _state, _decode?) do
+    wrap_closure(ref)
+  end
+
+  def wrap_value({:native_func, fun} = ref, _state, _decode?) do
+    %NativeFunc{fun: fun, ref: ref}
+  end
+
+  # decode: false — wrap tref/udref too, and recurse into table peek.
+  def wrap_value({:tref, id} = ref, state, false) do
+    peek = peek_table(state, id, false)
+    %DTable{id: id, peek: peek, ref: ref}
+  end
+
+  def wrap_value({:udref, id} = ref, state, false) do
+    term = State.get_userdata(state, ref)
+    %Userdata{id: id, term: term, ref: ref}
+  end
+
+  # decode: true catch-all (already-decoded values pass through)
+  def wrap_value(value, _state, _decode?), do: value
+
+  # ---- internal helpers ----
+
+  defp wrap_closure({:lua_closure, proto, _upvalues} = ref) do
+    {first_line, _last_line} = proto.lines || {0, 0}
+
+    %Closure{
+      source: proto.source,
+      line: first_line,
+      arity: proto.param_count,
+      vararg?: proto.is_vararg,
+      ref: ref
+    }
+  end
+
+  # Build a `peek` value for an unencoded table reference. Sequences
+  # (1..N keys) render as a list; mixed-key tables render as a map.
+  # Nested tables/closures are recursively wrapped so `Inspect` does
+  # not have to know about live VM state.
+  defp peek_table(state, id, decode?) do
+    case Map.fetch(state.tables, id) do
+      {:ok, table} ->
+        data = table.data
+
+        if sequence_like?(data) do
+          Enum.map(1..map_size(data), &wrap_value(Map.fetch!(data, &1), state, decode?))
+        else
+          Map.new(data, fn {k, v} -> {k, wrap_value(v, state, decode?)} end)
+        end
+
+      :error ->
+        # Stale or detached reference. Render an empty peek rather
+        # than crashing — the `id` field is enough to identify it.
+        []
+    end
+  end
+
+  defp sequence_like?(data) when map_size(data) == 0, do: false
+
+  defp sequence_like?(data) do
+    Enum.all?(1..map_size(data), &Map.has_key?(data, &1))
+  end
+end

--- a/lib/lua/vm/display/closure.ex
+++ b/lib/lua/vm/display/closure.ex
@@ -1,0 +1,57 @@
+defmodule Lua.VM.Display.Closure do
+  @moduledoc """
+  Display wrapper for a Lua closure (`{:lua_closure, proto, upvalues}`)
+  returned across the `Lua.eval/2` / `Lua.eval!/2` boundary.
+
+  Carries the closure's source, line, and arity for human display.
+  The wrap fires in both `decode: true` and `decode: false` modes
+  because raw closure tuples have always leaked to the user.
+
+  ## Fields
+
+  - `:source` — source name attached to the closure's prototype
+    (for example `"<eval>"` or `"my_script.lua"`).
+  - `:line` — first line of the closure's body, derived from the
+    prototype's `:lines` field.
+  - `:arity` — the number of declared parameters. Variadic closures
+    have `:arity` equal to the fixed-parameter count; the variadic
+    flag is reflected by appending `+...` in the inspect output.
+  - `:vararg?` — true when the closure accepts varargs (`...`).
+  - `:ref` — the original `{:lua_closure, proto, upvalues}` tuple
+    so callers can still reach the live closure (for example via
+    `Lua.call_function/3`).
+
+  Internal pattern matches against `{:lua_closure, _, _}` are
+  unaffected; the wrap is a display affordance applied at the eval
+  boundary only.
+  """
+
+  @type t :: %__MODULE__{
+          source: binary(),
+          line: non_neg_integer(),
+          arity: non_neg_integer(),
+          vararg?: boolean(),
+          ref: tuple()
+        }
+
+  defstruct [:source, :line, :arity, :vararg?, :ref]
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%Lua.VM.Display.Closure{} = c, opts) do
+      arity = Integer.to_string(c.arity || 0)
+      arity = if c.vararg?, do: arity <> "+...", else: arity
+
+      concat([
+        "#Lua.Closure<source: ",
+        to_doc(c.source, opts),
+        ", line: ",
+        Integer.to_string(c.line || 0),
+        ", arity: ",
+        arity,
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/lua/vm/display/native_func.ex
+++ b/lib/lua/vm/display/native_func.ex
@@ -1,0 +1,41 @@
+defmodule Lua.VM.Display.NativeFunc do
+  @moduledoc """
+  Display wrapper for a native Elixir-backed Lua function
+  (`{:native_func, fun}`) returned across the `Lua.eval/2` /
+  `Lua.eval!/2` boundary.
+
+  Carries the underlying function so the `Inspect` impl can render
+  the captured `module/function/arity`, falling back to the fun's
+  default inspect output for anonymous functions.
+
+  ## Fields
+
+  - `:fun` — the Elixir function passed to `Lua.set!/3` or installed
+    via `deflua`.
+  - `:ref` — the original `{:native_func, fun}` tuple so callers can
+    still pass it back to `Lua.call_function/3`.
+
+  The wrap fires in both `decode: true` and `decode: false` modes —
+  raw `{:native_func, fun}` tuples have always leaked to the user.
+  Internal pattern matches against `{:native_func, _}` are unaffected.
+  """
+
+  @type t :: %__MODULE__{
+          fun: function(),
+          ref: tuple()
+        }
+
+  defstruct [:fun, :ref]
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%Lua.VM.Display.NativeFunc{fun: fun}, opts) do
+      concat([
+        "#Lua.NativeFunc<",
+        to_doc(fun, opts),
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/lua/vm/display/table.ex
+++ b/lib/lua/vm/display/table.ex
@@ -1,0 +1,47 @@
+defmodule Lua.VM.Display.Table do
+  @moduledoc """
+  Display wrapper for a Lua table reference returned across the
+  `Lua.eval/2` / `Lua.eval!/2` boundary in `decode: false` mode.
+
+  Carries a snapshot of the table's contents (`:peek`) so the
+  `Inspect` impl does not need access to live VM state. The wrap is
+  a display affordance only — internally the VM still uses the
+  `{:tref, id}` tuple, and pattern-matches against that tag remain
+  the supported way to detect a table reference.
+
+  ## Fields
+
+  - `:id` — the integer id of the underlying `{:tref, id}` reference.
+  - `:peek` — a snapshot of the table's data as it was at the time
+    the eval boundary was crossed, suitable for human display. May
+    be a list (sequence-like tables) or a map (mixed-key tables).
+    Truncated to `Inspect.Opts.limit` entries when rendered.
+  - `:ref` — the original `{:tref, id}` tuple so callers can
+    round-trip the value back into the VM (via `Lua.set!/3`,
+    `Lua.encode!/2`, etc.).
+
+  See `Lua.eval!/3` and the `decode:` option.
+  """
+
+  @type t :: %__MODULE__{
+          id: non_neg_integer(),
+          peek: list() | map(),
+          ref: tuple()
+        }
+
+  defstruct [:id, :peek, :ref]
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%Lua.VM.Display.Table{id: id, peek: peek}, opts) do
+      concat([
+        "#Lua.Table<id: ",
+        Integer.to_string(id),
+        ", ",
+        to_doc(peek, opts),
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/lua/vm/display/userdata.ex
+++ b/lib/lua/vm/display/userdata.ex
@@ -1,0 +1,44 @@
+defmodule Lua.VM.Display.Userdata do
+  @moduledoc """
+  Display wrapper for a Lua userdata reference (`{:udref, id}`)
+  returned across the `Lua.eval/2` / `Lua.eval!/2` boundary in
+  `decode: false` mode.
+
+  Default `decode: true` returns `{:userdata, term}` and is unaffected
+  by this wrap.
+
+  ## Fields
+
+  - `:id` — the integer id of the underlying `{:udref, id}` reference.
+  - `:term` — the wrapped Elixir term, looked up at the time the eval
+    boundary was crossed.
+  - `:ref` — the original `{:udref, id}` tuple so callers can
+    round-trip the value back into the VM (via `Lua.set!/3`,
+    `Lua.encode!/2`, etc.).
+
+  Internal pattern matches against `{:udref, _}` are unaffected; the
+  wrap is a display affordance applied at the eval boundary only.
+  """
+
+  @type t :: %__MODULE__{
+          id: non_neg_integer(),
+          term: term(),
+          ref: tuple()
+        }
+
+  defstruct [:id, :term, :ref]
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%Lua.VM.Display.Userdata{id: id, term: term}, opts) do
+      concat([
+        "#Lua.Userdata<id: ",
+        Integer.to_string(id),
+        ", term: ",
+        to_doc(term, opts),
+        ">"
+      ])
+    end
+  end
+end

--- a/test/lua/util_test.exs
+++ b/test/lua/util_test.exs
@@ -23,7 +23,9 @@ defmodule Lua.UtilTest do
       {func, _lua} = Lua.encode!(Lua.new(), fn a -> a end)
       assert Lua.Util.encoded?(func)
 
-      # Lua closure
+      # Lua closure — eval/eval! wraps closures in `Lua.VM.Display.Closure`
+      # for friendly inspect output. `Util.encoded?/1` operates on the
+      # raw VM tags, so unwrap before checking.
       {[closure], _lua} =
         Lua.eval!(
           """
@@ -36,7 +38,7 @@ defmodule Lua.UtilTest do
           decode: false
         )
 
-      assert Lua.Util.encoded?(closure)
+      assert Lua.Util.encoded?(Lua.unwrap(closure))
     end
 
     test "returns false for non decoded values" do

--- a/test/lua/vm/display_test.exs
+++ b/test/lua/vm/display_test.exs
@@ -1,0 +1,269 @@
+defmodule Lua.VM.DisplayTest do
+  @moduledoc """
+  Inspect protocol for VM values surfaced at the `Lua.eval/2` /
+  `Lua.eval!/2` boundary.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.VM.Display
+  alias Lua.VM.Display.Closure
+  alias Lua.VM.Display.NativeFunc
+  alias Lua.VM.Display.Table, as: DTable
+  alias Lua.VM.Display.Userdata
+
+  describe "Lua.VM.Display.Table inspect" do
+    test "renders a sequence-like table as a list" do
+      {[t], _} = Lua.eval!(Lua.new(), "return {10, 20, 30}", decode: false)
+
+      assert %DTable{id: id, peek: [10, 20, 30]} = t
+      assert is_integer(id)
+      assert inspect(t) == "#Lua.Table<id: #{id}, [10, 20, 30]>"
+    end
+
+    test "renders a mixed-key table as a map" do
+      {[t], _} = Lua.eval!(Lua.new(), "return {a = 1, b = 2}", decode: false)
+
+      assert %DTable{peek: peek} = t
+      assert peek == %{"a" => 1, "b" => 2}
+      assert inspect(t) =~ ~r/^#Lua\.Table<id: \d+, %\{"a" => 1, "b" => 2\}>$/
+    end
+
+    test "stores the underlying tref on :ref so Lua.unwrap recovers it" do
+      {[t], _} = Lua.eval!(Lua.new(), "return {}", decode: false)
+
+      assert match?({:tref, _}, Lua.unwrap(t))
+      assert Lua.unwrap(t) == t.ref
+    end
+
+    test "renders empty tables" do
+      {[t], _} = Lua.eval!(Lua.new(), "return {}", decode: false)
+
+      assert %DTable{peek: peek} = t
+      # Empty table renders as the underlying empty map, since it is
+      # not sequence-like.
+      assert peek == %{}
+      assert inspect(t) =~ "#Lua.Table<id: "
+    end
+
+    test "respects Inspect.Opts (limit truncates large peeks)" do
+      {[t], _} =
+        Lua.eval!(
+          Lua.new(),
+          "local t = {}; for i = 1, 50 do t[i] = i end; return t",
+          decode: false
+        )
+
+      tight = inspect(t, limit: 5)
+      loose = inspect(t, limit: 50)
+
+      # The tight render must show a truncation marker; the loose
+      # render shows everything and is therefore strictly longer.
+      assert tight =~ "..."
+      assert byte_size(tight) < byte_size(loose)
+    end
+  end
+
+  describe "Lua.VM.Display.Closure inspect" do
+    test "wraps Lua closures returned in default decode mode" do
+      {[c], _} = Lua.eval!(Lua.new(), "return function(a, b) return a + b end")
+
+      assert %Closure{
+               source: "<eval>",
+               line: 1,
+               arity: 2,
+               vararg?: false,
+               ref: {:lua_closure, _, _}
+             } = c
+
+      assert inspect(c) == "#Lua.Closure<source: \"<eval>\", line: 1, arity: 2>"
+    end
+
+    test "wraps Lua closures returned in decode: false mode" do
+      {[c], _} = Lua.eval!(Lua.new(), "return function() end", decode: false)
+
+      assert %Closure{ref: {:lua_closure, _, _}} = c
+      assert inspect(c) =~ "#Lua.Closure<"
+    end
+
+    test "marks variadic closures with +..." do
+      {[c], _} = Lua.eval!(Lua.new(), "return function(a, ...) return a end")
+
+      assert %Closure{arity: 1, vararg?: true} = c
+      assert inspect(c) =~ "arity: 1+..."
+    end
+
+    test "honours custom :source from the eval option" do
+      {[c], _} =
+        Lua.eval!(
+          Lua.new(),
+          "return function() end",
+          source: "my_script.lua"
+        )
+
+      assert %Closure{source: "my_script.lua"} = c
+      assert inspect(c) =~ ~s|source: "my_script.lua"|
+    end
+  end
+
+  describe "Lua.VM.Display.NativeFunc inspect" do
+    test "wraps native functions returned in default decode mode" do
+      {[f], _} = Lua.eval!(Lua.new(), "return string.lower")
+
+      assert %NativeFunc{ref: {:native_func, _}} = f
+      assert inspect(f) =~ "#Lua.NativeFunc<"
+    end
+
+    test "wraps user-defined Elixir functions installed via Lua.set!/3" do
+      lua = Lua.set!(Lua.new(), [:double], fn [n] -> [n * 2] end)
+      {[f], _} = Lua.eval!(lua, "return double")
+
+      assert %NativeFunc{ref: {:native_func, _}} = f
+      assert inspect(f) =~ "#Lua.NativeFunc<"
+    end
+  end
+
+  describe "Lua.VM.Display.Userdata inspect" do
+    test "wraps userdata refs in decode: false mode" do
+      lua = Lua.set!(Lua.new(), [:opaque], {:userdata, %{secret: 42}})
+      {[u], _} = Lua.eval!(lua, "return opaque", decode: false)
+
+      assert %Userdata{
+               id: id,
+               term: %{secret: 42},
+               ref: {:udref, _}
+             } = u
+
+      assert is_integer(id)
+      assert inspect(u) =~ "#Lua.Userdata<id: #{id}, term: %{secret: 42}>"
+    end
+
+    test "default decode preserves the legacy {:userdata, term} shape" do
+      lua = Lua.set!(Lua.new(), [:opaque], {:userdata, :marker})
+      {[u], _} = Lua.eval!(lua, "return opaque")
+
+      # decode: true is the default. Userdata stays as the
+      # backwards-compatible {:userdata, term} tuple.
+      assert u == {:userdata, :marker}
+    end
+  end
+
+  describe "Lua.unwrap/1" do
+    test "returns the underlying tref for tables" do
+      {[t], _} = Lua.eval!(Lua.new(), "return {1}", decode: false)
+
+      assert match?({:tref, _}, Lua.unwrap(t))
+    end
+
+    test "returns the underlying lua_closure for closures" do
+      {[c], _} = Lua.eval!(Lua.new(), "return function() end")
+
+      assert match?({:lua_closure, _, _}, Lua.unwrap(c))
+    end
+
+    test "returns the underlying native_func for native funcs" do
+      {[f], _} = Lua.eval!(Lua.new(), "return string.lower")
+
+      assert match?({:native_func, _}, Lua.unwrap(f))
+    end
+
+    test "returns the underlying udref for userdata" do
+      lua = Lua.set!(Lua.new(), [:opaque], {:userdata, :anything})
+      {[u], _} = Lua.eval!(lua, "return opaque", decode: false)
+
+      assert match?({:udref, _}, Lua.unwrap(u))
+    end
+
+    test "passes plain values through unchanged" do
+      assert Lua.unwrap(42) == 42
+      assert Lua.unwrap("hello") == "hello"
+      assert Lua.unwrap(nil) == nil
+      assert Lua.unwrap({:tref, 7}) == {:tref, 7}
+    end
+  end
+
+  describe "round-tripping wrapped values back into the VM" do
+    test "Lua.set!/3 accepts a wrapped table" do
+      {[t], lua} = Lua.eval!(Lua.new(), "return {a = 1}", decode: false)
+      lua = Lua.set!(lua, [:saved], t)
+
+      assert {[1], _} = Lua.eval!(lua, "return saved.a")
+    end
+
+    test "Lua.set!/3 accepts a wrapped closure" do
+      {[c], lua} = Lua.eval!(Lua.new(), "return function(x) return x + 1 end")
+      lua = Lua.set!(lua, [:f], c)
+
+      assert {[6], _} = Lua.eval!(lua, "return f(5)")
+    end
+
+    test "Lua.call_function/3 accepts a wrapped closure" do
+      {[c], lua} = Lua.eval!(Lua.new(), "return function(x) return x * 3 end")
+
+      assert {:ok, [21], _} = Lua.call_function(lua, c, [7])
+    end
+
+    test "Lua.call_function/3 accepts a wrapped native func" do
+      {[f], lua} = Lua.eval!(Lua.new(), "return string.upper")
+
+      assert {:ok, ["HELLO"], _} = Lua.call_function(lua, f, ["hello"])
+    end
+
+    test "Lua.encode!/2 accepts a wrapped value" do
+      {[t], lua} = Lua.eval!(Lua.new(), "return {1, 2}", decode: false)
+      assert {{:tref, _}, _} = Lua.encode!(lua, t)
+    end
+
+    test "Lua.decode!/2 accepts a wrapped value" do
+      {[t], lua} = Lua.eval!(Lua.new(), "return {1, 2}", decode: false)
+      decoded = Lua.decode!(lua, t)
+
+      assert Enum.sort(decoded) == [{1, 1}, {2, 2}]
+    end
+  end
+
+  describe "Lua.VM.Display.display_struct?/1" do
+    test "recognises every display struct" do
+      assert Display.display_struct?(%DTable{id: 0, peek: [], ref: {:tref, 0}})
+      assert Display.display_struct?(%Userdata{id: 0, term: nil, ref: {:udref, 0}})
+
+      assert Display.display_struct?(%Closure{
+               source: "x",
+               line: 0,
+               arity: 0,
+               vararg?: false,
+               ref: {:lua_closure, nil, nil}
+             })
+
+      assert Display.display_struct?(%NativeFunc{
+               fun: fn _, s -> {[], s} end,
+               ref: {:native_func, fn _, s -> {[], s} end}
+             })
+    end
+
+    test "rejects ordinary values" do
+      refute Display.display_struct?(42)
+      refute Display.display_struct?("hello")
+      refute Display.display_struct?({:tref, 0})
+      refute Display.display_struct?({:lua_closure, nil, nil})
+      refute Display.display_struct?({:native_func, fn _, _ -> nil end})
+      refute Display.display_struct?({:udref, 0})
+    end
+  end
+
+  describe "no regression for default decode" do
+    test "tables still come back as a list of {key, value} tuples" do
+      {[result], _} = Lua.eval!(Lua.new(), "return {a = 1, b = 2}")
+
+      assert is_list(result)
+      assert Enum.sort(result) == [{"a", 1}, {"b", 2}]
+    end
+
+    test "userdata still comes back as {:userdata, term}" do
+      lua = Lua.set!(Lua.new(), [:opaque], {:userdata, %{x: 1}})
+      {[result], _} = Lua.eval!(lua, "return opaque")
+
+      assert result == {:userdata, %{x: 1}}
+    end
+  end
+end

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -328,7 +328,13 @@ defmodule LuaTest do
       {[decoded], _} = Lua.eval!(chunk, decode: true)
       assert Enum.sort(decoded) == [{"a", 1}, {"b", 2}]
 
-      assert {[{:tref, _}], _} = Lua.eval!(chunk, decode: false)
+      # decode: false now wraps tref in a `Lua.VM.Display.Table` for
+      # friendly inspect output. The underlying ref is preserved on
+      # the struct and reachable via `Lua.unwrap/1`.
+      assert {[%Lua.VM.Display.Table{ref: {:tref, _}} = wrapped], _} =
+               Lua.eval!(chunk, decode: false)
+
+      assert match?({:tref, _}, Lua.unwrap(wrapped))
     end
 
     test "invalid functions raise" do


### PR DESCRIPTION
## Inspect protocol for VM values

Plan: [`.agents/plans/A27-inspect-protocol.md`](.agents/plans/A27-inspect-protocol.md)

### Goal

Implement `Inspect` for the four opaque VM value tags so `iex` shows
something useful instead of a tuple soup. Today, a `{:tref, 7}` in
the iex output tells the user nothing about what's in the table; a
`{:lua_closure, _, _}` tells them nothing about the function.

Targets:

- `{:tref, integer()}` — table reference. Renders contents (or
  a short summary if large) and the table id.
- `{:lua_closure, _proto, _upvalues}` — Lua function. Renders
  source location and arity (with `+...` for varargs).
- `{:native_func, fun}` — Elixir-defined Lua callable. Renders
  module/function/arity via the function's own inspect output.
- `{:udref, integer()}` — userdata reference. Renders the
  underlying Elixir term and the udref id.

### Approach: boundary wrap

When a Lua value crosses out to Elixir (`Lua.eval/2` / `Lua.eval!/2`
return path), wrap each VM tag in a thin display struct. The struct
exists *only* for outbound display; internally the VM still uses the
tagged-tuple form, and pattern matches against `{:tref, _}` etc.
inside the VM are unaffected.

Module layout:

- `Lua.VM.Display.Table` — `[:id, :peek, :ref]`
- `Lua.VM.Display.Closure` — `[:source, :line, :arity, :vararg?, :ref]`
- `Lua.VM.Display.NativeFunc` — `[:fun, :ref]`
- `Lua.VM.Display.Userdata` — `[:id, :term, :ref]`

The display structs each carry the original VM tag tuple on `:ref`, so
callers can round-trip the value back into the VM. `Lua.set!/3`,
`Lua.encode!/2`, `Lua.decode!/2`, and `Lua.call_function/3` all
unwrap display structs at their entry points so wrapped values flow
back through the public API without ceremony. A new public
`Lua.unwrap/1` helper exposes the underlying tuple for any caller
that needs it directly.

### Decode-mode matrix

| tag                  | `decode: true` (default)        | `decode: false`              |
|----------------------|---------------------------------|------------------------------|
| `{:tref, _}`         | unchanged (list of tuples)      | `%Lua.VM.Display.Table{}`    |
| `{:udref, _}`        | unchanged (`{:userdata, term}`) | `%Lua.VM.Display.Userdata{}` |
| `{:lua_closure, _, _}` | `%Lua.VM.Display.Closure{}`   | `%Lua.VM.Display.Closure{}`  |
| `{:native_func, _}`  | `%Lua.VM.Display.NativeFunc{}`  | `%Lua.VM.Display.NativeFunc{}` |

Default-decode tables and userdata keep their existing
Elixir-friendly shapes (list of `{k, v}` tuples and
`{:userdata, term}`) so `deflua` flows and existing doctests are
unaffected. Closures and native funcs are wrapped in *both* modes
because their default decoded form has always been the raw tuple.
Two pre-existing tests pattern-matching on `{:tref, _}` from
`decode: false` were updated to match the new `%Lua.VM.Display.Table{}`
shape (and exercise `Lua.unwrap/1`).

### Success criteria

- [x] `Lua.eval!(Lua.new(), "return {1, 2, 3}", decode: false)` shows
      `#Lua.Table<id: 11, [1, 2, 3]>` instead of `{:tref, 11}`. Verified
      manually and in `test/lua/vm/display_test.exs`.
- [x] Closures render as `#Lua.Closure<source: "<eval>", line: 1, arity: 2>`
      (and `arity: N+...` for variadics) in both decode modes.
- [x] Native funcs render as `#Lua.NativeFunc<#Function<...>>` in both
      decode modes.
- [x] `Lua.eval!(lua, "return opaque", decode: false)` for a userdata
      shows `#Lua.Userdata<id: 0, term: %{secret: 42}>`.
- [x] Inspect output respects `Inspect.Opts` — large table peeks
      truncate to `:limit`, and `to_doc/2` is used for nested values.
- [x] No regression in default-decode shape: tables stay as
      list-of-tuples; `{:userdata, term}` is preserved.
- [x] `mix test` passes (1654 tests, 0 failures, +28 from
      `test/lua/vm/display_test.exs`).

### Manual verification

```elixir
iex> {[t], _} = Lua.eval!(Lua.new(), "return {1, 2, 3}", decode: false)
iex> t
#Lua.Table<id: 11, [1, 2, 3]>

iex> {[t], _} = Lua.eval!(Lua.new(), "return {a = 1, b = 2}", decode: false)
iex> t
#Lua.Table<id: 11, %{"a" => 1, "b" => 2}>

iex> {[c], _} = Lua.eval!(Lua.new(), "return function(a, b) return a + b end")
iex> c
#Lua.Closure<source: "<eval>", line: 1, arity: 2>

iex> {[c], _} = Lua.eval!(Lua.new(), "return function(a, ...) return a end")
iex> c
#Lua.Closure<source: "<eval>", line: 1, arity: 1+...>

iex> {[f], _} = Lua.eval!(Lua.new(), "return string.lower")
iex> f
#Lua.NativeFunc<#Function<1.12573577/2 in Lua.VM.Stdlib.String.string_lower>>

iex> lua = Lua.set!(Lua.new(), [:opaque], {:userdata, %{secret: 42}})
iex> {[u], _} = Lua.eval!(lua, "return opaque", decode: false)
iex> u
#Lua.Userdata<id: 0, term: %{secret: 42}>
```

### Changes

```
 .agents/plans/A27-inspect-protocol.md | 124 ++++++++++++----
 lib/lua.ex                            |  50 ++++++-
 lib/lua/vm/display.ex                 | 159 ++++++++++++++++++++
 lib/lua/vm/display/closure.ex         |  57 +++++++
 lib/lua/vm/display/native_func.ex     |  41 ++++++
 lib/lua/vm/display/table.ex           |  47 ++++++
 lib/lua/vm/display/userdata.ex        |  44 ++++++
 test/lua/util_test.exs                |   6 +-
 test/lua/vm/display_test.exs          | 269 ++++++++++++++++++++++++++++++++++
 test/lua_test.exs                     |   8 +-
 10 files changed, 771 insertions(+), 34 deletions(-)
```

### Verification

```
$ mix format
$ mix compile --warnings-as-errors
Generated lua app

$ mix test
55 doctests, 51 properties, 1654 tests, 0 failures, 30 skipped

$ mix test --only lua53
29 tests, 0 failures, 23 skipped (1731 excluded)
```

### Discoveries

- `Lua.Table` already exists as a public utility module (for casting
  decoded tables to lists/maps). Display structs live under
  `Lua.VM.Display.*` to make the namespace clear and avoid collisions.
  Inspect output still uses the short forms (`#Lua.Table<...>`,
  `#Lua.Closure<...>`, etc.) regardless of full module path.
- Closures need source/line/arity for human display. The existing
  `Lua.Compiler.Prototype` struct carries `:source`, `:lines` (a
  `{first, last}` tuple), `:param_count`, and `:is_vararg` — the
  display wrap reads from those four fields, no proto changes needed.
- Round-trip support (`Lua.set!/3`, `Lua.encode!/2`, etc.) had to be
  added to keep the wrap transparent for existing flows. The cleanest
  fix was a single `Display.unwrap/1` call at each public-API entry
  point, plus an opportunistic `Util.encoded?/1` shortcut in `encode!`
  to handle the case where the unwrapped value is already a raw VM tag.

### Out of scope (intentional)

- Changing the internal tuple representation. The wrap is a display
  affordance, not a data-model change.
- Pretty-printing for very large tables beyond `Inspect.Opts.limit`
  truncation. The peek caps at `:limit` entries and shows `…` for
  the rest.
- `Lua.dbg/2` helper — that's plan A28.
- Wrapping userdata in default `decode: true` mode (would change the
  existing `{:userdata, term}` API; out of scope by design).