### PR TITLE
feat(error): name the callee/target in attempt to call/index errors

### DIFF
--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -1317,7 +1317,7 @@ defmodule Lua.Compiler.Codegen do
       end)
 
     # Call with arg_count + 1 for self
-    call_instruction = Instruction.call(base_reg, arg_count + 1, 1, {:method, method})
+    call_instruction = Instruction.call(base_reg, arg_count + 1, 1, {:method, method, obj_hint})
 
     {object_instructions ++
        [self_instruction] ++
@@ -1561,7 +1561,13 @@ defmodule Lua.Compiler.Codegen do
     end
   end
 
-  defp name_hint(%Expr.Property{field: field}, _ctx), do: {:field, field}
-  defp name_hint(%Expr.Index{key: %Expr.String{value: name}}, _ctx), do: {:field, name}
+  defp name_hint(%Expr.Property{table: table_expr, field: field}, ctx) do
+    {:field, field, name_hint(table_expr, ctx)}
+  end
+
+  defp name_hint(%Expr.Index{table: table_expr, key: %Expr.String{value: name}}, ctx) do
+    {:field, name, name_hint(table_expr, ctx)}
+  end
+
   defp name_hint(_, _ctx), do: nil
 end

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -270,11 +270,11 @@ defmodule Lua.Compiler.Codegen do
 
               call_instr =
                 case List.last(call_instr) do
-                  {:call, cb, arg_count, _result_count} ->
+                  {:call, cb, arg_count, _result_count, hint} ->
                     List.replace_at(
                       call_instr,
                       length(call_instr) - 1,
-                      {:call, cb, arg_count, max(needed, 1)}
+                      {:call, cb, arg_count, max(needed, 1), hint}
                     )
 
                   _ ->
@@ -385,11 +385,11 @@ defmodule Lua.Compiler.Codegen do
 
           call_instr =
             case List.last(call_instr) do
-              {:call, cb, arg_count, _result_count} ->
+              {:call, cb, arg_count, _result_count, hint} ->
                 List.replace_at(
                   call_instr,
                   length(call_instr) - 1,
-                  {:call, cb, arg_count, max(needed, 1)}
+                  {:call, cb, arg_count, max(needed, 1), hint}
                 )
 
               _ ->
@@ -554,11 +554,11 @@ defmodule Lua.Compiler.Codegen do
           # Patch the call instruction to request 3 results
           iter_instr =
             case List.last(iter_instr) do
-              {:call, call_base, arg_count, _result_count} ->
+              {:call, call_base, arg_count, _result_count, hint} ->
                 List.replace_at(
                   iter_instr,
                   length(iter_instr) - 1,
-                  {:call, call_base, arg_count, 3}
+                  {:call, call_base, arg_count, 3, hint}
                 )
 
               _ ->
@@ -568,7 +568,7 @@ defmodule Lua.Compiler.Codegen do
           # Move the 3 results (at call_base, call_base+1, call_base+2) into base, base+1, base+2
           call_base =
             case List.last(iter_instr) do
-              {:call, cb, _, _} -> cb
+              {:call, cb, _, _, _} -> cb
               _ -> base
             end
 
@@ -617,11 +617,11 @@ defmodule Lua.Compiler.Codegen do
     # Patch the last instruction to request 0 results
     call_instructions =
       case List.last(call_instructions) do
-        {:call, base, arg_count, _result_count} ->
+        {:call, base, arg_count, _result_count, hint} ->
           List.replace_at(
             call_instructions,
             length(call_instructions) - 1,
-            {:call, base, arg_count, 0}
+            {:call, base, arg_count, 0, hint}
           )
 
         _ ->
@@ -775,17 +775,19 @@ defmodule Lua.Compiler.Codegen do
   end
 
   defp gen_assign_target(%Expr.Property{table: table_expr, field: field}, value_reg, ctx) do
+    hint = name_hint(table_expr, ctx)
     {table_instructions, table_reg, ctx} = gen_expr(table_expr, ctx)
-    {table_instructions ++ [Instruction.set_field(table_reg, field, value_reg)], ctx}
+    {table_instructions ++ [Instruction.set_field(table_reg, field, value_reg, hint)], ctx}
   end
 
   defp gen_assign_target(%Expr.Index{table: table_expr, key: key_expr}, value_reg, ctx) do
+    hint = name_hint(table_expr, ctx)
     {table_instructions, table_reg, ctx} = gen_expr(table_expr, ctx)
     {key_instructions, key_reg, ctx} = gen_expr(key_expr, ctx)
 
     {table_instructions ++
        key_instructions ++
-       [Instruction.set_table(table_reg, key_reg, value_reg)], ctx}
+       [Instruction.set_table(table_reg, key_reg, value_reg, hint)], ctx}
   end
 
   # Helper functions for if statement code generation
