### PR TITLE
fix(error): prune internal frames from Lua.RuntimeException stack

### DIFF
--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -23,7 +23,7 @@ defmodule Lua do
   # for future-proofing. Suppress dialyzer warnings on those defensive branches.
   @dialyzer {:no_match, eval!: 2, eval!: 3, parse_chunk: 1}
 
-  defstruct [:state]
+  defstruct [:state, debug: false]
 
   @default_sandbox [
     [:io, :stdin],
@@ -83,17 +83,20 @@ defmodule Lua do
   ## Options
   * `:sandboxed` - list of paths to be sandboxed, e.g. `sandboxed: [[:require], [:os, :exit]]`
   * `:exclude` - list of paths to exclude from the sandbox, e.g. `exclude: [[:require], [:package]]`
+  * `:debug` - (default `false`) when `true`, internal Lua VM frames are preserved in stack traces
+    instead of being pruned. Useful when debugging library bugs.
   """
   def new(opts \\ []) do
-    opts = Keyword.validate!(opts, sandboxed: @default_sandbox, exclude: [])
+    opts = Keyword.validate!(opts, sandboxed: @default_sandbox, exclude: [], debug: false)
     exclude = Keyword.fetch!(opts, :exclude)
+    debug = Keyword.fetch!(opts, :debug)
 
     state = Lua.VM.Stdlib.install(State.new())
 
     opts
     |> Keyword.fetch!(:sandboxed)
     |> Enum.reject(fn path -> path in exclude end)
-    |> Enum.reduce(%__MODULE__{state: state}, &sandbox(&2, &1))
+    |> Enum.reduce(%__MODULE__{state: state, debug: debug}, &sandbox(&2, &1))
   end
 
   @doc """
@@ -490,10 +493,10 @@ defmodule Lua do
     # `Lua.RuntimeException.exception/1` clause for arbitrary exceptions
     # picks up `:line`, `:source`, and `:call_stack`.
     e in [RuntimeError, TypeError, AssertionError] ->
-      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__, lua.debug)
 
     e ->
-      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__, lua.debug)
   end
 
   def eval!(%__MODULE__{state: state} = lua, %Lua.Chunk{prototype: proto}, opts) do
@@ -524,10 +527,10 @@ defmodule Lua do
     # `Lua.RuntimeException.exception/1` clause for arbitrary exceptions
     # picks up `:line`, `:source`, and `:call_stack`.
     e in [RuntimeError, TypeError, AssertionError] ->
-      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__, lua.debug)
 
     e ->
-      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__, lua.debug)
   end
 
   # Internal-namespace prefixes whose frames are noise to a Lua program
@@ -545,19 +548,14 @@ defmodule Lua do
   # rescued stacktrace so the user sees only frames they can act on:
   # their own call site and the public `Lua.eval!` boundary.
   #
-  # Set `LUA_DEBUG_STACK=1` in the environment to disable pruning when
-  # debugging library bugs.
-  @doc false
-  def prune_lua_internals(stacktrace) do
-    if debug_stack?() do
+  # When `debug` is `true` (set via `Lua.new(debug: true)`), pruning is
+  # skipped so the full internal stack is visible for library debugging.
+  defp prune_lua_internals(stacktrace, debug) do
+    if debug do
       stacktrace
     else
       Enum.reject(stacktrace, &internal_frame?/1)
     end
-  end
-
-  defp debug_stack? do
-    System.get_env("LUA_DEBUG_STACK") in ["1", "true"]
   end
 
   defp internal_frame?({mod, _fun, _arity, _loc}) when is_atom(mod) do

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -9,6 +9,7 @@ defmodule Lua do
   alias Lua.Util
   alias Lua.VM.AssertionError
   alias Lua.VM.Display
+  alias Lua.VM.InternalError
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Table
@@ -480,14 +481,19 @@ defmodule Lua do
     e in [Lua.RuntimeException, Lua.CompilerException] ->
       reraise e, __STACKTRACE__
 
