### PR TITLE
plans(B5): pivot from BEAM codegen to dispatcher + bytecode

### DIFF
--- a/.agents/plans/B5-compile-prototypes-to-erlang.md
+++ b/.agents/plans/B5-compile-prototypes-to-erlang.md
@@ -1,18 +1,52 @@
 ---
 id: B5
-title: Compile Lua prototypes to Erlang functions (executor JIT)
+title: Compile Lua prototypes to Erlang functions (executor JIT) — SUPERSEDED
 issue: null
-pr: null
-branch: perf/compile-to-erlang
+pr: 235 (closed unmerged)
+branch: n/a
 base: main
-status: blocked
+status: superseded
 direction: B
-unlocks:
-  - sub-Luerl latency on tight numeric/call workloads
-  - "perf parity with Luerl, ±10%" 1.0 commitment headroom
+superseded_by: B5-dispatcher-and-bytecode
 ---
 
-## Blocked on
+## Status: superseded by B5-dispatcher-and-bytecode
+
+This plan committed to lowering each `%Prototype{}` to a fresh BEAM
+module via `:compile.forms/2` + `:code.load_binary/3`. A prototype
+build of that approach shipped to PR #235 and met its functional bar
+(1.07x faster than Luerl on fib(30)). The PR was closed unmerged
+because the path is fundamentally unsafe for an embedded Lua library
+that exposes runtime compilation via `load()` / `loadstring()`:
+
+- Every successful compile mints a fresh module atom (atoms are
+  never GC'd on the BEAM; default cap ~1M then the VM aborts).
+- Every successful compile loads a BEAM module that sits in the
+  code server until explicitly purged.
+- Purging is not viable: `:code.soft_purge/1` is blocked by any
+  process executing in the module (including Lua coroutines
+  suspended mid-call), and `:code.purge/1` kills those processes.
+
+A Lua program calling `load(untrusted_bytes)` in a loop is an
+atom-table-exhaustion DoS reachable from any host that exposes
+runtime Lua compilation — which is the whole point of an embedded
+Lua.
+
+Luerl, the reference Erlang Lua implementation, never calls
+`compile:*` or `code:*`. Its compiled chunks are plain Erlang data
+walked by a hand-written interpreter (`luerl_emul:emul_1/7`). GC
+reclaims them like any other term.
+
+**See `.agents/plans/B5-dispatcher-and-bytecode.md` for the
+replacement plan.** The replacement adopts Luerl's "no runtime
+BEAM codegen" constraint and ships a single hand-written dispatcher
+module over dense register-based bytecode. The historical record
+below remains useful for context — most of the per-opcode lowering
+decisions port to the new bytecode encoder.
+
+---
+
+## (Historical) Blocked on
 
 - B4 — the flat instruction stream is the natural intermediate
   representation to translate into Erlang. Trying to JIT directly from

--- a/.agents/plans/B5-dispatcher-and-bytecode.md
+++ b/.agents/plans/B5-dispatcher-and-bytecode.md
@@ -1,0 +1,512 @@
+---
+id: B5
+title: Dense bytecode + single dispatcher module (executor JIT, take 2)
+issue: null
+pr: null
+branch: n/a (split into B5a-B5e)
+base: main
+status: split
+direction: B
+unlocks:
+  - sub-Luerl latency on tight numeric/call workloads, without
+    runtime BEAM code generation
+  - "perf parity with Luerl, ±10%" 1.0 commitment headroom
+supersedes: B5-compile-prototypes-to-erlang
+---
+
+## Why this plan replaces the old B5
+
+The original B5 took the path Luerl explicitly didn't: lower each
+prototype to Erlang abstract forms and call `:compile.forms/2` +
+`:code.load_binary/3` per compile. B5a shipped a working version of
+that and the perf number (1.07x vs Luerl on fib(30)) was real. The
+lifecycle was not.
+
+### What killed it
+
+Every successful compile mints a fresh module atom and loads a new
+BEAM binary. Atoms are never GC'd by the BEAM. Modules sit in the
+code server until explicitly purged. And purging has two problems
+that ref-counting can't fix:
+
+1. `:code.soft_purge/1` returns `false` while any process is
+   executing the module. A Lua coroutine suspended mid-call inside a
+   compiled chunk pins the module forever — the host has no way to
+   know when (or if) the coroutine will resume.
+2. `:code.purge/1` (hard purge) kills every process executing in old
+   code. That is not a behaviour we can expose to embedders. Their
+   own GenServers and request handlers run "inside" the compiled
+   module via continuations into the dispatch.
+
+The B5b plan (content-addressable + ref-counted purging) addressed
+the cache-hit case but never resolved (1) or (2). A Lua program
+running `load(user_input)` in a loop — which is the literal point of
+embedding Lua — exhausts the atom table and crashes the BEAM.
+
+Luerl avoids this entirely by never calling `compile:*` or `code:*`.
+Its compile output is just data (tuples and records from
+`luerl_instrs.hrl`), walked by a hand-written interpreter
+(`luerl_emul:emul_1/7`). GC reclaims compiled chunks like any other
+Erlang term.
+
+### What this plan does instead
+
+Keep the codegen *structure* from B5a. Change the *output target*.
+Instead of emitting Erlang abstract forms and loading a fresh BEAM
+module per prototype, emit a dense, register-based **bytecode** —
+plain Erlang terms — and ship a single hand-written **dispatcher
+module** in `lib/` that interprets it. Compiled prototypes carry the
+bytecode as data on the existing `%Prototype{}` value.
+
+The dispatcher is one module, written once, included in the
+application. No `:compile.forms`, no `:code.load_binary`, no atoms
+minted per compile, no purging, no DoS surface. Compiled chunks are
+GC'd as ordinary terms.
+
+We give up some of the per-prototype inlining the BEAM JIT could do
+on freshly loaded modules. We keep almost all of the dispatch win
+that the spikes attributed to "no interpreter loop." The two costs
+are not the same — dispatch is the bigger one (see B5a's
+discoveries: `setelement/3` was the main remaining ceiling, not
+opcode-selection cost).
+
+## Status: split into B5a–B5e
+
+The work is split into five sequential plans, each shippable as one
+PR per the `ship-a-plan` contract:
+
+- **B5a** — Dispatcher module + dense bytecode IR; covers fib +
+  arithmetic + control flow. Falls back on tables and closures.
+- **B5b** — Table opcodes added to the dispatcher.
+- **B5c** — Closures, varargs, multi-return.
+- **B5d** — Error position fidelity.
+- **B5e** — Profile-guided opcode densification (super-instructions,
+  inline fast paths). Optional; only ship if benchmarks justify it.
+
+Note the renumbering: the old "B5b — module lifecycle" plan is
+deleted, not superseded — there are no modules to manage. Tables
+move from B5c to B5b, closures from B5d to B5c, errors from B5e to
+B5d, and B5e becomes the optional perf-tuning phase.
+
+This parent plan stays as the strategic record: spike data,
+architectural decisions, and what was decided out of scope. Read
+the child plans for what gets implemented.
+
+## Why this is the right shape
+
+Three constraints made the original B5 untenable; this plan
+satisfies all three:
+
+1. **No per-compile BEAM modules.** No atom growth, no code-server
+   growth, no purge calls. A host that runs `load()` in a loop on
+   untrusted input is GC-safe — every compile is just allocating
+   data terms.
+2. **No coroutine / in-flight execution hazard.** The dispatcher
+   module is loaded once at boot like any other library module. It
+   does not need to be unloaded. Lua coroutines suspended inside
+   compiled bytecode pin nothing.
+3. **No global state.** No `Lua.VM.CodeCache` GenServer. No process
+   tree to supervise. Compiled chunks live where every other
+   `%Lua.Chunk{}` lives — owned by the caller.
+
+The fourth constraint — perf — needs a separate argument. The
+question is whether a hand-written dispatcher in Elixir can match
+what `:compile.forms` produced.
+
+### Perf hypothesis
+
+B5a's compiled-erlang path beat the interpreter by ~1.45x on
+fib(30) and tied Luerl. The bottlenecks identified in B5a's
+discoveries were:
+
+- `throw/catch` for non-tail `:return` (~8% of profile).
+- `setelement/3` per register write (~22% of profile).
+- Per-opcode case scrutiny in the dispatch loop.
+
+The first two have nothing to do with whether the executor is
+generated or hand-written. They're properties of the *value
+representation* (register tuple, return-via-throw). They survive
+this rewrite unchanged. B5a's win over the interpreter came from
+the third: collapsing the dispatch shape.
+
+A hand-written dispatcher can collapse dispatch differently:
+
+- **Dense bytecode**: opcodes become small integers (or short
+  atoms), operands are unboxed integers where possible. Decoding
+  is `case Op of 1 -> ...; 2 -> ...; end` over an integer — the
+  BEAM compiles this to a jump table.
+- **Register-based**: same register model as today, same operand
+  positions, no operand decoding tricks. Keep the simple path.
+- **One pattern-match per opcode**: the BEAM's case-clause selection
+  on integer keys is already as fast as anything `:compile.forms`
+  produces for dispatch. The win the codegen had was *not having to
+  dispatch at all* per opcode — that win is gone here, replaced by
+  a single tight dispatch.
+
+Expected ceiling: somewhere between the current interpreter (1.07x
+Luerl on B5a, but the interpreter is closer to 0.74x) and B5a's
+codegen output. Likely ~1.1x–1.3x Luerl on fib. The target is to
+match Luerl, not to beat it dramatically. Beating Luerl
+dramatically requires giving up GC-safety, which is the lesson of
+B5a.
+
+If the dispatcher hits ~Luerl parity on fib and ~2x interpreter on
+tables, that's the win condition. Hosts get safe, predictable
+behaviour and the perf gap to Luerl closes. Anyone who needs more
+than that runs PUC-Lua via a NIF.
+
+### Why this is not just "rewrite the interpreter"
+
+The current `Lua.VM.Executor` dispatches over a *list of tuples* —
+`[{:add, 1, 2, 3}, {:move, 4, 1}, ...]`. Every opcode pays for:
+
+- The list-cons cell traversal (`[op | rest]` pattern match).
+- The tuple pattern match on the opcode atom.
+- Construction of a new `rest` list spine on every step.
+- A function call (the tail-recursion).
+
+The new dispatcher:
+
+- Stores opcodes in a **binary or a tuple**, indexed by PC integer.
+  `:erlang.element/2` and `:binary.at/2` are O(1) and don't churn
+  list cells.
+- Decodes opcodes as small integers, dispatched via integer case.
+- Keeps PC as an integer; jumps become `pc = N` rather than
+  `find_label/2` linear scans (B4's planned win, never landed,
+  inherited here).
+- Eliminates the per-step list spine reallocation.
+
+The codegen work in `lib/lua/compiler/erlang/opcodes.ex` translates
+naturally — most of it is "given this Lua opcode and these operands,
+emit a snippet." The snippet target changes from "Erlang abstract
+forms that compute the result" to "a fixed-length record of
+bytecode bytes/elements that drive the dispatcher to compute the
+result." Same op-table, different encoder.
+
+## Goal
+
+For each `%Prototype{}`, generate a **compiled bytecode** value —
+a packed sequence of opcodes + operands as plain Erlang data —
+that the new `Lua.VM.Dispatcher` module executes via a single
+tight pattern-matched loop. No runtime BEAM module generation.
+No atoms minted per compile. No `:compile.forms`, no
+`:code.load_binary`.
+
+## Out of scope
+
+- Native code generation, NIFs, or anything that leaves the BEAM.
+- Eliminating the interpreter path. The list-of-tuples interpreter
+  stays as a debugging fallback and a fidelity reference for the
+  dispatcher's behaviour. New language features land there first;
+  dispatcher catches up in a subsequent plan if perf needs it.
+- Cross-prototype optimization (inlining one Lua function into
+  another).
+- Direct-threaded dispatch (computed-goto-equivalent on BEAM).
+  Worth investigating only if the case-dispatch ceiling is the
+  measured bottleneck after this plan lands.
+
+## Success criteria
+
+- [ ] `Lua.VM.Dispatcher` module exists, hand-written, exports an
+      `execute/3` (or similar) that takes a `%Prototype{}` with
+      compiled bytecode, args, and state, and returns
+      `{results, state}`.
+- [ ] `Lua.Compiler.Bytecode` module exists, takes a `%Prototype{}`
+      with the current list-of-tuples instruction stream and emits
+      the bytecode value. The current `lib/lua/compiler/erlang/`
+      opcode-lowering knowledge port to it.
+- [ ] All opcodes have a dispatcher clause (no fallback gaps after
+      B5c lands).
+- [ ] `mix test` passes; suite pass count does not regress.
+- [ ] **No new atoms or modules introduced at compile/eval time.**
+      Verified by: run `Lua.eval!` in a loop with N distinct sources,
+      assert `length(:code.all_loaded())` is unchanged and
+      `:erlang.system_info(:atom_count)` is unchanged (modulo
+      Elixir's own atom interning of literal source strings).
+- [ ] Lua's own `load()` / `loadstring()` builtins, fed untrusted
+      bytes in a loop, do not grow VM memory or atom count.
+- [ ] fib(25): match Luerl (±10%). Stretch: 1.2x faster.
+- [ ] table_sum(1000): match Luerl (±10%). Stretch: 1.5x faster.
+- [ ] No workload regresses from current `main` interpreter perf by
+      more than 10%.
+
+## Implementation notes
+
+### Bytecode shape
+
+Three options for the bytecode storage:
+
+1. **Tuple of opcodes**: `{op1, op2, op3, ...}` where each opcode
+   is itself a small tuple `{:add, 1, 2, 3}`. Dispatch via
+   `:erlang.element(pc, code)`. **Drawback**: each opcode is still
+   an allocated tuple — no allocation win over the current
+   interpreter.
+2. **Binary bytecode**: a packed `binary` of `<<opcode:8, operands>>`.
+   Dispatch via `:binary.at/2` or pattern matching on a binary cursor.
+   **Drawback**: operand decoding needs to handle variable-width
+   operands (constants don't fit in 8 bits). Adds decode complexity.
+3. **Tuple of integers + side tables**: bytecode is a tuple of
+   16-bit integers `{op_code, arg1, arg2, ...}` where constants and
+   atoms are indices into per-prototype constant pools (already
+   present on `%Prototype{}` as `proto.constants`). Dispatch is
+   `element/2`, no allocation per step.
+
+Recommend (3). Reuses the existing `proto.constants` pool,
+no decoding overhead beyond `element/2`, no per-step allocation,
+and integer comparison is the BEAM's best case for case-clause
+selection.
+
+### Dispatcher shape
+
+```elixir
+defmodule Lua.VM.Dispatcher do
+  # opcode integers — keep this in sync with Lua.Compiler.Bytecode.
+  @op_load_constant 1
+  @op_move 2
+  @op_add 3
+  # ...
+
+  def execute(proto, args, state) do
+    regs = initial_regs(proto, args)
+    dispatch(proto.bytecode, proto.constants, 0, regs, proto.upvalues, state)
+  end
+
+  defp dispatch(code, consts, pc, regs, ups, state) do
+    case :erlang.element(pc + 1, code) do
+      {@op_load_constant, dest, k_idx} ->
+        regs2 = :erlang.setelement(dest + 1, regs, :erlang.element(k_idx + 1, consts))
+        dispatch(code, consts, pc + 1, regs2, ups, state)
+
+      {@op_add, dest, a, b} ->
+        # integer fast path inline, slow path delegates
+        # ...
+        dispatch(code, consts, pc + 1, regs2, ups, state)
+
+      # ... one clause per opcode
+    end
+  end
+end
+```
+
+This is **the same shape** as the current `do_execute/8` in
+`lib/lua/vm/executor.ex`. The differences:
+
+- Instructions are indexed by `pc` integer, not consumed off a list.
+  PC math replaces list-spine consumption. Jumps are `pc = N`.
+- Opcode head is an integer, not an atom. Case dispatch becomes a
+  jump table.
+- Function head matches `{@op_X, ...}` once per opcode. The opcode
+  integer is the case scrutinee.
+
+Whether this is meaningfully faster than the current list-of-tuples
+interpreter is the gamble. The argument for "yes": B5a's perf gap
+to the codegen came primarily from `setelement/3` and `throw/catch`,
+neither of which this rewrite touches. B5a measured **dispatch
+alone** to be ~10–20% of the gap. The new dispatcher targets that
+slice without taking on the lifecycle hazard.
+
+If after B5a-take-2 we are not faster than the current interpreter
+by at least 1.2x on fib, this plan was the wrong bet and we should
+revisit (option C in the discussion: stay interpreter, profile and
+tune).
+
+### Codegen reuse from the deleted B5
+
+The `lib/lua/compiler/erlang/` tree has three files: `erlang.ex`,
+`codegen.ex`, `opcodes.ex`. The `Opcodes.lower/2` function in
+`opcodes.ex` (~798 lines) holds the per-opcode lowering rules.
+Most of those rules ("for `:add`, lower to a guarded integer fast
+path; for `:test`, branch on truthiness") translate directly to
+the new bytecode encoder. The Erlang-AST output type goes away;
+the structural decisions don't.
+
+`erlang.ex` (`:compile.forms/2` + `:code.load_binary/3`
+orchestration) deletes entirely.
+
+`codegen.ex` becomes `lib/lua/compiler/bytecode.ex` — same role
+(walk the prototype, build the output), different output.
+
+`runtime.ex` (helpers called from generated code) becomes
+`Lua.VM.Dispatcher` helpers.
+
+The `:compiled_closure` value type stays but its third element
+changes meaning: instead of `{:compiled_closure, mod, fun,
+upvalues}` it's `{:compiled_closure, bytecode, proto, upvalues}`
+(or just rename to keep the existing `:lua_closure` shape and
+add a `bytecode` field on the prototype). The `Executor` already
+has the right dispatch clause from B5a; it points to
+`Dispatcher.execute/3` instead of `apply(mod, fun, ...)`.
+
+### Fallback path
+
+Each compiler entry point tries the bytecode path. If it fails
+(opcode not yet covered, codegen bug), it falls back to the
+existing list-of-tuples interpreter. Same all-or-nothing per
+prototype as B5a.
+
+Difference from B5a: fallback is cheap — no atom was minted, no
+module was loaded, no purge required. Drop the result on the floor
+and use the original prototype.
+
+### Register representation
+
+Stay with the register tuple. Same as current interpreter. SSA
+promotion (eliminating `setelement/3`) was not realistic in
+generated Erlang either (B5a's discoveries called it out as
+deferred); it's even less realistic in a hand-written dispatcher
+where the tuple is part of the API surface.
+
+If `setelement/3` is the post-B5 ceiling, the next plan is mutable
+register storage via `:array` or a small dedicated process
+dictionary slot — not SSA. Out of scope for this rewrite.
+
+### What changes in `%Prototype{}`
+
+- Drop the B5a-added `compiled_module :: {atom(), atom()} | nil`
+  field.
+- Add `bytecode :: tuple() | nil` — the compiled bytecode value, or
+  `nil` if the prototype falls back to interpretation.
+- Constants pool stays put.
+
+### Sub-prototype compilation
+
+Same rule as B5a: sub-prototypes compile independently. The parent's
+`:closure` opcode checks `nested_proto.bytecode` and emits the
+right closure shape. This was the right call in B5a; it survives.
+
+### Error fidelity
+
+Same status as B5a's `:source_line`-based approach. The dispatcher
+threads a `current_line` integer through dispatch, updated by
+`:source_line` ops. On error, we raise with that line. Full position
+fidelity (B5d in this plan's renumbering) lands later.
+
+### Bench / lifecycle test
+
+Critical regression test that didn't exist for B5a: assert the
+codegen does **not** introduce VM growth. Add to the test suite:
+
+```elixir
+test "compiling N distinct sources does not grow atom table or code server" do
+  before_atoms = :erlang.system_info(:atom_count)
+  before_modules = length(:code.all_loaded())
+
+  for i <- 1..1000 do
+    {:ok, _, _} = Lua.eval(Lua.new(), "return #{i} + 1")
+  end
+
+  :erlang.garbage_collect()
+
+  # Some atoms get interned from Elixir-side string ops, but not 1000.
+  assert :erlang.system_info(:atom_count) - before_atoms < 50
+  assert length(:code.all_loaded()) == before_modules
+end
+```
+
+This is the test B5a should have had. Its absence is what shipped
+the leak.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+
+# Perf check.
+MIX_ENV=benchmark mix run benchmarks/fibonacci.exs
+MIX_ENV=benchmark mix run benchmarks/oop.exs
+MIX_ENV=benchmark mix run benchmarks/closures.exs
+MIX_ENV=benchmark mix run benchmarks/table_ops.exs
+
+# Leak check — must show no growth.
+mix run -e '
+before_atoms = :erlang.system_info(:atom_count)
+before_modules = length(:code.all_loaded())
+for i <- 1..10_000 do
+  {:ok, _, _} = Lua.eval(Lua.new(), "return #{i}")
+end
+:erlang.garbage_collect()
+IO.inspect(:erlang.system_info(:atom_count) - before_atoms, label: "new atoms")
+IO.inspect(length(:code.all_loaded()) - before_modules, label: "new modules")
+# Both should be ~0.
+'
+```
+
+## Risks
+
+- **The dispatcher does not beat the current interpreter
+  meaningfully.** Possible — the current interpreter is already
+  pretty tight. The B4 work that was meant to land flat-instruction-
+  stream dispatch never shipped. If this rewrite ends up at +5–10%
+  vs current interpreter, the work cost wasn't worth it and we
+  should pause Direction B until a better lever is identified.
+  Mitigation: B5a (the new B5a, not the deleted one) is the gating
+  experiment. It must clear "+20% on fib vs current interpreter"
+  to justify continuing.
+- **Decoding cost hides the dispatch win.** Tuple-element access is
+  cheap but not free; unpacking `{op, a, b, c}` per step costs
+  something. If profiling shows decode dominates dispatch we may
+  need to flatten to a tuple of bare integers and accept the loss
+  of operand-shape readability. Defer until measured.
+- **Mutation-via-setelement remains the ceiling.** Acknowledged.
+  Out of scope here. If it's the next bottleneck, the follow-up
+  plan is mutable register storage (process dict slot, `:array`,
+  or a small NIF) — not more codegen.
+- **Loss of speculative inlining the BEAM JIT was doing on B5a-
+  generated modules.** Real, hard to quantify without measuring.
+  Inlining wins were never the dominant factor in B5a's perf
+  number; dispatch elimination was. We give up the smaller win to
+  remove the safety hazard.
+
+## Discoveries
+
+### Why the original B5 path was abandoned
+
+B5a shipped successfully and met its functional bar but introduced
+an unbounded BEAM module + atom leak with no safe path to GC. Hard
+purge kills in-flight processes; soft purge is blocked by Lua
+coroutines suspended inside compiled chunks. A Lua program calling
+`load(untrusted_bytes)` in a loop is an atom-table-exhaustion DoS.
+
+See review of PR #235 (closed) for the full analysis. The decision
+to pivot was: "compile to BEAM modules" is fundamentally unsafe in
+a library that exposes runtime Lua compilation, no matter how
+clever the cache. Luerl avoids this by never generating BEAM modules
+in the first place. This plan adopts that constraint.
+
+### Spike data inherited from the deleted B5
+
+The faithful fib(25) spike measured 12.4x faster than interpreter
+when dispatching through a hand-loaded BEAM module. That number is
+not reachable from this plan — it came primarily from the
+single-prototype module enabling BEAMASM speculative optimization.
+The dispatcher path keeps the dispatch-elimination win (the
+bigger slice) but not the per-prototype-inlining win.
+
+Realistic target inherited from the spikes: ~2-3x interpreter on
+fib, ~2x interpreter on tables. Enough to clear the Luerl gap
+without claiming an unrealistic ceiling.
+
+### What survives from B5a
+
+- `Lua.VM.Executor` learned `:compiled_closure` dispatch. Useful;
+  keep the clause, repoint it at `Dispatcher.execute/3`.
+- `lib/lua/compiler/erlang/opcodes.ex` has per-opcode lowering
+  decisions (integer fast-path inlining, comparison shape, etc.).
+  Knowledge ports to the new bytecode encoder.
+- Test infrastructure for "compiled-vs-interpreted result equality"
+  ports unchanged.
+
+### What does not survive
+
+- `Lua.Compiler.Erlang` — entire `:compile.forms` + `:code.load_binary`
+  orchestration. Delete.
+- `Lua.Compiler.Erlang.Codegen` — Erlang-AST emission. Delete; some
+  per-opcode shape decisions port to bytecode encoder.
+- The `:erl_lint :unsafe_var` warning footgun goes away — bytecode
+  doesn't go through `:compile.forms`.
+- The `:throw/:catch` for non-tail return shape goes away (bytecode
+  jumps don't need to escape an Erlang function call boundary).
+  This may actually be a perf win the codegen path didn't have.

--- a/.agents/plans/B5a-v2-dispatcher-foundation.md
+++ b/.agents/plans/B5a-v2-dispatcher-foundation.md
@@ -1,0 +1,402 @@
+---
+id: B5a-v2
+title: Dispatcher foundation — single hand-written executor over dense bytecode
+issue: null
+pr: null
+branch: perf/dispatcher-foundation
+base: main
+status: ready
+direction: B
+unlocks:
+  - B5b-v2 (table opcodes), B5c-v2 (closures), B5d-v2 (error fidelity)
+  - Luerl parity on numeric workloads without runtime BEAM codegen
+parent: B5-dispatcher-and-bytecode
+---
+
+## Blocked on
+
+- Closing PR #235 and reverting any `:compile.forms`-related code
+  paths that may have leaked into `main` (none have, but the
+  `lib/lua/compiler/erlang/` tree on the PR branch must not be
+  carried into this work).
+
+## Goal
+
+Land the foundation for the new B5 approach: a single hand-written
+**dispatcher module** in `lib/lua/vm/dispatcher.ex` that interprets
+a **dense bytecode** representation of `%Prototype{}` values. No
+runtime BEAM module generation. No atoms minted per compile. No
+`:compile.forms`, no `:code.load_binary`.
+
+Scope mirrors the original B5a: arithmetic, comparison, logical
+ops, conditional `:test`, single-result `:call`, single-value
+`:return`, and the common `_ENV.name` lookup path. Tables and
+closures fall back to the existing list-of-tuples interpreter.
+
+## Why now
+
+The original B5a (PR #235) proved the dispatch-elimination
+hypothesis (1.45x faster than current interpreter, 1.07x faster
+than Luerl on fib(30)) but did so by generating per-prototype BEAM
+modules, which is fundamentally unsafe for an embedded Lua exposing
+runtime `load()`.
+
+The same dispatch shape, expressed as a single pattern-matched
+function over an integer-opcode bytecode, is the BEAM's standard
+case-jump-table idiom. It should capture most of the dispatch win
+without the lifecycle hazard.
+
+This is the gating experiment for Direction B. If the dispatcher
+does not beat the current interpreter by at least 1.2x on fib(25),
+the whole Direction-B premise is wrong and we should redirect to
+data-shape work (B6/B7) instead.
+
+## Out of scope
+
+- Tables. Falls back to interpreter. → B5b-v2.
+- Closures, varargs, multi-return. Falls back. → B5c-v2.
+- Error position fidelity in the dispatcher. → B5d-v2.
+- SSA / register promotion. Same as B5a-original — defer.
+- Direct-threaded dispatch (computed-goto-equivalent). Not until
+  case-dispatch is measured as the ceiling.
+- Mutable register storage (`:array`, process dict). Out of scope.
+- Mixed-mode (dispatcher prototype calls interpreter for a missing
+  opcode mid-stream). All-or-nothing per prototype.
+
+## Success criteria
+
+- [ ] `Lua.VM.Dispatcher` module exists at `lib/lua/vm/dispatcher.ex`,
+      hand-written, exports `execute(proto, args, state)` returning
+      `{results, state}`. One pattern-match clause per supported
+      opcode integer.
+- [ ] `Lua.Compiler.Bytecode` module exists at
+      `lib/lua/compiler/bytecode.ex`, walks a `%Prototype{}` with
+      the existing list-of-tuples instruction stream and produces
+      either `{:ok, bytecode_tuple}` or `:fallback`.
+- [ ] `%Prototype{}` gains a `bytecode :: tuple() | nil` field. Set
+      when the bytecode compiler accepts the prototype; nil
+      otherwise.
+- [ ] `Lua.VM.Executor.call_function/3` learns a clause for
+      `{:compiled_closure, bytecode, proto, upvalues}` that
+      dispatches to `Lua.VM.Dispatcher.execute/3`. (The
+      `:compiled_closure` value shape from PR #235's spike survives;
+      its third element changes meaning from "function name atom"
+      to "the prototype struct" so the dispatcher has metadata.)
+- [ ] The `:call` opcode in the existing interpreter learns the same
+      shortcut: when calling a `:compiled_closure`, route to
+      dispatcher with no register-tuple round trip.
+- [ ] Opcode coverage in this PR (mirror of original B5a):
+      `:load_constant`, `:load_boolean`, `:load_nil`, `:move`,
+      `:source_line`, `:scope`, `:get_upvalue`, `:get_global`,
+      `:load_env`, `:get_field` (env-lookup form only), `:add`,
+      `:subtract`, `:multiply`, `:divide`, `:floor_divide`,
+      `:modulo`, `:power`, `:negate`, `:less_than`, `:less_equal`,
+      `:greater_than`, `:greater_equal`, `:equal`, `:not_equal`,
+      `:not`, `:test`, `:test_true`, `:call` (single result),
+      `:return` (single value).
+- [ ] Uncovered opcodes return `:fallback` from the bytecode
+      compiler; the prototype stays interpreted. **No crashes.**
+- [ ] `mix test`: existing 1705 tests + 51 properties + 55 doctests,
+      0 failures.
+- [ ] `mix test --only lua53`: 29 tests, 0 failures.
+- [ ] **Leak regression test passes** (new test, see Implementation
+      notes): running `Lua.eval!` over 1000 distinct sources grows
+      atom count and code-loaded count by < 50 (allowing for
+      Elixir's string interning).
+- [ ] fib(25) beats current interpreter by ≥1.2x. Stretch: parity
+      with Luerl (±10%).
+- [ ] No workload regresses from current interpreter perf by more
+      than 10%.
+
+## Implementation notes
+
+### Bytecode shape
+
+The bytecode is a flat tuple of fixed-shape opcode tuples:
+
+```elixir
+proto.bytecode = {
+  {1, 0, 0},        # @op_load_constant dest=0 k_idx=0
+  {3, 2, 0, 1},     # @op_add dest=2 a=0 b=1
+  {12, 2, 0},       # @op_return single base=2 count=0 (count encoded in opcode)
+}
+```
+
+Each opcode is a small tuple with an integer opcode tag in slot 1
+and operand integers in subsequent slots. Constants are indices
+into `proto.constants` (already present).
+
+Why tuples, not binaries:
+
+- Operand widths vary by opcode (some have 2 args, some 4). Tuples
+  encode this naturally without bit-packing complexity.
+- `:erlang.element/2` is O(1) and the BEAM compiler emits a direct
+  load. Binary-cursor patterns are O(1) too but require explicit
+  decode logic.
+- The "no per-step allocation" property is satisfied — bytecode
+  tuples are built once at compile time, never mutated.
+
+Why integer opcode tags, not atoms:
+
+- Integer case-clause matching produces a jump table in BEAM
+  assembly. Atom matching usually does too, but integers are
+  unambiguously the fast path and the encoding stays tight.
+
+### Dispatcher shape
+
+```elixir
+defmodule Lua.VM.Dispatcher do
+  alias Lua.VM.{State, Value, Numeric, Executor}
+
+  @op_load_constant 1
+  @op_move 2
+  @op_add 3
+  @op_subtract 4
+  # ... one constant per supported opcode
+
+  @spec execute(Prototype.t(), [term()], State.t()) ::
+          {[term()], State.t()}
+  def execute(proto, args, state) do
+    regs = build_initial_regs(proto, args)
+    dispatch(proto.bytecode, proto.constants, proto.upvalues, 1, regs, state, 0)
+  end
+
+  defp dispatch(code, consts, ups, pc, regs, state, line) do
+    case :erlang.element(pc, code) do
+      {@op_load_constant, dest, k_idx} ->
+        v = :erlang.element(k_idx + 1, consts)
+        regs2 = :erlang.setelement(dest + 1, regs, v)
+        dispatch(code, consts, ups, pc + 1, regs2, state, line)
+
+      {@op_move, dest, src} ->
+        v = :erlang.element(src + 1, regs)
+        regs2 = :erlang.setelement(dest + 1, regs, v)
+        dispatch(code, consts, ups, pc + 1, regs2, state, line)
+
+      {@op_add, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+        case {va, vb} do
+          {ia, ib} when is_integer(ia) and is_integer(ib) ->
+            regs2 = :erlang.setelement(dest + 1, regs, ia + ib)
+            dispatch(code, consts, ups, pc + 1, regs2, state, line)
+          _ ->
+            {v, state2} = Numeric.add(va, vb, state)
+            regs2 = :erlang.setelement(dest + 1, regs, v)
+            dispatch(code, consts, ups, pc + 1, regs2, state2, line)
+        end
+
+      {@op_return_one, base} ->
+        v = :erlang.element(base + 1, regs)
+        {[v], state}
+
+      # ... etc, one clause per opcode
+    end
+  end
+end
+```
+
+Same shape as `Lua.VM.Executor.do_execute/8` today, with PC arithmetic
+instead of list consumption and integer dispatch instead of
+atom-keyed tuple dispatch.
+
+### Compiler entry point
+
+```elixir
+defmodule Lua.Compiler.Bytecode do
+  @spec compile(Prototype.t()) :: {:ok, Prototype.t()} | :fallback
+
+  def compile(%Prototype{} = proto) do
+    with {:ok, encoded} <- encode_instructions(proto.instructions, proto),
+         {:ok, sub_protos} <- compile_subprotos(proto.subprotos) do
+      {:ok, %{proto | bytecode: encoded, subprotos: sub_protos}}
+    else
+      :fallback -> :fallback
+    end
+  end
+
+  defp encode_instructions(instructions, proto) do
+    # walk instructions, emit bytecode tuples, return :fallback on first
+    # uncovered opcode.
+  end
+end
+```
+
+`Lua.Compiler.compile/2` (the existing entry) wraps this:
+
+```elixir
+def compile(source, opts \\ []) do
+  proto = existing_parse_compile_pipeline(source, opts)
+  case Lua.Compiler.Bytecode.compile(proto) do
+    {:ok, with_bytecode} -> with_bytecode
+    :fallback -> proto
+  end
+end
+```
+
+### Per-opcode lowering (porting from PR #235)
+
+The `Lua.Compiler.Erlang.Opcodes.lower/2` function in PR #235's
+branch held the integer fast-path inlining decisions for each
+opcode. Those decisions port directly to the bytecode compiler:
+
+- `:add`/`:subtract`/`:multiply` with integer fast path: the
+  dispatcher clause inlines the integer guard, slow path delegates
+  to `Numeric.add` etc.
+- `:divide`/`:floor_divide`/`:modulo`/`:power`: slow path only in
+  the dispatcher (matches the executor's existing structure).
+- `:less_than` etc. with number fast path: same.
+- `:test` / `:test_true`: compile to a branch that updates PC. The
+  compiler resolves label-to-PC at encode time; jumps become
+  `pc = N` in the dispatcher.
+
+The encoding boundary is the only thing that's new. The lowering
+*decisions* are knowledge transfer from PR #235.
+
+### `:compiled_closure` value type
+
+Carried over from PR #235's spike, adapted:
+
+```elixir
+# Before (PR #235):
+{:compiled_closure, module_name, function_name, upvalues_tuple, proto}
+
+# After (this plan):
+{:compiled_closure, bytecode_tuple, proto, upvalues_tuple}
+```
+
+Why keep the wrapper instead of just adding `bytecode` to `:lua_closure`:
+
+- Pattern-match locality. `Executor.call_function/3` dispatches on
+  the head atom. A separate `:compiled_closure` keeps the
+  dispatcher path off the interpreter's hot path.
+- Matches the closure-creation cascade rules from PR #235:
+  sub-prototype compile status flows through the closure value, not
+  back through the prototype.
+
+### Closure-creation cascade
+
+Same rule as PR #235's discovery: sub-prototypes compile
+independently. The parent's `:closure` opcode (in the interpreter,
+since `:closure` isn't covered by this plan's bytecode) checks
+`nested_proto.bytecode` and emits either `:compiled_closure` (if
+set) or `:lua_closure` (if nil). This was the right call in PR #235;
+it survives.
+
+### Files
+
+- `lib/lua/vm/dispatcher.ex` (new) — hand-written executor over
+  bytecode. One clause per opcode integer. Roughly 1 case branch
+  per opcode → ~30 branches in this PR.
+- `lib/lua/compiler/bytecode.ex` (new) — bytecode encoder. Per-
+  opcode encode helpers. Returns `:fallback` on first uncovered
+  opcode.
+- `lib/lua/compiler/prototype.ex` — add `bytecode` field, default
+  nil. **Remove** any `compiled_module` field from PR #235 if it
+  exists in the branch (it should not have been merged).
+- `lib/lua/compiler.ex` — wire `Lua.Compiler.Bytecode.compile/1`
+  into the main compile path.
+- `lib/lua/vm/executor.ex` — add `:compiled_closure` clauses to
+  `call_function/3` and the `:call` opcode dispatch. Both route
+  to `Dispatcher.execute/3`.
+- `lib/lua/vm.ex` — top-level `execute/2` dispatches via
+  Dispatcher if `proto.bytecode` is non-nil.
+- `test/lua/vm/dispatcher_test.exs` (new) — per-opcode golden tests
+  (compiled result == interpreted result).
+- `test/lua/compiler/bytecode_test.exs` (new) — fallback cascade
+  tests (every uncovered opcode returns `:fallback`; sub-prototype
+  fallback does **not** cascade to parent).
+- `test/lua/vm/leak_regression_test.exs` (new) — **critical**.
+  Asserts that 1000 distinct `Lua.eval!` calls grow neither the
+  atom count nor the loaded-module count by more than a small
+  noise threshold. This is the test PR #235 should have had.
+
+### Leak regression test (specific shape)
+
+```elixir
+defmodule Lua.VM.LeakRegressionTest do
+  use ExUnit.Case, async: false
+
+  test "compiling N distinct prototypes does not grow atom table" do
+    before_atoms = :erlang.system_info(:atom_count)
+    before_modules = length(:code.all_loaded())
+
+    for i <- 1..1_000 do
+      {:ok, _, _} = Lua.eval(Lua.new(), "return #{i} + 1")
+    end
+
+    :erlang.garbage_collect()
+
+    after_atoms = :erlang.system_info(:atom_count)
+    after_modules = length(:code.all_loaded())
+
+    # Elixir may intern atoms for compiled string ops. Allow some headroom
+    # but the per-iteration growth must be ~0.
+    assert after_atoms - before_atoms < 50,
+      "atom count grew by #{after_atoms - before_atoms} over 1000 evals"
+    assert after_modules == before_modules,
+      "loaded module count grew by #{after_modules - before_modules}"
+  end
+
+  test "load() with unique sources does not grow atom table" do
+    before_atoms = :erlang.system_info(:atom_count)
+
+    lua = Lua.new()
+    {_, lua} = Lua.eval!(lua, "for i = 1, 1000 do load('return ' .. i)() end")
+
+    :erlang.garbage_collect()
+
+    assert :erlang.system_info(:atom_count) - before_atoms < 50
+  end
+end
+```
+
+This test is non-negotiable for this plan. The whole point of the
+rewrite is that it passes.
+
+### Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+mix test test/lua/vm/leak_regression_test.exs
+
+# Perf gate.
+MIX_ENV=benchmark mix run benchmarks/fibonacci.exs
+
+# Smoke other workloads.
+MIX_ENV=benchmark mix run benchmarks/oop.exs
+MIX_ENV=benchmark mix run benchmarks/closures.exs
+MIX_ENV=benchmark mix run benchmarks/table_ops.exs
+MIX_ENV=benchmark mix run benchmarks/string_ops.exs
+```
+
+## Risks
+
+- **The dispatcher is no faster than the current interpreter.**
+  This is the gating risk. PR #235 measured the codegen at 1.45x
+  the current interpreter on fib(30); some of that win came from
+  BEAMASM speculative inlining on freshly loaded per-prototype
+  modules, which the dispatcher cannot replicate. If the
+  dispatcher is below 1.2x current interpreter on fib(25), pause
+  Direction B and revisit. The codegen plus all of B5 was the wrong
+  bet.
+- **`setelement/3` ceiling.** Inherited from PR #235's discoveries.
+  Out of scope here. If profiling shows it's the post-this-PR
+  ceiling, the next plan is mutable register storage, not more
+  dispatch work.
+- **Tuple-element decode cost.** Pattern-matching `{@op_add, dest,
+  a, b}` allocates nothing but does cost a tuple-shape check per
+  opcode. Likely ~5–10% on top of pure dispatch. If profiling
+  shows decode dominates, follow-up plan flattens to a tuple of
+  bare integers and accepts the operand-shape readability loss.
+- **Hot-reload during `mix test`.** Now a non-issue. The
+  dispatcher is a normal module. No per-prototype modules to
+  invalidate. Bytecode tuples live in `%Prototype{}` and have no
+  affinity to a particular code version.
+
+## Discoveries
+
+(Will be filled in during implementation.)

--- a/.agents/plans/B5b-v2-dispatcher-tables.md
+++ b/.agents/plans/B5b-v2-dispatcher-tables.md
@@ -1,0 +1,48 @@
+---
+id: B5b-v2
+title: Dispatcher table opcodes — make table-heavy workloads bypass the interpreter
+issue: null
+pr: null
+branch: perf/dispatcher-tables
+base: main
+status: blocked
+direction: B
+unlocks:
+  - ~2x speedup on table_ops benchmarks
+  - the full OOP benchmark workload (depends on tables + closures)
+parent: B5-dispatcher-and-bytecode
+---
+
+## Blocked on
+
+- B5a-v2 (dispatcher foundation).
+
+## Goal
+
+Extend `Lua.VM.Dispatcher` and `Lua.Compiler.Bytecode` to lower the
+table opcode family: `:new_table`, `:get_table`, `:set_table`,
+`:set_list`, `:get_field` (full path, not just env lookup),
+`:set_field`. After this PR, prototypes that touch tables compile
+end-to-end and stay out of the interpreter fallback path.
+
+The original B5 third spike measured **2.1x faster than interpreter**
+on run_table_sum(1000). The dispatcher should land at a similar or
+slightly worse ratio (the spike used a compiled BEAM module; the
+dispatcher pays per-step dispatch).
+
+## Out of scope
+
+- Mutable table storage. `Table.put/3` allocation churn is the
+  ceiling for table workloads on the BEAM; not addressed here.
+- Metamethod dispatch via `__index` / `__newindex` short-circuiting.
+  The dispatcher delegates to existing `Executor.index_value/6`
+  helpers, which handle metamethods.
+
+## Success criteria
+
+(To be detailed when this plan unblocks. Mirrors original B5c
+success criteria but targets the dispatcher rather than codegen.)
+
+## Discoveries
+
+(Empty until implementation.)

--- a/.agents/plans/B5c-v2-dispatcher-closures.md
+++ b/.agents/plans/B5c-v2-dispatcher-closures.md
@@ -1,0 +1,49 @@
+---
+id: B5c-v2
+title: Dispatcher closures, varargs, and multi-return — every opcode covered
+issue: null
+pr: null
+branch: perf/dispatcher-closures
+base: main
+status: blocked
+direction: B
+unlocks:
+  - 100% opcode coverage in the dispatcher (no more fallbacks)
+  - closures and OOP benchmarks fully dispatcher-routed
+parent: B5-dispatcher-and-bytecode
+---
+
+## Blocked on
+
+- B5a-v2 (foundation), B5b-v2 (tables).
+
+## Goal
+
+Cover the remaining opcodes in `Lua.VM.Dispatcher`:
+
+- `:closure` — closure construction with upvalue capture.
+- `:set_upvalue`.
+- `:get_open_upvalue`, `:set_open_upvalue` — open-cell access for
+  captures of mutable locals.
+- `:vararg`, `:return_vararg`.
+- `:return` with count > 1.
+- `:generic_for`, `:self`, `:tail_call`.
+
+After this PR no prototype falls back to the list-of-tuples
+interpreter for opcode-coverage reasons.
+
+## Out of scope
+
+- Tail-call elimination beyond what the BEAM gives us "for free"
+  from tail-recursive dispatch.
+- Optimised closure capture (escape analysis, capture-by-value
+  promotion). Defer.
+
+## Success criteria
+
+(To be detailed when this plan unblocks. Mirrors original B5d
+success criteria.)
+
+## Discoveries
+
+(Empty until implementation.)

--- a/.agents/plans/B5d-v2-dispatcher-errors.md
+++ b/.agents/plans/B5d-v2-dispatcher-errors.md
@@ -1,0 +1,52 @@
+---
+id: B5d-v2
+title: Dispatcher error position fidelity
+issue: null
+pr: null
+branch: perf/dispatcher-errors
+base: main
+status: blocked
+direction: B
+unlocks:
+  - parity with interpreter on every error-message test
+  - removes the last semantic gap between dispatcher and interpreter
+parent: B5-dispatcher-and-bytecode
+---
+
+## Blocked on
+
+- B5a-v2 (foundation), B5b-v2 (tables), B5c-v2 (closures).
+
+## Goal
+
+Make dispatcher-executed prototypes raise exceptions with the same
+`line:`, `source:`, and stack-trace information the interpreter
+raises. After this PR no error-message test can distinguish a
+dispatcher-routed prototype from an interpreted one.
+
+## Implementation strategy
+
+PC-to-line table per prototype, populated by the bytecode encoder
+from `:source_line` opcodes. The dispatcher threads `current_line`
+through every step (already in B5a-v2's signature). On raise, wrap
+in try/catch and re-raise with the right position. This is
+cheaper inside a single dispatcher than across a generated-module
+boundary (the original B5e's plan) because no cross-module
+unwinding is needed.
+
+## Out of scope
+
+- Stack-trace shape for compiled-to-compiled call chains. The
+  per-call shape from the interpreter survives — `call_function/3`
+  already carries position context.
+- Source-map formats compatible with external debuggers. Not in
+  scope for this rewrite.
+
+## Success criteria
+
+(To be detailed when this plan unblocks. Mirrors original B5e
+success criteria.)
+
+## Discoveries
+
+(Empty until implementation.)


### PR DESCRIPTION
Strategic pivot for Direction B following PR #235's closure.

## What this changes

- **New parent plan**: `.agents/plans/B5-dispatcher-and-bytecode.md`.
- **New B5a–B5d**: dispatcher module + bytecode encoder, then tables, closures, errors. Versioned `-v2` to keep the old plan structure findable in git history.
- **Old B5 parent**: marked superseded. Historical content (spikes, perf data, lowering decisions) preserved.
- The old B5a–B5e child plans never existed on `main` — they were only on PR #235's branch — so nothing to delete here.

## Why

PR #235 shipped a working BEAM-codegen path (1.07x faster than Luerl on fib(30)) but it leaks atoms and modules per compile with no safe GC path:

- `:code.soft_purge/1` is blocked by any process executing in the module, including Lua coroutines suspended mid-call.
- `:code.purge/1` kills those processes.
- Atoms minted for module names are never GC'd. Default cap ~1M, then the VM aborts.

A Lua program calling `load(untrusted_bytes)` in a loop becomes an atom-table DoS reachable from any host that exposes runtime Lua compilation — which is the whole point of an embedded Lua. The proposed lifecycle fix (B5b in the old sequence) could not address this.

Luerl avoids the problem entirely by never calling `compile:*` or `code:*`. Its compiled chunks are plain Erlang data walked by `luerl_emul:emul_1/7`. This pivot adopts the same constraint.

## The new shape

- `Lua.VM.Dispatcher` — single hand-written module, loaded once at boot. One pattern-match clause per opcode integer over a tight tail-recursive dispatch.
- `Lua.Compiler.Bytecode` — encodes a `%Prototype{}` to a tuple of fixed-shape opcode tuples, with operand indices into the existing constants pool.
- `%Prototype{}` gains a `bytecode` field; nil means fall back to the existing list-of-tuples interpreter.
- B5a-v2 includes a non-negotiable leak regression test: 1000 distinct evals must not grow atom count or loaded-module count. This is the test PR #235 should have had.

## Perf expectation

Lower ceiling than PR #235 but still enough to clear the Luerl gap. B5a-v2 must beat the current interpreter by ≥1.2x on fib(25); if it doesn't, the whole Direction-B premise is wrong and we redirect to data-shape work (B6/B7).

## What survives from PR #235

The per-opcode lowering knowledge in `lib/lua/compiler/erlang/opcodes.ex` ports directly to the bytecode encoder — integer fast paths, comparison shape, branch encoding. Only the output target changes. The `:compile.forms` orchestration deletes entirely.

This PR is plans-only. No `lib/` changes. The implementation lands via B5a-v2 next.