### PR TITLE
perf(vm): fast-path Numeric.to_signed_int64 for in-range integers

### DIFF
--- a/.agents/plans/B8-inline-numeric-narrowing.md
+++ b/.agents/plans/B8-inline-numeric-narrowing.md
@@ -2,10 +2,10 @@
 id: B8
 title: Inline `to_signed_int64/1` for the in-range fast path
 issue: null
-pr: null
+pr: 227
 branch: perf/inline-numeric-narrowing
 base: main
-status: in-progress
+status: review
 direction: B
 unlocks:
   - small but free win on all integer-arithmetic workloads
@@ -155,4 +155,34 @@ Lua.eval!(lua, chunk)
 
 ## Discoveries
 
-(populated during implementation)
+- `@compile {:inline, ...}` only inlines within the same module. Cross-module
+  callers in `Lua.VM.Executor` and `Lua.VM.Value` still trip a function
+  boundary on every call. tprof call count stayed at 85,968 before/after,
+  confirming no inlining happened at the dispatch sites. This caps the
+  realized win below the plan's stretch target — the gain comes entirely
+  from the guard short-circuit, not from inlining at call sites.
+- Profile self-time on fib(22) moved 3.82% → 3.38%, a 12% relative drop
+  on the function itself. Plan's stretch target of < 1.5% was not hit
+  because it implicitly required cross-module inlining.
+- Wall-clock win on fib(30) is real: lua (chunk) 873.4ms → 844.8ms
+  (**-3.3%**), well outside the ±0.5% deviation band. luerl (control)
+  did not move. The plan's 3% stretch floor on fib was met.
+
+## What changed
+
+- `lib/lua/vm/numeric.ex` — added in-range guard clause to
+  `to_signed_int64/1`; added `@compile {:inline, signed?: 1,
+  to_signed_int64: 1}`.
+
+PR: #227
+
+Suite delta: 1692 tests passing → 1692 tests passing (no regression).
+lua53 suite: 29 tests, 0 failures (matches main).
+
+Benchmarks (fib(30), 10s benchee, 2s warmup):
+
+| benchmark    | baseline    | after        | delta  |
+|--------------|-------------|--------------|--------|
+| lua (chunk)  | 873.36 ms   | 844.76 ms    | -3.3%  |
+| lua (eval)   | 876.74 ms   | 852.21 ms    | -2.8%  |
+| luerl (ctl)  | 730.87 ms   | 731.78 ms    | noise  |

--- a/.agents/plans/B8-inline-numeric-narrowing.md
+++ b/.agents/plans/B8-inline-numeric-narrowing.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: perf/inline-numeric-narrowing
 base: main
-status: ready
+status: in-progress
 direction: B
 unlocks:
   - small but free win on all integer-arithmetic workloads

--- a/lib/lua/vm/numeric.ex
+++ b/lib/lua/vm/numeric.ex
@@ -39,6 +39,8 @@ defmodule Lua.VM.Numeric do
   @max_int 0x7FFFFFFFFFFFFFFF
   @min_int -0x8000000000000000
 
+  @compile {:inline, signed?: 1, to_signed_int64: 1}
+
   @doc "Maximum signed 64-bit integer (`2^63 - 1`)."
   @spec max_int() :: integer()
   def max_int, do: @max_int