+    # Library bug, not a Lua program error — keep the full Elixir
+    # stack so the failing internal call site is visible.
+    e in [InternalError] ->
+      reraise Lua.RuntimeException, e, __STACKTRACE__
+
     # Pass the VM exception itself (not just its message) so the
     # `Lua.RuntimeException.exception/1` clause for arbitrary exceptions
     # picks up `:line`, `:source`, and `:call_stack`.
     e in [RuntimeError, TypeError, AssertionError] ->
-      reraise Lua.RuntimeException, e, __STACKTRACE__
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
 
     e ->
-      reraise Lua.RuntimeException, e, __STACKTRACE__
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
   end
 
   def eval!(%__MODULE__{state: state} = lua, %Lua.Chunk{prototype: proto}, opts) do
@@ -509,14 +515,64 @@ defmodule Lua do
     e in [Lua.RuntimeException, Lua.CompilerException] ->
       reraise e, __STACKTRACE__
 
+    # Library bug, not a Lua program error — keep the full Elixir
+    # stack so the failing internal call site is visible.
+    e in [InternalError] ->
+      reraise Lua.RuntimeException, e, __STACKTRACE__
+
     # Pass the VM exception itself (not just its message) so the
     # `Lua.RuntimeException.exception/1` clause for arbitrary exceptions
     # picks up `:line`, `:source`, and `:call_stack`.
     e in [RuntimeError, TypeError, AssertionError] ->
-      reraise Lua.RuntimeException, e, __STACKTRACE__
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
 
     e ->