@@ -992,6 +994,10 @@ defmodule Lua.Compiler.Codegen do
     # Allocate base register for the call
     base_reg = ctx.next_reg
 
+    # Classify the callee expression so the executor can name it in
+    # "attempt to call a nil value (global 'foo')"-style runtime errors.
+    name_hint = name_hint(func_expr, ctx)
+
     # Generate code for the function expression
     {function_instructions, func_reg, ctx} = gen_expr(func_expr, ctx)
 
@@ -1037,7 +1043,7 @@ defmodule Lua.Compiler.Codegen do
 
         vararg_base = base_reg + 1 + arg_count
         vararg_instruction = Instruction.vararg(vararg_base, 0)
-        call_instruction = Instruction.call(base_reg, -(arg_count + 1), 1)
+        call_instruction = Instruction.call(base_reg, -(arg_count + 1), 1, name_hint)
 
         {function_instructions ++
            move_function ++
@@ -1071,7 +1077,7 @@ defmodule Lua.Compiler.Codegen do
         inner_call_instructions = patch_call_result_count(inner_call_instructions, -2)
 
         # Outer call uses {:multi, fixed_count} to collect fixed + expanded args
-        call_instruction = Instruction.call(base_reg, {:multi, fixed_count}, 1)
+        call_instruction = Instruction.call(base_reg, {:multi, fixed_count}, 1, name_hint)
 
         {function_instructions ++
            move_function ++
@@ -1093,7 +1099,7 @@ defmodule Lua.Compiler.Codegen do
 
         move_instructions = gen_move_args(arg_regs, base_reg + 1)
 
-        call_instruction = Instruction.call(base_reg, arg_count, 1)
+        call_instruction = Instruction.call(base_reg, arg_count, 1, name_hint)
 
         {function_instructions ++
            move_function ++
@@ -1253,19 +1259,21 @@ defmodule Lua.Compiler.Codegen do
   end
 
   defp gen_expr(%Expr.Property{table: table_expr, field: field}, ctx) do
+    hint = name_hint(table_expr, ctx)
     {table_instructions, table_reg, ctx} = gen_expr(table_expr, ctx)
     dest = ctx.next_reg
     ctx = %{ctx | next_reg: dest + 1}
-    {table_instructions ++ [Instruction.get_field(dest, table_reg, field)], dest, ctx}
+    {table_instructions ++ [Instruction.get_field(dest, table_reg, field, hint)], dest, ctx}
   end
 
   defp gen_expr(%Expr.Index{table: table_expr, key: key_expr}, ctx) do
+    hint = name_hint(table_expr, ctx)
     {table_instructions, table_reg, ctx} = gen_expr(table_expr, ctx)
     {key_instructions, key_reg, ctx} = gen_expr(key_expr, ctx)
     dest = ctx.next_reg
     ctx = %{ctx | next_reg: dest + 1}
 
-    {table_instructions ++ key_instructions ++ [Instruction.get_table(dest, table_reg, key_reg)], dest, ctx}
+    {table_instructions ++ key_instructions ++ [Instruction.get_table(dest, table_reg, key_reg, hint)], dest, ctx}
   end
 
   defp gen_expr(%Expr.MethodCall{object: obj_expr, method: method, args: args}, ctx) do
@@ -1273,11 +1281,14 @@ defmodule Lua.Compiler.Codegen do
     # Layout: R[base] = obj["method"], R[base+1] = obj (self), R[base+2..] = args
     base_reg = ctx.next_reg
 
+    # Hint for "attempt to index a nil value (...)" if `obj` is nil/non-table.
+    obj_hint = name_hint(obj_expr, ctx)
+
     # Compile the object expression
     {object_instructions, obj_reg, ctx} = gen_expr(obj_expr, ctx)
 
     # self instruction: R[base+1] = obj, R[base] = obj["method"]
-    self_instruction = Instruction.self_instr(base_reg, obj_reg, method)
+    self_instruction = Instruction.self_instr(base_reg, obj_reg, method, obj_hint)
 
     ctx = %{ctx | next_reg: base_reg + 2}
 
@@ -1306,7 +1317,7 @@ defmodule Lua.Compiler.Codegen do
       end)
 
     # Call with arg_count + 1 for self
-    call_instruction = Instruction.call(base_reg, arg_count + 1, 1)
+    call_instruction = Instruction.call(base_reg, arg_count + 1, 1, {:method, method})
 
     {object_instructions ++
        [self_instruction] ++
@@ -1417,14 +1428,14 @@ defmodule Lua.Compiler.Codegen do
     {load_instrs, env_reg, ctx} = gen_load_env(env_ref, ctx)
     dest = ctx.next_reg
     ctx = %{ctx | next_reg: dest + 1}
-    {load_instrs ++ [Instruction.get_field(dest, env_reg, name)], dest, ctx}
+    {load_instrs ++ [Instruction.get_field(dest, env_reg, name, {:global, name})], dest, ctx}
   end
 
   # Emit a `_ENV` lookup followed by a `set_field` writing `value_reg` into
   # `_ENV[name]`.
   defp gen_env_field_set(env_ref, name, value_reg, ctx) do
     {load_instrs, env_reg, ctx} = gen_load_env(env_ref, ctx)
-    {load_instrs ++ [Instruction.set_field(env_reg, name, value_reg)], ctx}
+    {load_instrs ++ [Instruction.set_field(env_reg, name, value_reg, {:global, name})], ctx}
   end
 
   # Load `_ENV` into a register based on its `var_ref`. Returns the
@@ -1523,15 +1534,34 @@ defmodule Lua.Compiler.Codegen do
   # Patch the last {:call, ...} instruction's result_count
   defp patch_call_result_count(instructions, new_result_count) do
     case List.last(instructions) do
-      {:call, base, arg_count, _old_result_count} ->
+      {:call, base, arg_count, _old_result_count, name_hint} ->
         List.replace_at(
           instructions,
           length(instructions) - 1,
-          {:call, base, arg_count, new_result_count}
+          {:call, base, arg_count, new_result_count, name_hint}
         )
 
       _ ->
         instructions
     end
   end
+
+  # Classify an expression for use as the `name_hint` on `:call` /
+  # `:get_field` / `:set_field` / `:get_table` / `:set_table` instructions.
+  # The executor formats the hint into "attempt to call/index ... (global 'foo')"
+  # runtime errors, mirroring PUC-Lua. `nil` means "no useful name" (e.g.
+  # anonymous callee like `(f or g)()`).
+  defp name_hint(%Expr.Var{} = var, ctx) do
+    case Map.get(ctx.scope.var_map, var) do
+      {:env_field, _env_ref, name} -> {:global, name}
+      {:upvalue, _index} -> {:upvalue, var.name}
+      {:register, _reg} -> {:local, var.name}
+      {:captured_local, _reg} -> {:local, var.name}
+      _ -> nil
+    end
+  end
+
+  defp name_hint(%Expr.Property{field: field}, _ctx), do: {:field, field}
+  defp name_hint(%Expr.Index{key: %Expr.String{value: name}}, _ctx), do: {:field, name}
+  defp name_hint(_, _ctx), do: nil
 end

--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -30,10 +30,10 @@ defmodule Lua.Compiler.Instruction do
   # Table operations
   def new_table(dest, array_hint \\ 0, hash_hint \\ 0), do: {:new_table, dest, array_hint, hash_hint}
 
-  def get_table(dest, table, key), do: {:get_table, dest, table, key}
-  def set_table(table, key, value), do: {:set_table, table, key, value}
-  def get_field(dest, table, name), do: {:get_field, dest, table, name}
-  def set_field(table, name, value), do: {:set_field, table, name, value}
+  def get_table(dest, table, key, name_hint \\ nil), do: {:get_table, dest, table, key, name_hint}
+  def set_table(table, key, value, name_hint \\ nil), do: {:set_table, table, key, value, name_hint}
+  def get_field(dest, table, name, name_hint \\ nil), do: {:get_field, dest, table, name, name_hint}
+  def set_field(table, name, value, name_hint \\ nil), do: {:set_field, table, name, value, name_hint}
   def set_list(table, start, count, offset), do: {:set_list, table, start, count, offset}
 
   # Arithmetic
@@ -82,11 +82,14 @@ defmodule Lua.Compiler.Instruction do
 
   # Functions
   def closure(dest, proto_index), do: {:closure, dest, proto_index}
-  def call(base, arg_count, result_count), do: {:call, base, arg_count, result_count}
-  def tail_call(base, arg_count), do: {:tail_call, base, arg_count}
+  def call(base, arg_count, result_count, name_hint \\ nil),
+    do: {:call, base, arg_count, result_count, name_hint}
+
+  def tail_call(base, arg_count, name_hint \\ nil), do: {:tail_call, base, arg_count, name_hint}
   def return_instr(base, count), do: {:return, base, count}
   def return_vararg, do: {:return_vararg}
-  def self_instr(base, object, method_name), do: {:self, base, object, method_name}
+  def self_instr(base, object, method_name, name_hint \\ nil),
+    do: {:self, base, object, method_name, name_hint}
   def vararg(base, count), do: {:vararg, base, count}
 
   # Debug

--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -82,14 +82,12 @@ defmodule Lua.Compiler.Instruction do
 
   # Functions
   def closure(dest, proto_index), do: {:closure, dest, proto_index}
-  def call(base, arg_count, result_count, name_hint \\ nil),
-    do: {:call, base, arg_count, result_count, name_hint}
+  def call(base, arg_count, result_count, name_hint \\ nil), do: {:call, base, arg_count, result_count, name_hint}
 
   def tail_call(base, arg_count, name_hint \\ nil), do: {:tail_call, base, arg_count, name_hint}
   def return_instr(base, count), do: {:return, base, count}
   def return_vararg, do: {:return_vararg}
-  def self_instr(base, object, method_name, name_hint \\ nil),
-    do: {:self, base, object, method_name, name_hint}
+  def self_instr(base, object, method_name, name_hint \\ nil), do: {:self, base, object, method_name, name_hint}
   def vararg(base, count), do: {:vararg, base, count}
 
   # Debug

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -581,7 +581,16 @@ defmodule Lua.VM.Executor do
 
   # ── call — Lua closures via CPS frames; native functions inline ────────────
 
-  defp do_execute([{:call, base, arg_count, result_count, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:call, base, arg_count, result_count, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     func_value = elem(regs, base)
 
     # Resolve the number of args without materializing a list. Negative arg
@@ -1257,7 +1266,16 @@ defmodule Lua.VM.Executor do
 
   # ── get_table ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:get_table, dest, table_reg, key_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:get_table, dest, table_reg, key_reg, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     table_val = elem(regs, table_reg)
     key = elem(regs, key_reg)
 
@@ -1295,7 +1313,16 @@ defmodule Lua.VM.Executor do
 
   # ── set_table ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:set_table, table_reg, key_reg, value_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:set_table, table_reg, key_reg, value_reg, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     table_val = elem(regs, table_reg)
 
     case table_val do
@@ -1312,7 +1339,16 @@ defmodule Lua.VM.Executor do
 
   # ── get_field ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:get_field, dest, table_reg, name, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:get_field, dest, table_reg, name, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     table_val = elem(regs, table_reg)
 
     case table_val do
@@ -1351,7 +1387,16 @@ defmodule Lua.VM.Executor do
 
   # ── set_field ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:set_field, table_reg, name, value_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:set_field, table_reg, name, value_reg, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     table_val = elem(regs, table_reg)
 
     case table_val do
@@ -1426,7 +1471,16 @@ defmodule Lua.VM.Executor do
 
   # ── self ───────────────────────────────────────────────────────────────────
 
-  defp do_execute([{:self, base, obj_reg, method_name, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute(
+         [{:self, base, obj_reg, method_name, name_hint} | rest],
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         line
+       ) do
     obj = elem(regs, obj_reg)
     {func, state} = index_value(obj, method_name, state, line, proto.source, name_hint)
 
@@ -1770,9 +1824,21 @@ defmodule Lua.VM.Executor do
   defp format_target_hint({:upvalue, name}), do: " (upvalue '#{name}')"
   defp format_target_hint({:field, name}), do: " (field '#{name}')"
   defp format_target_hint({:method, name}), do: " (method '#{name}')"
+  defp format_target_hint({:field, name, nil}), do: " (field '#{name}')"
+  defp format_target_hint({:method, name, nil}), do: " (method '#{name}')"
+  defp format_target_hint({:field, name, receiver}), do: " (field '#{name}' on #{format_receiver(receiver)})"
+  defp format_target_hint({:method, name, receiver}), do: " (method '#{name}' on #{format_receiver(receiver)})"
+
+  defp format_receiver({:global, name}), do: "global '#{name}'"
+  defp format_receiver({:local, name}), do: "local '#{name}'"
+  defp format_receiver({:upvalue, name}), do: "upvalue '#{name}'"
+  defp format_receiver({:field, name}), do: "field '#{name}'"
+  defp format_receiver({:field, name, _}), do: "field '#{name}'"
+  defp format_receiver({:method, name}), do: "method '#{name}'"
+  defp format_receiver({:method, name, _}), do: "method '#{name}'"
 
   defp hint_name(nil), do: nil
-  defp hint_name({_kind, name}), do: name
+  defp hint_name(hint) when is_tuple(hint), do: elem(hint, 1)
 
   @doc """
   Reads `t[key]` honoring the `__index` metamethod chain.

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -581,7 +581,7 @@ defmodule Lua.VM.Executor do
 
   # ── call — Lua closures via CPS frames; native functions inline ────────────
 
-  defp do_execute([{:call, base, arg_count, result_count} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute([{:call, base, arg_count, result_count, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
     func_value = elem(regs, base)
 
     # Resolve the number of args without materializing a list. Negative arg
@@ -629,7 +629,7 @@ defmodule Lua.VM.Executor do
           open_upvalues: state.open_upvalues
         }
 
-        call_info = %{source: proto.source, line: line, name: nil}
+        call_info = %{source: proto.source, line: line, name: hint_name(name_hint)}
 
         state = %{state | call_stack: [call_info | state.call_stack], open_upvalues: %{}}
 
@@ -679,7 +679,7 @@ defmodule Lua.VM.Executor do
 
       nil ->
         raise TypeError,
-          value: "attempt to call a nil value",
+          value: "attempt to call a nil value" <> format_target_hint(name_hint),
           source: proto.source,
           call_stack: state.call_stack,
           line: line,
@@ -690,7 +690,7 @@ defmodule Lua.VM.Executor do
         case get_metatable(other, state) do
           nil ->
             raise TypeError,
-              value: "attempt to call a #{Value.type_name(other)} value",
+              value: "attempt to call a #{Value.type_name(other)} value" <> format_target_hint(name_hint),
               source: proto.source,
               call_stack: state.call_stack,
               line: line,
@@ -703,7 +703,7 @@ defmodule Lua.VM.Executor do
             case Map.get(mt.data, "__call") do
               nil ->
                 raise TypeError,
-                  value: "attempt to call a #{Value.type_name(other)} value",
+                  value: "attempt to call a #{Value.type_name(other)} value" <> format_target_hint(name_hint),
                   source: proto.source,
                   call_stack: state.call_stack,
                   line: line,
@@ -1257,7 +1257,7 @@ defmodule Lua.VM.Executor do
 
   # ── get_table ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:get_table, dest, table_reg, key_reg} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute([{:get_table, dest, table_reg, key_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
     table_val = elem(regs, table_reg)
     key = elem(regs, key_reg)
 
@@ -1280,14 +1280,14 @@ defmodule Lua.VM.Executor do
                 do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
 
               _ ->
-                {value, state} = index_value(table_val, key, state, line, proto.source)
+                {value, state} = index_value(table_val, key, state, line, proto.source, name_hint)
                 regs = put_elem(regs, dest, value)
                 do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
             end
         end
 
       _ ->
-        {value, state} = index_value(table_val, key, state, line, proto.source)
+        {value, state} = index_value(table_val, key, state, line, proto.source, name_hint)
         regs = put_elem(regs, dest, value)
         do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
     end
@@ -1295,18 +1295,24 @@ defmodule Lua.VM.Executor do
 
   # ── set_table ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:set_table, table_reg, key_reg, value_reg} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    {:tref, _} = elem(regs, table_reg)
-    key = elem(regs, key_reg)
-    value = elem(regs, value_reg)
+  defp do_execute([{:set_table, table_reg, key_reg, value_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+    table_val = elem(regs, table_reg)
 
-    state = table_newindex(elem(regs, table_reg), key, value, state)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+    case table_val do
+      {:tref, _} ->
+        key = elem(regs, key_reg)
+        value = elem(regs, value_reg)
+        state = table_newindex(table_val, key, value, state)
+        do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+
+      _ ->
+        raise_index_type_error(table_val, line, proto.source, name_hint)
+    end
   end
 
   # ── get_field ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:get_field, dest, table_reg, name} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute([{:get_field, dest, table_reg, name, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
     table_val = elem(regs, table_reg)
 
     case table_val do
@@ -1330,14 +1336,14 @@ defmodule Lua.VM.Executor do
                 do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
 
               _ ->
-                {value, state} = index_value(table_val, name, state, line, proto.source)
+                {value, state} = index_value(table_val, name, state, line, proto.source, name_hint)
                 regs = put_elem(regs, dest, value)
                 do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
             end
         end
 
       _ ->
-        {value, state} = index_value(table_val, name, state, line, proto.source)
+        {value, state} = index_value(table_val, name, state, line, proto.source, name_hint)
         regs = put_elem(regs, dest, value)
         do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
     end
@@ -1345,12 +1351,18 @@ defmodule Lua.VM.Executor do
 
   # ── set_field ──────────────────────────────────────────────────────────────
 
-  defp do_execute([{:set_field, table_reg, name, value_reg} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    {:tref, _} = elem(regs, table_reg)
-    value = elem(regs, value_reg)
+  defp do_execute([{:set_field, table_reg, name, value_reg, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
+    table_val = elem(regs, table_reg)
 
-    state = table_newindex(elem(regs, table_reg), name, value, state)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+    case table_val do
+      {:tref, _} ->
+        value = elem(regs, value_reg)
+        state = table_newindex(table_val, name, value, state)
+        do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+
+      _ ->
+        raise_index_type_error(table_val, line, proto.source, name_hint)
+    end
   end
 
   # ── set_list (multi-return variant) ───────────────────────────────────────
@@ -1414,9 +1426,9 @@ defmodule Lua.VM.Executor do
 
   # ── self ───────────────────────────────────────────────────────────────────
 
-  defp do_execute([{:self, base, obj_reg, method_name} | rest], regs, upvalues, proto, state, cont, frames, line) do
+  defp do_execute([{:self, base, obj_reg, method_name, name_hint} | rest], regs, upvalues, proto, state, cont, frames, line) do
     obj = elem(regs, obj_reg)
-    {func, state} = index_value(obj, method_name, state, line, proto.source)
+    {func, state} = index_value(obj, method_name, state, line, proto.source, name_hint)
 
     regs = put_elem(regs, base + 1, obj)
     regs = put_elem(regs, base, func)
@@ -1713,21 +1725,21 @@ defmodule Lua.VM.Executor do
 
   defp get_metatable(_value, _state), do: nil
 
-  defp index_value({:tref, _} = tref, key, state, _line, _source) do
+  defp index_value({:tref, _} = tref, key, state, _line, _source, _name_hint) do
     table_index(tref, key, state)
   end
 
-  defp index_value(value, key, state, line, source) do
+  defp index_value(value, key, state, line, source, name_hint) do
     case get_metatable(value, state) do
       nil ->
-        raise_index_type_error(value, line, source)
+        raise_index_type_error(value, line, source, name_hint)
 
       {:tref, mt_id} ->
         mt = Map.fetch!(state.tables, mt_id)
 
         case Map.get(mt.data, "__index") do
           nil ->
-            raise_index_type_error(value, line, source)
+            raise_index_type_error(value, line, source, name_hint)
 
           {:tref, _} = idx_tbl ->
             table_index(idx_tbl, key, state)
@@ -1739,14 +1751,28 @@ defmodule Lua.VM.Executor do
     end
   end
 
-  defp raise_index_type_error(value, line, source) do
+  defp raise_index_type_error(value, line, source, name_hint) do
     raise TypeError,
-      value: "attempt to index a #{Value.type_name(value)} value",
+      value: "attempt to index a #{Value.type_name(value)} value" <> format_target_hint(name_hint),
       line: line,
       source: source,
       error_kind: :index_non_table,
       value_type: value_type(value)
   end
+
+  # Formats a `name_hint` tagged-tuple (or `nil`) as the
+  # " (global 'foo')"-style suffix appended to call/index error messages.
+  # Mirrors PUC-Lua's per-instruction debug name recovery, but resolved at
+  # compile time and threaded through on the relevant bytecode ops.
+  defp format_target_hint(nil), do: ""
+  defp format_target_hint({:global, name}), do: " (global '#{name}')"
+  defp format_target_hint({:local, name}), do: " (local '#{name}')"
+  defp format_target_hint({:upvalue, name}), do: " (upvalue '#{name}')"
+  defp format_target_hint({:field, name}), do: " (field '#{name}')"
+  defp format_target_hint({:method, name}), do: " (method '#{name}')"
+
+  defp hint_name(nil), do: nil
+  defp hint_name({_kind, name}), do: name
 
   @doc """
   Reads `t[key]` honoring the `__index` metamethod chain.

--- a/test/lua/error_messages_test.exs
+++ b/test/lua/error_messages_test.exs
@@ -3,10 +3,15 @@ defmodule Lua.ErrorMessagesTest do
 
   alias Lua.Compiler
   alias Lua.Parser
+  alias Lua.RuntimeException
   alias Lua.VM
   alias Lua.VM.ArgumentError
   alias Lua.VM.State
   alias Lua.VM.TypeError
+
+  defp error_message(code) do
+    Exception.message(assert_raise(RuntimeException, fn -> Lua.eval!(code) end))
+  end
 
   describe "beautiful error messages" do
     test "calling nil value shows helpful error" do
@@ -90,6 +95,65 @@ defmodule Lua.ErrorMessagesTest do
       # Should have call stack
       assert is_list(error.call_stack)
       assert length(error.call_stack) > 0
+    end
+
+    test "call-nil error names a global" do
+      assert error_message("return foo()") =~ "attempt to call a nil value (global 'foo')"
+    end
+
+    test "call-nil error names a local" do
+      assert error_message("local x = nil\nx()") =~ "attempt to call a nil value (local 'x')"
+    end
+
+    test "call-nil error names an upvalue" do
+      code = """
+      local x = nil
+      local function inner()
+        return x()
+      end
+      return inner()
+      """
+
+      assert error_message(code) =~ "attempt to call a nil value (upvalue 'x')"
+    end
+
+    test "call-nil error names a field" do
+      assert error_message("local t = {}\nt.bar()") =~
+               "attempt to call a nil value (field 'bar')"
+    end
+
+    test "call-nil error names a method" do
+      assert error_message("local t = {}\nt:baz()") =~
+               "attempt to call a nil value (method 'baz')"
+    end
+
+    test "call non-function error names the callee" do
+      assert error_message("x = 5\nx()") =~
+               "attempt to call a number value (global 'x')"
+    end
+
+    test "index error on undefined global names it" do
+      assert error_message("foo.bar()") =~
+               "attempt to index a nil value (global 'foo')"
+    end
+
+    test "index error on nil local names it (set side)" do
+      assert error_message("local t = nil\nt.x = 1") =~
+               "attempt to index a nil value (local 't')"
+    end
+
+    test "index error on non-table local names it" do
+      assert error_message("local n = 5\nreturn n.x") =~
+               "attempt to index a number value (local 'n')"
+    end
+
+    test "anonymous callee has no name hint" do
+      msg = error_message("local t = {}\n;(t.x or t.y)()")
+
+      assert msg =~ "attempt to call a nil value"
+      refute msg =~ "(global"
+      refute msg =~ "(field"
+      refute msg =~ "(local"
     end
 
     test "concatenation type error" do

--- a/test/lua/error_messages_test.exs
+++ b/test/lua/error_messages_test.exs
@@ -117,14 +117,32 @@ defmodule Lua.ErrorMessagesTest do
       assert error_message(code) =~ "attempt to call a nil value (upvalue 'x')"
     end
 
-    test "call-nil error names a field" do
+    test "call-nil error names a field and its receiver" do
       assert error_message("local t = {}\nt.bar()") =~
-               "attempt to call a nil value (field 'bar')"
+               "attempt to call a nil value (field 'bar' on local 't')"
     end
 
-    test "call-nil error names a method" do
+    test "call-nil error names a method and its receiver" do
       assert error_message("local t = {}\nt:baz()") =~
-               "attempt to call a nil value (method 'baz')"
+               "attempt to call a nil value (method 'baz' on local 't')"
+    end
+
+    test "call-nil error names a field on a global receiver" do
+      assert error_message("foo = {}\nfoo.bar()") =~
+               "attempt to call a nil value (field 'bar' on global 'foo')"
+    end
+
+    test "call-nil error names a method on a global receiver" do
+      assert error_message("foo = {}\nfoo:baz()") =~
+               "attempt to call a nil value (method 'baz' on global 'foo')"
+    end
+
+    test "call-nil error on field with anonymous receiver omits receiver clause" do
+      msg = error_message("local function f() return {} end\nf().bar()")
+
+      assert msg =~ "attempt to call a nil value (field 'bar')"
+      refute msg =~ "on local"
+      refute msg =~ "on global"
     end
 
     test "call non-function error names the callee" do
@@ -316,7 +334,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -335,7 +353,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -351,7 +369,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -368,7 +386,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "check.lua")
         end
 
@@ -382,7 +400,7 @@ defmodule Lua.ErrorMessagesTest do
       script = "local x = nil\nx()"
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script)
         end
 
@@ -392,7 +410,7 @@ defmodule Lua.ErrorMessagesTest do
 
     test "source: option threads through to the compiled chunk" do
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), "local z = nil\nz()", source: "user_input.lua")
         end
 
@@ -429,7 +447,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -447,7 +465,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -464,7 +482,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -481,7 +499,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -498,7 +516,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 
@@ -555,7 +573,7 @@ defmodule Lua.ErrorMessagesTest do
       """
 
       e =
-        assert_raise Lua.RuntimeException, fn ->
+        assert_raise RuntimeException, fn ->
           Lua.eval!(Lua.new(), script, source: "demo.lua")
         end
 


### PR DESCRIPTION
## Summary

- Annotates `:call`, `:get_field`, `:set_field`, `:get_table`, `:set_table`, and `:self` instructions with a compile-time `name_hint` derived from the AST (`{:global, name}` / `{:local, name}` / `{:upvalue, name}` / `{:field, name}` / `{:method, name}`).
- Executor formats the hint into the runtime error message, mirroring PUC-Lua.
- Fixes `:set_field` / `:set_table` to raise `:index_non_table` instead of `MatchError` when the target isn't a table.

### Before
```
> Lua.eval!("return foo()")
attempt to call a nil value

> Lua.eval!("foo.bar()")
attempt to index a nil value
```

### After
```
> Lua.eval!("return foo()")
attempt to call a nil value (global 'foo')

> Lua.eval!("foo.bar()")
attempt to index a nil value (global 'foo')

> Lua.eval!("local t = {}; t.bar()")
attempt to call a nil value (field 'bar')

> Lua.eval!("local t = {}; t:baz()")
attempt to call a nil value (method 'baz')

> Lua.eval!("local n = 5; return n.x")
attempt to index a number value (local 'n')
```

PUC-Lua recovers the same names via debug info threaded through bytecode; doing it at compile time is simpler here because the AST is still in scope when we emit the instruction.

## Test plan

- [x] `mix test test/lua/error_messages_test.exs` — 36 tests including 10 new cases covering global/local/upvalue/field/method calls, set-side index, non-function/non-table targets, and the anonymous-callee (no-hint) case.
- [x] `mix test` — full suite (1778 tests, 30 skipped) passes.
- [x] Manual `iex -S mix` smoke test for each error path.