@@ -68,6 +70,10 @@ defmodule Lua.VM.Numeric do
       -1
   """
   @spec to_signed_int64(integer()) :: integer()
+  def to_signed_int64(n) when is_integer(n) and n >= @min_int and n <= @max_int do
+    n
+  end
+
   def to_signed_int64(n) when is_integer(n) do
     masked = band(n, @uint64_mask)
     if masked >= @sign_bit, do: masked - @uint64_modulus, else: masked


### PR DESCRIPTION
## Inline `to_signed_int64/1` for the in-range fast path

Plan: [`.agents/plans/B8-inline-numeric-narrowing.md`](.agents/plans/B8-inline-numeric-narrowing.md)

### Goal

`Lua.VM.Numeric.to_signed_int64/1` is called on every integer arithmetic result
to wrap into signed 64-bit per Lua 5.3 §3.4.1. In the fib(22) tprof profile it
accounts for **3.82%** of total time across 85,968 calls. For the overwhelming
common case where the result is already in `[-2^63, 2^63 - 1]`, the masking and
conditional subtraction are wasted work. Adding a guarded fast-path clause that
returns the input as-is when it's already in range short-circuits the cost on
that branch, and `@compile {:inline, ...}` lets the BEAM inline both clauses at
intra-module call sites.

### Success criteria

- [x] `to_signed_int64/1` has a guard-clause fast path for inputs already in
      the signed 64-bit range — verified in `lib/lua/vm/numeric.ex`.
- [x] `signed?/1` is `@compile {:inline, signed?: 1}` so the fast-path guard
      is cheap — applied alongside `to_signed_int64: 1`.
- [x] `mix test` passes — 1692 tests, 51 properties, 55 doctests, 0 failures.
- [x] `mix test --only lua53` does not regress — 29 tests, 0 failures (matches
      main).
- [x] Profile after merge: `Numeric.to_signed_int64` self-time drops on fib(22).
      Measured: 3.82% → 3.38% (12% relative drop). The plan's stretch target of
      < 1.5% relied on cross-module inlining, which `@compile {:inline, ...}`
      does not perform; the realized win comes from the guard short-circuit only.
- [x] Microbenchmarks: fib improves by ≥ 1% floor / 3% stretch. Measured fib(30)
      wall clock: lua (chunk) 873.4ms → 844.8ms (**-3.3%**), lua (eval) 876.7ms
      → 852.2ms (**-2.8%**). Luerl (control) 730.9ms → 731.8ms (unchanged).
      Both runs at ±0.5% deviation, well outside noise.
- [x] No regression on overflow-heavy tests. Spot-checked:
      `9223372036854775807 + 1 == -9223372036854775808`,
      `-9223372036854775808 - 1 == 9223372036854775807`,
      `0xFFFFFFFFFFFFFFFF == -1`. All correct.

### Changes

```
 lib/lua/vm/numeric.ex                            | 6 ++++++
 .agents/plans/B8-inline-numeric-narrowing.md     | 2 +-
 2 files changed, 7 insertions(+), 1 deletion(-)
```

The behavior is bit-for-bit identical; the fast path is purely a guard-tested
return-as-is. The slow path (already-out-of-range integers needing wrap-around)
is unchanged.

### Discoveries

- `@compile {:inline, ...}` only inlines within the same module. Cross-module
  callers in `Lua.VM.Executor` and `Lua.VM.Value` still trip a function
  boundary on every call. This caps the win below the plan's stretch target —
  the realized improvement comes entirely from the guard short-circuit, not
  from inlining at the dispatch sites.
- tprof call count stayed at 85,968 before/after, confirming no inlining
  happened at the cross-module callers. The wall-clock improvement is real
  (luerl as control did not move), so the per-call win is genuine even if
  modest.

### Verification

```
mix format
mix compile --warnings-as-errors
mix test            # 1692 tests, 0 failures
mix test --only lua53   # 29 tests, 0 failures, 23 skipped
```

Benchmark (fib(30), 10s benchee runs, 2s warmup):

```
Name                ips      average     deviation  median
lua (chunk)        1.18    844.76 ms     ±0.42%    845.56 ms   (was 873.36ms, -3.3%)
lua (eval)         1.17    852.21 ms     ±0.43%    851.97 ms   (was 876.74ms, -2.8%)
luerl              1.37    731.78 ms     ±0.50%    732.24 ms   (was 730.87ms, unchanged - control)
C Lua (luaport)   36.66     27.28 ms     ±4.38%     26.86 ms
```

Profile (fib(22), `mix profile.tprof`):

```
Lua.VM.Numeric.to_signed_int64/1   85968 calls   3.82% -> 3.38%
Lua.VM.Executor.do_execute/8      802388 calls  50.63% -> 52.09% (no change, just relative shift)
```

### Out of scope (intentional)

- Bypassing `to_signed_int64/1` calls entirely at the executor level — that
  is B5 territory (compiling prototypes to Erlang).
- Changing Lua wrap-around semantics. Behavior is identical.
- Turning call sites into inline arithmetic. That would tangle with B5 and is
  not the right place.