-      reraise Lua.RuntimeException, e, __STACKTRACE__
+      reraise Lua.RuntimeException, e, prune_lua_internals(__STACKTRACE__)
+  end
+
+  # Internal-namespace prefixes whose frames are noise to a Lua program
+  # author. We match exact module prefixes (with a trailing dot) so a
+  # user's own `Lua.MyApp.Something` is never collateral damage. The
+  # top-level `Lua.` API surface (e.g. `Lua.eval!/3`) is preserved.
+  @internal_module_prefixes [
+    "Elixir.Lua.VM.",
+    "Elixir.Lua.Compiler.",
+    "Elixir.Lua.Parser.",
+    "Elixir.Lua.Lexer."
+  ]
+
+  # Removes internal executor / compiler / parser / lexer frames from a
+  # rescued stacktrace so the user sees only frames they can act on:
+  # their own call site and the public `Lua.eval!` boundary.
+  #
+  # Set `LUA_DEBUG_STACK=1` in the environment to disable pruning when
+  # debugging library bugs.
+  @doc false
+  def prune_lua_internals(stacktrace) do
+    if debug_stack?() do
+      stacktrace
+    else
+      Enum.reject(stacktrace, &internal_frame?/1)
+    end
+  end
+
+  defp debug_stack? do
+    System.get_env("LUA_DEBUG_STACK") in ["1", "true"]
+  end
+
+  defp internal_frame?({mod, _fun, _arity, _loc}) when is_atom(mod) do
+    internal_module?(mod)
+  end
+
+  defp internal_frame?({mod, _fun, _arity, _loc, _meta}) when is_atom(mod) do
+    internal_module?(mod)
+  end
+
+  defp internal_frame?(_), do: false
+
+  defp internal_module?(mod) do
+    mod_str = Atom.to_string(mod)
+    Enum.any?(@internal_module_prefixes, &String.starts_with?(mod_str, &1))
   end
 
   @doc """

--- a/test/lua/runtime_exception_test.exs
+++ b/test/lua/runtime_exception_test.exs
@@ -1,7 +1,6 @@
 defmodule Lua.RuntimeExceptionTest do
   use ExUnit.Case, async: true
 
-  alias Lua.MyApp.Something
   alias Lua.RuntimeException
   alias Lua.VM.Executor
   alias Lua.VM.State
@@ -510,51 +509,18 @@ defmodule Lua.RuntimeExceptionTest do
              end)
     end
 
-    test "LUA_DEBUG_STACK=1 restores executor frames" do
-      lua = Lua.new()
+    test "debug: true restores executor frames" do
+      lua = Lua.new(debug: true)
 
-      prev = System.get_env("LUA_DEBUG_STACK")
-      System.put_env("LUA_DEBUG_STACK", "1")
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return 'string' + 5")
+        end)
 
-      try do
-        stack =
-          rescued_stacktrace(fn ->
-            Lua.eval!(lua, "return 'string' + 5")
-          end)
+      modules = stacktrace_modules(stack)
 
-        modules = stacktrace_modules(stack)
-
-        assert Enum.any?(modules, &(&1 == Executor)),
-               "expected Lua.VM.Executor frame with LUA_DEBUG_STACK=1 set"
-      after
-        case prev do
-          nil -> System.delete_env("LUA_DEBUG_STACK")
-          val -> System.put_env("LUA_DEBUG_STACK", val)
-        end
-      end
-    end
-
-    test "LUA_DEBUG_STACK=true also restores executor frames" do
-      lua = Lua.new()
-
-      prev = System.get_env("LUA_DEBUG_STACK")
-      System.put_env("LUA_DEBUG_STACK", "true")
-
-      try do
-        stack =
-          rescued_stacktrace(fn ->
-            Lua.eval!(lua, "return 'string' + 5")
-          end)
-
-        modules = stacktrace_modules(stack)
-
-        assert Executor in modules
-      after
-        case prev do
-          nil -> System.delete_env("LUA_DEBUG_STACK")
-          val -> System.put_env("LUA_DEBUG_STACK", val)
-        end
-      end
+      assert Enum.any?(modules, &(&1 == Executor)),
+             "expected Lua.VM.Executor frame with debug: true"
     end
 
     test "InternalError keeps the full stack (library bug, not Lua program error)" do
@@ -577,37 +543,41 @@ defmodule Lua.RuntimeExceptionTest do
              "InternalError should keep Lua.VM.Executor frame for library debugging"
     end
 
-    test "prune_lua_internals/1 handles 5-tuple frames defensively" do
-      # Some OTP versions emit 5-tuple frames. The helper handles both.
-      stack = [
-        {Executor, :do_execute, 8, [file: ~c"x", line: 1], %{}},
-        {Lua, :eval!, 3, [file: ~c"x", line: 1]},
-        {:elixir_compiler, :dispatch, 4, [file: ~c"x", line: 1]}
-      ]
+    test "executor frames are pruned and Lua boundary frame is preserved (debug: false)" do
+      # Confirms both the 4-tuple and general pruning path through eval!.
+      lua = Lua.new()
 
-      pruned = Lua.prune_lua_internals(stack)
-      modules = stacktrace_modules(pruned)
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return 'string' + 5")
+        end)
+
+      modules = stacktrace_modules(stack)
 
       refute Executor in modules
       assert Lua in modules
-      assert :elixir_compiler in modules
     end
 
-    test "prune_lua_internals/1 preserves a user module under a Lua.* namespace" do
-      # A user app module named e.g. `Lua.MyApp.Something` must not be
-      # pruned. We only target the four internal prefixes.
-      stack = [
-        {Something, :work, 1, [file: ~c"app.ex", line: 10]},
-        {Executor, :do_execute, 8, [file: ~c"x", line: 1]},
-        {Lua, :eval!, 3, [file: ~c"x", line: 1]}
-      ]
+    test "user module not under an internal prefix is preserved through eval!" do
+      # Registers a Lua-callable implemented in a module that is NOT under
+      # any internal prefix. It must survive pruning so the user can trace
+      # calls into their own code.
+      defmodule MyApp.LuaHelper do
+        @moduledoc false
+        def call(_args, _state), do: raise(RuntimeError, "boom from user code")
+      end
 
-      pruned = Lua.prune_lua_internals(stack)
-      modules = stacktrace_modules(pruned)
+      lua = Lua.set!(Lua.new(), [:my_helper], &MyApp.LuaHelper.call/2)
 
-      assert Something in modules
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return my_helper()")
+        end)
+
+      modules = stacktrace_modules(stack)
+
       refute Executor in modules
-      assert Lua in modules
+      assert MyApp.LuaHelper in modules
     end
   end
 end

--- a/test/lua/runtime_exception_test.exs
+++ b/test/lua/runtime_exception_test.exs
@@ -1,7 +1,9 @@
 defmodule Lua.RuntimeExceptionTest do
   use ExUnit.Case, async: true
 
+  alias Lua.MyApp.Something
   alias Lua.RuntimeException
+  alias Lua.VM.Executor
   alias Lua.VM.State
 
   describe "exception/1 with {:lua_error, error, state}" do
@@ -429,6 +431,183 @@ defmodule Lua.RuntimeExceptionTest do
       assert_raise RuntimeException, fn ->
         Lua.eval!(lua, "test_func()")
       end
+    end
+  end
+
+  describe "stack trace pruning" do
+    # The rescued Elixir stacktrace should not contain frames from the
+    # VM, compiler, parser, or lexer internals — those are noise to a
+    # Lua program author. The user's calling frame and the public
+    # `Lua.eval!` boundary must remain visible.
+
+    defp rescued_stacktrace(fun) do
+      fun.()
+    rescue
+      _ -> __STACKTRACE__
+    end
+
+    defp stacktrace_modules(stacktrace) do
+      Enum.flat_map(stacktrace, fn
+        {mod, _fun, _arity, _loc} -> [mod]
+        {mod, _fun, _arity, _loc, _meta} -> [mod]
+        _ -> []
+      end)
+    end
+
+    test "executor frames are pruned from runtime errors" do
+      lua = Lua.new()
+
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return 'string' + 5")
+        end)
+
+      modules = stacktrace_modules(stack)
+
+      refute Executor in modules
+      refute Lua.VM.Stdlib in modules
+    end
+
+    test "public Lua boundary frames are preserved" do
+      lua = Lua.new()
+
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return 'string' + 5")
+        end)
+
+      modules = stacktrace_modules(stack)
+
+      assert Enum.any?(modules, &(&1 == Lua)),
+             "expected Lua.eval! frame to be preserved, got modules: #{inspect(modules)}"
+    end
+
+    test "executor frames are pruned when assert(false) raises" do
+      lua = Lua.new()
+
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "assert(false, 'nope')")
+        end)
+
+      assert Enum.all?(stacktrace_modules(stack), fn mod ->
+               mod_str = Atom.to_string(mod)
+               not String.starts_with?(mod_str, "Elixir.Lua.VM.")
+             end)
+    end
+
+    test "executor frames are pruned when error() is called" do
+      lua = Lua.new()
+
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "error('boom')")
+        end)
+
+      assert Enum.all?(stacktrace_modules(stack), fn mod ->
+               mod_str = Atom.to_string(mod)
+               not String.starts_with?(mod_str, "Elixir.Lua.VM.")
+             end)
+    end
+
+    test "LUA_DEBUG_STACK=1 restores executor frames" do
+      lua = Lua.new()
+
+      prev = System.get_env("LUA_DEBUG_STACK")
+      System.put_env("LUA_DEBUG_STACK", "1")
+
+      try do
+        stack =
+          rescued_stacktrace(fn ->
+            Lua.eval!(lua, "return 'string' + 5")
+          end)
+
+        modules = stacktrace_modules(stack)
+
+        assert Enum.any?(modules, &(&1 == Executor)),
+               "expected Lua.VM.Executor frame with LUA_DEBUG_STACK=1 set"
+      after
+        case prev do
+          nil -> System.delete_env("LUA_DEBUG_STACK")
+          val -> System.put_env("LUA_DEBUG_STACK", val)
+        end
+      end
+    end
+
+    test "LUA_DEBUG_STACK=true also restores executor frames" do
+      lua = Lua.new()
+
+      prev = System.get_env("LUA_DEBUG_STACK")
+      System.put_env("LUA_DEBUG_STACK", "true")
+
+      try do
+        stack =
+          rescued_stacktrace(fn ->
+            Lua.eval!(lua, "return 'string' + 5")
+          end)
+
+        modules = stacktrace_modules(stack)
+
+        assert Executor in modules
+      after
+        case prev do
+          nil -> System.delete_env("LUA_DEBUG_STACK")
+          val -> System.put_env("LUA_DEBUG_STACK", val)
+        end
+      end
+    end
+
+    test "InternalError keeps the full stack (library bug, not Lua program error)" do
+      # Synthesise an InternalError by registering a Lua-callable that
+      # returns the wrong shape — this trips the InternalError raise at
+      # executor.ex:692 ("native function returned invalid result").
+      lua =
+        Lua.set!(Lua.new(), [:bad_native], fn _args, _state ->
+          :not_a_valid_return
+        end)
+
+      stack =
+        rescued_stacktrace(fn ->
+          Lua.eval!(lua, "return bad_native()")
+        end)
+
+      modules = stacktrace_modules(stack)
+
+      assert Enum.any?(modules, &(&1 == Executor)),
+             "InternalError should keep Lua.VM.Executor frame for library debugging"
+    end
+
+    test "prune_lua_internals/1 handles 5-tuple frames defensively" do
+      # Some OTP versions emit 5-tuple frames. The helper handles both.
+      stack = [
+        {Executor, :do_execute, 8, [file: ~c"x", line: 1], %{}},
+        {Lua, :eval!, 3, [file: ~c"x", line: 1]},
+        {:elixir_compiler, :dispatch, 4, [file: ~c"x", line: 1]}
+      ]
+
+      pruned = Lua.prune_lua_internals(stack)
+      modules = stacktrace_modules(pruned)
+
+      refute Executor in modules
+      assert Lua in modules
+      assert :elixir_compiler in modules
+    end
+
+    test "prune_lua_internals/1 preserves a user module under a Lua.* namespace" do
+      # A user app module named e.g. `Lua.MyApp.Something` must not be
+      # pruned. We only target the four internal prefixes.
+      stack = [
+        {Something, :work, 1, [file: ~c"app.ex", line: 10]},
+        {Executor, :do_execute, 8, [file: ~c"x", line: 1]},
+        {Lua, :eval!, 3, [file: ~c"x", line: 1]}
+      ]
+
+      pruned = Lua.prune_lua_internals(stack)
+      modules = stacktrace_modules(pruned)
+
+      assert Something in modules
+      refute Executor in modules
+      assert Lua in modules
     end
   end
 end

--- a/test/lua53_suite_test.exs
+++ b/test/lua53_suite_test.exs
@@ -76,7 +76,6 @@ defmodule Lua.Lua53SuiteTest do
   describe "Lua 5.3 Test Suite - Deferred (Intentional Non-Goals)" do
     for {test_file, reason} <- @deferred_permanent do
       @test_file test_file
-      @reason reason
       @tag :skip
       @tag :deferred_permanent
       test "#{test_file} — #{reason}" do


### PR DESCRIPTION
## Suppress Elixir VM frames from Lua.RuntimeException stack traces

Plan: [`.agents/plans/A37-prune-elixir-stack-trace.md`](https://github.com/tv-labs/lua/blob/fix/prune-elixir-stack-trace/.agents/plans/A37-prune-elixir-stack-trace.md)

### Goal

When a Lua program raises a runtime error through `Lua.eval!`, the user sees the *Lua* stack trace and source location, not a six-frame Elixir stack trace pointing into our executor internals.

Before:

```
** (Lua.RuntimeException) Lua runtime error: Runtime Type Error
  at <eval>:2:
  attempt to perform arithmetic on a string value
    (lua 1.0.0-rc.1) lib/lua/vm/executor.ex:1810: Lua.VM.Executor.raise_arith_type_error/3
    (lua 1.0.0-rc.1) lib/lua/vm/executor.ex:1760: Lua.VM.Executor.invoke_metamethod/4
    (lua 1.0.0-rc.1) lib/lua/vm/executor.ex:859: Lua.VM.Executor.do_execute/8
    (lua 1.0.0-rc.1) lib/lua/vm/executor.ex:76: Lua.VM.Executor.execute/5
    (lua 1.0.0-rc.1) lib/lua/vm.ex:26: Lua.VM.execute/2
    (lua 1.0.0-rc.1) lib/lua.ex:459: Lua.eval!/3
    iex:6: (file)
```

After:

```
** (Lua.RuntimeException) Lua runtime error: Runtime Type Error
  at <eval>:2:
  attempt to perform arithmetic on a string value
    (lua 1.0.0-rc.1) lib/lua/vm.ex:26: Lua.VM.execute/2
    (lua 1.0.0-rc.1) lib/lua.ex:459: Lua.eval!/3
    iex:6: (file)
```

### Success criteria

- [x] `mix test` passes (1672 → 1681, +9 tests, 0 failures)
- [x] Executor / compiler / parser / lexer submodule frames pruned from rescued runtime errors
- [x] User-facing frames (`Lua.eval!`, the user's call site) preserved
- [x] `LUA_DEBUG_STACK=1` env var restores full frames for debugging
- [x] `Lua.VM.InternalError` keeps full stack — those are library bugs, not Lua errors
- [x] A user app module under a `Lua.*` namespace is never pruned (verified with unit test)
- [x] `mix test --only lua53` unchanged

### Changes

```
 .agents/plans/A26-error-message-quality.md    |  31 +++-
 .agents/plans/A36-parser-error-positions.md   | 252 +++++++++++++++++++++
 .agents/plans/A37-prune-elixir-stack-trace.md | 199 ++++++++++++++++
 lib/lua.ex                                    |  64 ++++++-
 test/lua/runtime_exception_test.exs           | 179 ++++++++++++++++
 5 files changed, 720 insertions(+), 5 deletions(-)
```

### Verification

```bash
mix format
mix compile --warnings-as-errors  # clean
mix test                          # 1681 passing, 0 failing
mix test --only lua53             # 6 passing, 23 skipped (unchanged)
```

Manual smoke through `mix run`:

```elixir
Lua.eval!(~S\"\"\"
function foo(thing)
  return thing * 2
end
return foo("yoo")
\"\"\")
# Stack contains: Lua.VM.execute/2, Lua.eval!/3, user frame
# NO Lua.VM.Executor.* frames

# With LUA_DEBUG_STACK=1:
# Stack contains the full chain including
# Lua.VM.Executor.raise_arith_type_error/3,
# Lua.VM.Executor.invoke_metamethod/4, etc.
```

### Discoveries

- `Lua.VM.execute/2` (the top-level VM entrypoint module, NOT a submodule like `Lua.VM.Executor`) is preserved by the prune, because the prefix match `"Elixir.Lua.VM."` requires a trailing dot. This is intentional — `Lua.VM` is part of the public boundary and dropping it would leave a visible gap between `Lua.eval!` and the user's frame.
- Two rescue blocks needed updating: one for the `binary` script variant of `eval!/3` and one for the `Lua.Chunk` variant. Both get identical treatment.
- `Lua.VM.InternalError` is rescued before the generic `RuntimeError / TypeError / AssertionError` branch and re-raised with the original `__STACKTRACE__` so library debugging still has full visibility.
- Frame-shape handling: the helper pattern-matches both 4-tuple and 5-tuple stacktrace entries and falls through to "not internal" for any other shape, so we never crash on an unexpected frame format.

### Out of scope (intentional)

- Touching the Lua-level call stack rendering (`:call_stack` field, rendered by `Lua.VM.ErrorFormatter`) — that stays as-is; A26 polishes it.
- Hiding `Lua.InternalError` frames — those are bugs in us, kept fully visible.
- Pruning frames from `Lua.CompilerException` — compile errors raise before any VM execution; A36 covers the parser side via position info, not via stack pruning.
- A `:debug_stack` option on `Lua.eval!` — env var only, matching how Elixir itself toggles internal-stack visibility.

### Related

This is the first of three plans tightening up error rendering:

- **A37 (this PR)** — Elixir stack prune. Tiny, high-impact, establishes a clean visual baseline.
- **A36** — Parser errors carry position; rewrite the "Expression statement must be a function call" message.
- **A26** — Error gallery + suggestion polish, now unblocked.