### PR TITLE
perf(vm): add dense bytecode encoding + dispatcher for compiled prototypes

### DIFF
--- a/.agents/plans/B5a-v2-dispatcher-foundation.md
+++ b/.agents/plans/B5a-v2-dispatcher-foundation.md
@@ -2,10 +2,10 @@
 id: B5a-v2
 title: Dispatcher foundation — single hand-written executor over dense bytecode
 issue: null
-pr: null
+pr: 237
 branch: perf/dispatcher-foundation
 base: main
-status: in-progress
+status: review
 direction: B
 unlocks:
   - B5b-v2 (table opcodes), B5c-v2 (closures), B5d-v2 (error fidelity)
@@ -399,4 +399,144 @@ MIX_ENV=benchmark mix run benchmarks/string_ops.exs
 
 ## Discoveries
 
-(Will be filled in during implementation.)
+### IR shape diverges from plan
+
+The plan was drafted against a mental model of a flat instruction stream
+with absolute PC labels and a separate constants pool. The actual IR is
+**structured**: `:test` carries nested instruction lists for then/else
+branches, loops use CPS continuation markers (not PC jumps), and
+constants are inlined directly into opcodes (no pool, no `k_idx`).
+
+Adapted the design accordingly: the bytecode is a tuple of opcode tuples
+where `:test` recursively carries nested bytecode sub-tuples. The
+dispatcher pushes `{code, pc}` resume points onto a local continuation
+stack when entering a branch body, mirroring the interpreter's pattern.
+No PC label resolution machinery needed.
+
+### Several plan opcode signatures were stale
+
+- `:return` is `{:return, base, count}`, not `{:return_one, base}`.
+- `:call` is 5-tuple with `name_hint`, not 3-tuple.
+- `:load_env` carries `dest`, not zero operands.
+- `:source_line` is `{:source_line, line, file}`, not just `{line}`.
+- `:scope` is listed in coverage but never emitted by the current
+  codegen — it's vestigial in `Lua.Compiler.Instruction`.
+
+The bytecode encoder matches the actual shapes. `:scope` was dropped
+from coverage as a no-op.
+
+### `proto.subprotos` field is named `prototypes`
+
+The plan called it `subprotos` throughout. The actual struct field is
+`prototypes`. Bytecode compilation walks `proto.prototypes` and stores
+encoded children back in the same field.
+
+### `:source_line` opcodes stripped from bytecode
+
+Keeping them in the dense encoding cost one no-op dispatch per source
+line, ~5% on fib(25). Stripped at encode time. Error attribution for
+compiled prototypes is deferred to B5d-v2 anyway, so the
+instruction-stream `:source_line` entries (used by the interpreter for
+error positions) survive untouched on the prototype.
+
+### Perf gate is brushed, not robustly cleared
+
+Final measurements on fib(25) (full Benchee mode, median of 10s runs):
+
+- Dispatcher: ~65 ms/iter
+- Interpreter (same VM, bytecode stripped): ~76 ms/iter
+- **Speedup: 1.17x median** (range 1.14x – 1.21x across runs, ~1.5% deviation)
+
+The plan's gate was ≥1.2x. We sit between 1.14 and 1.21, with the
+median around 1.17. fib(30) full benchmark beats Luerl by ~5% on a good
+run (stretch goal: parity ±10%). No workload regresses.
+
+Why we didn't hit a clean 1.2x: the interpreter is already heavily
+tuned (per-clause guards, inlined integer fast paths, dedicated
+`{:return, _, 1}` fast clause). The dispatcher's wins — integer-tagged
+case dispatch, tuple-encoded operands, stripped `:source_line` — are
+real but bounded by the interpreter's existing optimisations.
+
+Profile attribution after all optimization passes:
+
+- `Dispatcher.dispatch/8`: 50% (the case-jump-table itself)
+- `:erlang.setelement/3`: 30% (register writes — unavoidable)
+- `copy_regs/5` + `init_callee_regs/4`: 9% (call setup tuple allocation)
+- `return_one/3`: 4% (frame unwinding)
+
+Further gains require structural changes explicitly out of scope:
+
+- Mutable register storage (`:array`/process dict) would eliminate
+  `setelement/3` allocations entirely.
+- Flat PC bytecode with label resolution would let `:test` skip the
+  continuation-stack push.
+- Direct-threaded dispatch (computed-goto-equivalent) would replace
+  the case statement with token-driven jumps.
+
+Each is its own follow-up plan.
+
+### Optimization iterations log
+
+For reproducibility — the perf loop that got us from 1.05x to 1.17x:
+
+1. **Initial baseline:** 1.05x (dispatch/8 + step/9 two-level chain).
+2. **Inlined `step/9` into `dispatch/8`:** 1.09x (eliminated one call frame per opcode).
+3. **Tuple frames + unboxed `return_one/3`:** 1.09x (skips `[v]` allocation on return).
+4. **Stripped `:source_line` from bytecode:** 1.15x (~5% win — 228k dispatches saved on fib(25)).
+5. **Inlined int64-bounds guard + truthy check:** 1.17x median (eliminated `Numeric.to_signed_int64` and `Value.truthy?` function calls in hot paths).
+6. **Tried open_upvalues empty-map elision:** -3% regression, reverted.
+
+### `:compiled_closure` plumbing has more touch points than expected
+
+Every site in the codebase that pattern-matches on `{:lua_closure, _, _}`
+needed a parallel clause for `{:compiled_closure, _, _}`:
+
+- `Lua.VM.Executor.call_function/3`, `:call` opcode, `:closure` opcode, `invoke_metamethod`, `call_value`, `value_type`
+- `Lua.VM.Value.type_name`, `to_string`
+- `Lua.VM.Stdlib.lua_load`, `compile_loaded_chunk`
+- `Lua.VM.Stdlib.Util.typeof`
+- `Lua.VM.Stdlib.String` (gsub repl)
+- `Lua.VM.Stdlib.Debug.getinfo`
+- `Lua.VM.Display.wrap_value`, `wrap_closure`
+- `Lua.Util.encoded?`
+- `Lua.Api.is_lua_func` guard
+- `Lua.do_call_function`
+
+Tests that asserted on the specific `:lua_closure` tag (display tests,
+unwrap doctest) had to learn that closures may now be either tag.
+
+This was a real cost. A future refactor could collapse the two tags
+into one (`{:lua_closure, proto, upvalues}` where `proto.bytecode != nil`
+implies dispatcher routing) — but the explicit tag makes the routing
+decision local to `call_function/3` and that's worth something.
+
+### Tests added
+
+- `test/lua/vm/dispatcher_test.exs` — 27 per-opcode goldens.
+- `test/lua/compiler/bytecode_test.exs` — 14 fallback cascade tests.
+- `test/lua/vm/leak_regression_test.exs` — 3 leak guards (atom count
+  growth, module load growth, bytecode-is-tuple shape).
+
+Total: +44 tests, 1705 → 1749, 0 failures.
+
+## What changed
+
+- New: `lib/lua/compiler/bytecode.ex` (encoder),
+  `lib/lua/vm/dispatcher.ex` (hand-written executor),
+  `benchmarks/dispatcher_vs_interpreter.exs` (perf comparison harness),
+  `test/lua/compiler/bytecode_test.exs`,
+  `test/lua/vm/dispatcher_test.exs`,
+  `test/lua/vm/leak_regression_test.exs`.
+- Modified: `lib/lua/compiler.ex` (wires bytecode encoder into compile
+  pipeline), `lib/lua/compiler/prototype.ex` (adds `bytecode` field),
+  `lib/lua/vm/executor.ex` (adds `:compiled_closure` clauses to
+  `call_function/3`, `:call` opcode, `:closure` opcode; adds
+  `dispatcher_*` bridge helpers for arithmetic/comparison/field access),
+  `lib/lua.ex`, `lib/lua/api.ex`, `lib/lua/util.ex`,
+  `lib/lua/vm/{display,value}.ex`,
+  `lib/lua/vm/stdlib/{debug,string,util}.ex`,
+  `lib/lua/vm/stdlib.ex` (all gain parallel `:compiled_closure` clauses).
+- Tests: `test/lua/vm/display_test.exs` updated to accept either
+  closure tag.
+
+PR: https://github.com/tv-labs/lua/pull/237

--- a/.agents/plans/B5a-v2-dispatcher-foundation.md
+++ b/.agents/plans/B5a-v2-dispatcher-foundation.md
@@ -5,7 +5,7 @@ issue: null
 pr: null
 branch: perf/dispatcher-foundation
 base: main
-status: ready
+status: in-progress
 direction: B
 unlocks:
   - B5b-v2 (table opcodes), B5c-v2 (closures), B5d-v2 (error fidelity)

--- a/.agents/plans/B5d-v2-dispatcher-errors.md
+++ b/.agents/plans/B5d-v2-dispatcher-errors.md
@@ -34,11 +34,19 @@ cheaper inside a single dispatcher than across a generated-module
 boundary (the original B5e's plan) because no cross-module
 unwinding is needed.
 
+In addition to per-prototype line info, `:call_one` in the
+dispatcher must push a `call_info` frame onto `state.call_stack`
+(matching the interpreter's `executor.ex:777` semantics) and the
+return path must pop it. Without this, `debug.traceback/0` from a
+compiled callee and the stack-trace section of any
+`RuntimeError` / `TypeError` / `ArgumentError` raised from a
+compiled-to-compiled call chain will silently truncate to the
+caller of `Dispatcher.execute/3-4`. The current B5a-v2 PR ships
+the missing frames as a known gap so the perf win can land first.
+See [PR #237 review summary](https://github.com/tv-labs/lua/pull/237).
+
 ## Out of scope
 
-- Stack-trace shape for compiled-to-compiled call chains. The
-  per-call shape from the interpreter survives — `call_function/3`
-  already carries position context.
 - Source-map formats compatible with external debuggers. Not in
   scope for this rewrite.
 

--- a/benchmarks/dispatcher_vs_interpreter.exs
+++ b/benchmarks/dispatcher_vs_interpreter.exs
@@ -1,0 +1,57 @@
+# Compares the dispatcher vs interpreter on the same fib(25) workload.
+# Strips `proto.bytecode` to force the interpreter path on an otherwise-
+# identical Lua VM state. Used by perf-gate verification for B5a-v2.
+
+Code.require_file("helpers.exs", __DIR__)
+
+fib_def = """
+function fib(n)
+  if n < 2 then return n end
+  return fib(n-1) + fib(n-2)
+end
+"""
+
+# Compile once, get a clean state with `fib` installed as a global.
+lua_dispatcher = Lua.new() |> Lua.eval!(fib_def) |> elem(1)
+
+strip_bytecode = fn walker, %Lua.Compiler.Prototype{} = p ->
+  %{p | bytecode: nil, prototypes: Enum.map(p.prototypes, &walker.(walker, &1))}
+end
+
+# Strip bytecode from fib so the call routes through the interpreter.
+strip_state = fn state ->
+  case Lua.VM.State.get_global(state, "fib") do
+    {:compiled_closure, proto, upvalues} ->
+      stripped = strip_bytecode.(strip_bytecode, proto)
+      Lua.VM.State.set_global(state, "fib", {:lua_closure, stripped, upvalues})
+
+    {:lua_closure, proto, upvalues} ->
+      stripped = strip_bytecode.(strip_bytecode, proto)
+      Lua.VM.State.set_global(state, "fib", {:lua_closure, stripped, upvalues})
+  end
+end
+
+lua_interpreter = %{lua_dispatcher | state: strip_state.(lua_dispatcher.state)}
+
+IO.puts("\n--- closure tags ---")
+{:compiled_closure, _, _} = Lua.VM.State.get_global(lua_dispatcher.state, "fib")
+{:lua_closure, _, _} = Lua.VM.State.get_global(lua_interpreter.state, "fib")
+IO.puts("dispatcher: :compiled_closure")
+IO.puts("interpreter: :lua_closure")
+
+# Correctness sanity check.
+{[result_d], _} = Lua.eval!(lua_dispatcher, "return fib(20)")
+{[result_i], _} = Lua.eval!(lua_interpreter, "return fib(20)")
+IO.puts("\nfib(20) dispatcher=#{result_d} interpreter=#{result_i} match=#{result_d == result_i}\n")
+
+call_fib = "return fib(25)"
+{chunk_d, _} = Lua.load_chunk!(lua_dispatcher, call_fib)
+{chunk_i, _} = Lua.load_chunk!(lua_interpreter, call_fib)
+
+Benchee.run(
+  %{
+    "dispatcher fib(25)" => fn -> Lua.eval!(lua_dispatcher, chunk_d) end,
+    "interpreter fib(25)" => fn -> Lua.eval!(lua_interpreter, chunk_i) end
+  },
+  Bench.opts()
+)

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -9,6 +9,7 @@ defmodule Lua do
   alias Lua.Util
   alias Lua.VM.AssertionError
   alias Lua.VM.Display
+  alias Lua.VM.Executor
   alias Lua.VM.InternalError
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
@@ -713,8 +714,17 @@ defmodule Lua do
       end)
 
     {results, _regs, new_state} =
-      Lua.VM.Executor.execute(proto.instructions, callee_regs, upvalues, proto, state)
+      Executor.execute(proto.instructions, callee_regs, upvalues, proto, state)
 
+    {:ok, results, new_state}
+  rescue
+    e -> {:error, Exception.message(e), state}
+  end
+
+  defp do_call_function({:compiled_closure, _, _} = closure, args, state) do
+    # Compiled callees route through the dispatcher; same observable
+    # contract as the interpreter branch above.
+    {results, new_state} = Executor.call_function(closure, args, state)
     {:ok, results, new_state}
   rescue
     e -> {:error, Exception.message(e), state}
@@ -757,7 +767,7 @@ defmodule Lua do
       true
 
       iex> {[c], _} = Lua.eval!(Lua.new(), "return function() end")
-      iex> match?({:lua_closure, _, _}, Lua.unwrap(c))
+      iex> match?({:lua_closure, _, _}, Lua.unwrap(c)) or match?({:compiled_closure, _, _}, Lua.unwrap(c))
       true
 
       iex> Lua.unwrap(42)

--- a/lib/lua/api.ex
+++ b/lib/lua/api.ex
@@ -141,7 +141,8 @@ defmodule Lua.API do
   Is the value a reference to a Lua function?
   """
   defguard is_lua_func(value)
-           when is_tuple(value) and tuple_size(value) == 3 and elem(value, 0) == :lua_closure
+           when is_tuple(value) and tuple_size(value) == 3 and
+                  (elem(value, 0) == :lua_closure or elem(value, 0) == :compiled_closure)
 
   @doc """
   Is the value a reference to an Erlang / Elixir function?

--- a/lib/lua/compiler.ex
+++ b/lib/lua/compiler.ex
@@ -6,6 +6,7 @@ defmodule Lua.Compiler do
   """
 
   alias Lua.AST.Chunk
+  alias Lua.Compiler.Bytecode
   alias Lua.Compiler.Codegen
   alias Lua.Compiler.Prototype
   alias Lua.Compiler.Scope
@@ -16,11 +17,19 @@ defmodule Lua.Compiler do
 
   @doc """
   Compiles a Lua AST chunk into a prototype.
+
+  After codegen, the prototype is offered to `Lua.Compiler.Bytecode` for
+  dense encoding. Sub-prototypes are encoded independently — the dispatcher
+  takes over per-prototype wherever every opcode in that prototype falls
+  within its coverage; anything else stays on the interpreter. The
+  original instruction stream is preserved either way, so error reporting
+  and tooling continue to work unchanged.
   """
   @spec compile(Chunk.t(), compile_opts()) :: {:ok, Prototype.t()} | {:error, term()}
   def compile(%Chunk{} = chunk, opts \\ []) do
-    with {:ok, scope_state} <- Scope.resolve(chunk, opts) do
-      Codegen.generate(chunk, scope_state, opts)
+    with {:ok, scope_state} <- Scope.resolve(chunk, opts),
+         {:ok, prototype} <- Codegen.generate(chunk, scope_state, opts) do
+      {:ok, Bytecode.compile(prototype)}
     end
   end
 

--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -1,0 +1,230 @@
+defmodule Lua.Compiler.Bytecode do
+  @moduledoc """
+  Bytecode encoder for `Lua.Compiler.Prototype`.
+
+  Walks the structured instruction stream of a prototype and emits a dense
+  tuple-of-tuples encoding suitable for `Lua.VM.Dispatcher`. Integer opcode
+  tags occupy slot 1 of each opcode tuple; operands follow in fixed slots.
+
+  Returns `{:ok, prototype}` with `bytecode` populated when every instruction
+  in the prototype falls within the dispatcher's coverage. Returns
+  `:fallback` the first time an uncovered opcode is encountered — the caller
+  keeps the prototype as-is, and the interpreter handles it.
+
+  Sub-prototypes are compiled independently. A parent that contains an
+  uncovered opcode falls back to interpretation even when its sub-prototypes
+  successfully compile, and vice versa.
+  """
+
+  alias Lua.Compiler.Prototype
+
+  # Integer opcode tags. Kept in lockstep with the corresponding @op_*
+  # constants in `Lua.VM.Dispatcher`. Small contiguous integers help the
+  # BEAM emit a jump table for the dispatcher's outer case.
+
+  @op_load_constant 1
+  @op_load_boolean 2
+  @op_load_nil 3
+  @op_move 4
+  @op_load_env 5
+  @op_get_upvalue 6
+  @op_get_global 7
+  @op_get_field 8
+  @op_add 9
+  @op_subtract 10
+  @op_multiply 11
+  @op_divide 12
+  @op_floor_divide 13
+  @op_modulo 14
+  @op_power 15
+  @op_negate 16
+  @op_less_than 17
+  @op_less_equal 18
+  @op_greater_than 19
+  @op_greater_equal 20
+  @op_equal 21
+  @op_not_equal 22
+  @op_not 23
+  @op_test 24
+  @op_test_true 25
+  @op_call_one 26
+  @op_return_one 27
+  @op_return_zero 28
+  @op_source_line 29
+
+  @doc """
+  Compile a prototype, populating its `bytecode` field on success.
+
+  Sub-prototypes are compiled recursively; each is independent. A failure
+  in one sub-prototype does not block another from being compiled.
+
+  The parent prototype only gains a bytecode encoding if every instruction
+  in its own body is supported. If the parent falls back, sub-prototype
+  encodings are still preserved on the children.
+  """
+  @spec compile(Prototype.t()) :: Prototype.t()
+  def compile(%Prototype{} = proto) do
+    compiled_children =
+      Enum.map(proto.prototypes, &compile/1)
+
+    proto_with_children = %{proto | prototypes: compiled_children}
+
+    case encode_list(proto.instructions, []) do
+      {:ok, encoded} ->
+        %{proto_with_children | bytecode: List.to_tuple(encoded)}
+
+      :fallback ->
+        proto_with_children
+    end
+  end
+
+  # ── Encoding ────────────────────────────────────────────────────────────
+  #
+  # Walks an instruction list, accumulating opcode tuples in reverse. On
+  # the first uncovered opcode, the whole list bails out as `:fallback`.
+
+  defp encode_list([], acc), do: {:ok, Enum.reverse(acc)}
+
+  # `:source_line` opcodes are stripped from the bytecode entirely. They
+  # only feed error attribution, which is deferred to B5d-v2 for compiled
+  # prototypes. Keeping them in the bytecode would cost one no-op
+  # dispatch each — for fib(25), that's ~228k extra dispatch cycles
+  # against zero observable benefit at this stage.
+  defp encode_list([{:source_line, _, _} | rest], acc) do
+    encode_list(rest, acc)
+  end
+
+  defp encode_list([instr | rest], acc) do
+    case encode(instr) do
+      {:ok, encoded} -> encode_list(rest, [encoded | acc])
+      :fallback -> :fallback
+    end
+  end
+
+  # ── Per-opcode encoding ─────────────────────────────────────────────────
+
+  defp encode({:load_constant, dest, value}), do: {:ok, {@op_load_constant, dest, value}}
+
+  defp encode({:load_boolean, dest, value}), do: {:ok, {@op_load_boolean, dest, value}}
+
+  # `:load_nil` clears `count + 1` registers starting at `dest`. The
+  # dispatcher unrolls the clear at execution time, so the operand is
+  # passed through verbatim.
+  defp encode({:load_nil, dest, count}), do: {:ok, {@op_load_nil, dest, count}}
+
+  defp encode({:move, dest, source}), do: {:ok, {@op_move, dest, source}}
+
+  defp encode({:load_env, dest}), do: {:ok, {@op_load_env, dest}}
+
+  defp encode({:get_upvalue, dest, index}), do: {:ok, {@op_get_upvalue, dest, index}}
+
+  defp encode({:get_global, dest, name}), do: {:ok, {@op_get_global, dest, name}}
+
+  # `:get_field` covers the `_ENV.name` global-lookup form alongside any
+  # other table field read. The dispatcher reuses the interpreter's
+  # `index_value` helper for the slow path, so coverage is full-fidelity.
+  defp encode({:get_field, dest, table_reg, name, name_hint}),
+    do: {:ok, {@op_get_field, dest, table_reg, name, name_hint}}
+
+  defp encode({:add, dest, a, b}), do: {:ok, {@op_add, dest, a, b}}
+  defp encode({:subtract, dest, a, b}), do: {:ok, {@op_subtract, dest, a, b}}
+  defp encode({:multiply, dest, a, b}), do: {:ok, {@op_multiply, dest, a, b}}
+  defp encode({:divide, dest, a, b}), do: {:ok, {@op_divide, dest, a, b}}
+  defp encode({:floor_divide, dest, a, b}), do: {:ok, {@op_floor_divide, dest, a, b}}
+  defp encode({:modulo, dest, a, b}), do: {:ok, {@op_modulo, dest, a, b}}
+  defp encode({:power, dest, a, b}), do: {:ok, {@op_power, dest, a, b}}
+  defp encode({:negate, dest, src}), do: {:ok, {@op_negate, dest, src}}
+
+  defp encode({:less_than, dest, a, b}), do: {:ok, {@op_less_than, dest, a, b}}
+  defp encode({:less_equal, dest, a, b}), do: {:ok, {@op_less_equal, dest, a, b}}
+  defp encode({:greater_than, dest, a, b}), do: {:ok, {@op_greater_than, dest, a, b}}
+  defp encode({:greater_equal, dest, a, b}), do: {:ok, {@op_greater_equal, dest, a, b}}
+  defp encode({:equal, dest, a, b}), do: {:ok, {@op_equal, dest, a, b}}
+  defp encode({:not_equal, dest, a, b}), do: {:ok, {@op_not_equal, dest, a, b}}
+
+  defp encode({:not, dest, src}), do: {:ok, {@op_not, dest, src}}
+
+  # `:test` carries nested instruction lists for the then/else branches.
+  # Both branches encode independently; either falling back collapses the
+  # whole test (and the enclosing prototype) to interpretation. Empty
+  # branches encode to an empty tuple so the dispatcher can distinguish
+  # "no branch" from "fell off the end of a branch".
+  defp encode({:test, reg, then_body, else_body}) do
+    with {:ok, then_enc} <- encode_list(then_body, []),
+         {:ok, else_enc} <- encode_list(else_body, []) do
+      {:ok, {@op_test, reg, List.to_tuple(then_enc), List.to_tuple(else_enc)}}
+    end
+  end
+
+  defp encode({:test_true, reg, then_body}) do
+    case encode_list(then_body, []) do
+      {:ok, then_enc} ->
+        {:ok, {@op_test_true, reg, List.to_tuple(then_enc)}}
+
+      :fallback ->
+        :fallback
+    end
+  end
+
+  # `:call` with `result_count == 1` is the dispatcher's only call form.
+  # Anything else (multi-return, return-position tail calls, zero-result
+  # statement calls) bails out so the interpreter's full machinery handles
+  # it. The `name_hint` operand survives for error attribution.
+  defp encode({:call, base, arg_count, 1, name_hint}) when is_integer(arg_count) and arg_count >= 0 do
+    {:ok, {@op_call_one, base, arg_count, name_hint}}
+  end
+
+  # `:return` shapes: single-value is the hot path (every recursive return
+  # in fib/factorial), zero-value falls through to the interpreter's "no
+  # explicit return = nil" handling.
+  defp encode({:return, base, 1}), do: {:ok, {@op_return_one, base}}
+  defp encode({:return, _base, 0}), do: {:ok, {@op_return_zero}}
+
+  # `:source_line` is preserved in the bytecode tuple but ignored at
+  # execution time (line tracking for compiled prototypes is deferred to
+  # B5d-v2). Stripping it would corrupt anyone reading the original
+  # instructions list for debugging; keeping it in bytecode at near-zero
+  # cost preserves the structural correspondence.
+  defp encode({:source_line, line, file}), do: {:ok, {@op_source_line, line, file}}
+
+  # Anything else — `:closure`, `:get_table`, `:concatenate`, loops,
+  # multi-return calls, vararg, etc. — is out of scope for v2.
+  defp encode(_other), do: :fallback
+
+  # ── Opcode tag accessors ────────────────────────────────────────────────
+  #
+  # Exposed for `Lua.VM.Dispatcher` (which mirrors these as its own
+  # compile-time constants) and for tests that assert on the encoded
+  # shape.
+
+  @spec op_load_constant() :: pos_integer()
+  def op_load_constant, do: @op_load_constant
+  def op_load_boolean, do: @op_load_boolean
+  def op_load_nil, do: @op_load_nil
+  def op_move, do: @op_move
+  def op_load_env, do: @op_load_env
+  def op_get_upvalue, do: @op_get_upvalue
+  def op_get_global, do: @op_get_global
+  def op_get_field, do: @op_get_field
+  def op_add, do: @op_add
+  def op_subtract, do: @op_subtract
+  def op_multiply, do: @op_multiply
+  def op_divide, do: @op_divide
+  def op_floor_divide, do: @op_floor_divide
+  def op_modulo, do: @op_modulo
+  def op_power, do: @op_power
+  def op_negate, do: @op_negate
+  def op_less_than, do: @op_less_than
+  def op_less_equal, do: @op_less_equal
+  def op_greater_than, do: @op_greater_than
+  def op_greater_equal, do: @op_greater_equal
+  def op_equal, do: @op_equal
+  def op_not_equal, do: @op_not_equal
+  def op_not, do: @op_not
+  def op_test, do: @op_test
+  def op_test_true, do: @op_test_true
+  def op_call_one, do: @op_call_one
+  def op_return_one, do: @op_return_one
+  def op_return_zero, do: @op_return_zero
+  def op_source_line, do: @op_source_line
+end

--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -46,7 +46,8 @@ defmodule Lua.Compiler.Bytecode do
   @op_not_equal 22
   @op_not 23
   @op_test 24
-  @op_test_true 25
+  # `25` was `@op_test_true`; codegen never emitted it so it has been
+  # removed. Tag is free for reuse.
   @op_call_one 26
   @op_return_one 27
   @op_return_zero 28
@@ -156,16 +157,6 @@ defmodule Lua.Compiler.Bytecode do
     end
   end
 
-  defp encode({:test_true, reg, then_body}) do
-    case encode_list(then_body, []) do
-      {:ok, then_enc} ->
-        {:ok, {@op_test_true, reg, List.to_tuple(then_enc)}}
-
-      :fallback ->
-        :fallback
-    end
-  end
-
   # `:call` with `result_count == 1` is the dispatcher's only call form.
   # Anything else (multi-return, return-position tail calls, zero-result
   # statement calls) bails out so the interpreter's full machinery handles
@@ -180,15 +171,11 @@ defmodule Lua.Compiler.Bytecode do
   defp encode({:return, base, 1}), do: {:ok, {@op_return_one, base}}
   defp encode({:return, _base, 0}), do: {:ok, {@op_return_zero}}
 
-  # `:source_line` is preserved in the bytecode tuple but ignored at
-  # execution time (line tracking for compiled prototypes is deferred to
-  # B5d-v2). Stripping it would corrupt anyone reading the original
-  # instructions list for debugging; keeping it in bytecode at near-zero
-  # cost preserves the structural correspondence.
-  defp encode({:source_line, line, file}), do: {:ok, {@op_source_line, line, file}}
-
   # Anything else — `:closure`, `:get_table`, `:concatenate`, loops,
   # multi-return calls, vararg, etc. — is out of scope for v2.
+  #
+  # `:source_line` is stripped upstream in `encode_list/2`, so it never
+  # reaches this clause table.
   defp encode(_other), do: :fallback
 
   # ── Opcode tag accessors ────────────────────────────────────────────────
@@ -222,7 +209,6 @@ defmodule Lua.Compiler.Bytecode do
   def op_not_equal, do: @op_not_equal
   def op_not, do: @op_not
   def op_test, do: @op_test
-  def op_test_true, do: @op_test_true
   def op_call_one, do: @op_call_one
   def op_return_one, do: @op_return_one
   def op_return_zero, do: @op_return_zero

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -64,12 +64,25 @@ defmodule Lua.Compiler.Codegen do
       # Emit source_line before each statement
       line_instr = emit_source_line(stmt, ctx)
       {new_instructions, ctx} = gen_statement(stmt, ctx)
-      # Track peak for max_registers, then reset for next statement
+      # Track peak for max_registers, then reset for next statement.
+      # `record_peak/1` (called at every internal reset of next_reg —
+      # e.g. inside `gen_expr` for `Expr.Call` after the callee is
+      # evaluated) keeps `peak_reg` honest across the statement; the
+      # `max` here picks up any tail allocation that wasn't reset.
       peak = max(Map.get(ctx, :peak_reg, 0), ctx.next_reg)
       ctx = %{ctx | next_reg: saved_next_reg}
       ctx = Map.put(ctx, :peak_reg, peak)
       {instructions ++ line_instr ++ new_instructions, ctx}
     end)
+  end
+
+  # Capture the current `ctx.next_reg` as a peak before a downward reset.
+  # Each `gen_expr` site that lowers `next_reg` (typically after a callee
+  # has been evaluated into a base register and the temp registers used
+  # to load it are about to be recycled) calls this first so the peak
+  # information survives the reset.
+  defp record_peak(ctx) do
+    Map.put(ctx, :peak_reg, max(Map.get(ctx, :peak_reg, 0), ctx.next_reg))
   end
 
   defp emit_source_line(%{meta: %{start: %{line: line}}}, ctx) when is_integer(line) do
@@ -1009,6 +1022,13 @@ defmodule Lua.Compiler.Codegen do
         [Instruction.move(base_reg, func_reg)]
       end
 
+    # Record the peak before resetting next_reg — `func_expr` may have
+    # used temp registers above `base_reg + 1` to load the callee
+    # (e.g. `_ENV.string.upper` chains through two `:get_field`
+    # opcodes). Without this, those high-water register indices are
+    # invisible to `max_registers` and downstream executors have to
+    # over-size their register tuples to compensate.
+    ctx = record_peak(ctx)
     ctx = %{ctx | next_reg: base_reg + 1}
 
     # Check what the last argument is — determines calling convention
@@ -1290,6 +1310,10 @@ defmodule Lua.Compiler.Codegen do
     # self instruction: R[base+1] = obj, R[base] = obj["method"]
     self_instruction = Instruction.self_instr(base_reg, obj_reg, method, obj_hint)
 
+    # Same peak-capture as `Expr.Call`: the object expression may have
+    # used temp registers above the call's base that we're about to
+    # discard, so promote them to `peak_reg` first.
+    ctx = record_peak(ctx)
     ctx = %{ctx | next_reg: base_reg + 2}
 
     # Compile arguments into temp registers above the arg window

--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -66,7 +66,6 @@ defmodule Lua.Compiler.Instruction do
 
   # Control flow
   def test(register, then_body, else_body), do: {:test, register, then_body, else_body}
-  def test_true(register, then_body), do: {:test_true, register, then_body}
   def test_and(dest, source, rest_body), do: {:test_and, dest, source, rest_body}
   def test_or(dest, source, rest_body), do: {:test_or, dest, source, rest_body}
 

--- a/lib/lua/compiler/prototype.ex
+++ b/lib/lua/compiler/prototype.ex
@@ -20,9 +20,16 @@ defmodule Lua.Compiler.Prototype do
           is_vararg: boolean(),
           max_registers: non_neg_integer(),
           source: binary(),
-          lines: {non_neg_integer(), non_neg_integer()}
+          lines: {non_neg_integer(), non_neg_integer()},
+          bytecode: tuple() | nil
         }
 
+  # `bytecode` is an optional dense encoding produced by `Lua.Compiler.Bytecode`.
+  # When set, the executor routes calls into `Lua.VM.Dispatcher` for a tighter
+  # dispatch loop. When nil, the prototype is interpreted in the usual way.
+  # The two representations are kept independent so the human-readable
+  # `instructions` list (used by error reporting, debugging, and any future
+  # tooling) survives untouched.
   defstruct instructions: [],
             prototypes: [],
             upvalue_descriptors: [],
@@ -31,7 +38,8 @@ defmodule Lua.Compiler.Prototype do
             max_registers: 0,
             source: <<"-no-source-">>,
             lines: {0, 0},
-            varargs: []
+            varargs: [],
+            bytecode: nil
 
   @doc """
   Creates a new prototype with the given options.

--- a/lib/lua/util.ex
+++ b/lib/lua/util.ex
@@ -16,6 +16,7 @@ defmodule Lua.Util do
   def encoded?(number) when is_number(number), do: true
   def encoded?({:tref, _}), do: true
   def encoded?({:lua_closure, _, _}), do: true
+  def encoded?({:compiled_closure, _, _}), do: true
   def encoded?({:native_func, _}), do: true
   def encoded?({:udref, _}), do: true
   def encoded?(_), do: false

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -61,11 +61,14 @@ defmodule Lua.VM.Dispatcher do
   @op_not_equal 22
   @op_not 23
   @op_test 24
-  @op_test_true 25
+  # `25` was `@op_test_true`; codegen never emitted it so it has been
+  # removed. Tag is free for reuse.
   @op_call_one 26
   @op_return_one 27
   @op_return_zero 28
-  @op_source_line 29
+  # `@op_source_line 29` is reserved but never reaches the dispatcher: the
+  # bytecode encoder strips `:source_line` entries in `encode_list/2`.
+  # Line tracking for compiled prototypes is B5d-v2.
 
   @doc """
   Execute a compiled prototype against `args` and `state`.
@@ -136,8 +139,8 @@ defmodule Lua.VM.Dispatcher do
   # exceeds `tuple_size(code)` the current body has finished — pop a
   # continuation from `cont` or unwind through `frames`.
   #
-  # `cont` holds `{code, pc}` resume markers pushed by `:test` /
-  # `:test_true` when descending into a branch body.
+  # `cont` holds `{code, pc}` resume markers pushed by `:test` when
+  # descending into a branch body.
   #
   # `frames` holds dispatcher-side call frames for in-mode calls. Out-of-
   # mode calls (compiled → interpreted) bridge through
@@ -173,7 +176,12 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_get_upvalue, dest, index} ->
         cell_ref = :erlang.element(index + 1, upvalues)
-        v = :erlang.map_get(cell_ref, state.upvalue_cells)
+        # Mirror the interpreter's `Map.get/2` (returns nil for a dangling
+        # cell) rather than `:erlang.map_get/2` (which raises `:badkey`).
+        # Compiled closures should never carry stale cell refs, but the
+        # invariant is the interpreter's, not ours, and the error shape
+        # has to match where it does fire.
+        v = Map.get(state.upvalue_cells, cell_ref)
         regs = :erlang.setelement(dest + 1, regs, v)
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
 
@@ -493,18 +501,6 @@ defmodule Lua.VM.Dispatcher do
 
         dispatch(branch, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames)
 
-      {@op_test_true, reg, then_bc} ->
-        case :erlang.element(reg + 1, regs) do
-          nil ->
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
-
-          false ->
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
-
-          _ ->
-            dispatch(then_bc, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames)
-        end
-
       # ── Calls ───────────────────────────────────────────────────────
       #
       # `:call_one` always asks for exactly one result placed at `base`.
@@ -517,16 +513,12 @@ defmodule Lua.VM.Dispatcher do
         func_value = :erlang.element(base + 1, regs)
 
         case func_value do
+          # Vararg bodies are out of scope for the bytecode encoder
+          # (`:vararg` / `:return_vararg` fall through to `:fallback`),
+          # so a `{:compiled_closure, ...}` is, by construction, never a
+          # vararg function. No varargs collection needed here.
           {:compiled_closure, callee_proto, callee_upvalues} ->
             callee_regs = init_callee_regs(callee_proto, regs, base + 1, arg_count)
-
-            callee_proto =
-              if callee_proto.is_vararg do
-                varargs = collect_varargs(regs, base + 1, arg_count, callee_proto.param_count)
-                %{callee_proto | varargs: varargs}
-              else
-                callee_proto
-              end
 
             # Frame is a tuple, not a map: pattern-matching a tuple in
             # `return_one/3` skips Map.fetch! lookups and lets the BEAM
@@ -575,13 +567,6 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_return_zero} ->
         return_one(nil, state, frames)
-
-      # ── No-ops in execution path ────────────────────────────────────
-
-      {@op_source_line, _line, _file} ->
-        # Line tracking for dispatcher-executed code is deferred; error
-        # attribution for compiled prototypes is the subject of B5d-v2.
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
     end
   end
 
@@ -639,11 +624,6 @@ defmodule Lua.VM.Dispatcher do
   defp copy_regs(src, src_i, dst, dst_i, n) do
     v = :erlang.element(src_i + 1, src)
     copy_regs(src, src_i + 1, :erlang.setelement(dst_i + 1, dst, v), dst_i + 1, n - 1)
-  end
-
-  defp collect_varargs(regs, base, total_args, param_count) do
-    extra = max(total_args - param_count, 0)
-    collect_args(regs, base + param_count, extra)
   end
 
   defp collect_args(_regs, _off, 0), do: []

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -1,0 +1,651 @@
+defmodule Lua.VM.Dispatcher do
+  @moduledoc """
+  Hand-written executor over the dense bytecode produced by
+  `Lua.Compiler.Bytecode`.
+
+  The dispatcher exists to test the hypothesis that integer-tagged opcode
+  dispatch over a tuple-encoded instruction stream measurably outperforms
+  the existing list-of-tagged-tuples interpreter. It implements a narrow
+  subset of opcodes — arithmetic, comparison, logical ops, conditional
+  `:test`, single-result `:call`, single-value `:return`, plus the
+  surrounding plumbing (constants, moves, env/upvalue/global lookups).
+  Anything the bytecode encoder rejects keeps its prototype on the
+  interpreter via the bytecode-compiler's `:fallback` cascade.
+
+  Inter-mode calls grow the Erlang stack by one frame at the boundary.
+  Dispatcher → dispatcher chains stay flat through `frames`. Mixed-mode
+  programs (compiled prototype calling an interpreted one, or vice versa)
+  pay a single recursive call at the transition; the recursion is bounded
+  by the number of mode switches, not the call depth within a single
+  mode.
+  """
+
+  alias Lua.Compiler.Prototype
+  alias Lua.VM.Executor
+  alias Lua.VM.Numeric
+  alias Lua.VM.State
+
+  # Opcode tags. These must stay in lockstep with `Lua.Compiler.Bytecode`.
+  # The module-attribute form lets each case branch match a constant
+  # integer, which the BEAM collapses to a jump table.
+
+  # Lua 5.3 signed-int64 bounds — duplicated from `Lua.VM.Numeric` to
+  # make the in-range check a guard-eligible compile-time constant.
+  # `to_signed_int64/1` is still called for the (rare) overflow path;
+  # the guard short-circuits the common case where the sum is already
+  # in range, saving one function call per integer-arithmetic opcode.
+  @max_int 0x7FFFFFFFFFFFFFFF
+  @min_int -0x8000000000000000
+
+  @op_load_constant 1
+  @op_load_boolean 2
+  @op_load_nil 3
+  @op_move 4
+  @op_load_env 5
+  @op_get_upvalue 6
+  @op_get_global 7
+  @op_get_field 8
+  @op_add 9
+  @op_subtract 10
+  @op_multiply 11
+  @op_divide 12
+  @op_floor_divide 13
+  @op_modulo 14
+  @op_power 15
+  @op_negate 16
+  @op_less_than 17
+  @op_less_equal 18
+  @op_greater_than 19
+  @op_greater_equal 20
+  @op_equal 21
+  @op_not_equal 22
+  @op_not 23
+  @op_test 24
+  @op_test_true 25
+  @op_call_one 26
+  @op_return_one 27
+  @op_return_zero 28
+  @op_source_line 29
+
+  @doc """
+  Execute a compiled prototype against `args` and `state`.
+  """
+  @spec execute(Prototype.t(), [term()], State.t()) :: {[term()], State.t()}
+  def execute(%Prototype{} = proto, args, %State{} = state) do
+    do_execute_top(proto, args, {}, state)
+  end
+
+  @doc """
+  Execute a compiled prototype with explicit upvalues.
+
+  Used from the interpreter's `:call` opcode and from
+  `Executor.call_function/3` when the callee is a `:compiled_closure`
+  carrying upvalue cells.
+  """
+  @spec execute(Prototype.t(), [term()], tuple(), State.t()) :: {[term()], State.t()}
+  def execute(%Prototype{} = proto, args, upvalues, %State{} = state) when is_tuple(upvalues) do
+    do_execute_top(proto, args, upvalues, state)
+  end
+
+  defp do_execute_top(proto, args, upvalues, state) do
+    regs = init_regs(proto, args)
+
+    proto =
+      if proto.is_vararg do
+        %{proto | varargs: Enum.drop(args, proto.param_count)}
+      else
+        proto
+      end
+
+    saved_open = state.open_upvalues
+    state = %{state | open_upvalues: %{}}
+
+    {results, state} = dispatch(proto.bytecode, 1, regs, upvalues, proto, state, [], [])
+
+    state = %{state | open_upvalues: saved_open}
+    {results, state}
+  end
+
+  defp init_regs(proto, args) do
+    size = max(proto.max_registers, proto.param_count) + 16
+    regs = Tuple.duplicate(nil, size)
+    copy_args(regs, 0, args, proto.param_count)
+  end
+
+  defp copy_args(regs, _i, _args, 0), do: regs
+
+  defp copy_args(regs, i, [arg | rest], n) do
+    copy_args(:erlang.setelement(i + 1, regs, arg), i + 1, rest, n - 1)
+  end
+
+  defp copy_args(regs, _i, [], _n), do: regs
+
+  # ── Dispatch loop ───────────────────────────────────────────────────────
+  #
+  # Single recursive function. Each opcode's handler lives directly inside
+  # the outer `case` so the BEAM can emit a jump table on the integer
+  # opcode tag — no per-opcode function call overhead, no intermediate
+  # pattern-match frame.
+  #
+  # `code` is the current bytecode tuple, `pc` is 1-indexed. When `pc`
+  # exceeds `tuple_size(code)` the current body has finished — pop a
+  # continuation from `cont` or unwind through `frames`.
+  #
+  # `cont` holds `{code, pc}` resume markers pushed by `:test` /
+  # `:test_true` when descending into a branch body.
+  #
+  # `frames` holds dispatcher-side call frames for in-mode calls. Out-of-
+  # mode calls (compiled → interpreted) bridge through
+  # `Executor.call_function/3` instead, paying one Erlang stack frame
+  # at the boundary.
+
+  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames) when pc > tuple_size(code) do
+    finish_body(regs, upvalues, proto, state, cont, frames)
+  end
+
+  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames) do
+    case :erlang.element(pc, code) do
+      {@op_load_constant, dest, value} ->
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_load_boolean, dest, value} ->
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_load_nil, dest, count} ->
+        regs = clear_nils(regs, dest, count + 1)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_move, dest, src} ->
+        v = :erlang.element(src + 1, regs)
+        regs = :erlang.setelement(dest + 1, regs, v)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_load_env, dest} ->
+        regs = :erlang.setelement(dest + 1, regs, State.g_ref(state))
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_get_upvalue, dest, index} ->
+        cell_ref = :erlang.element(index + 1, upvalues)
+        v = :erlang.map_get(cell_ref, state.upvalue_cells)
+        regs = :erlang.setelement(dest + 1, regs, v)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_get_global, dest, name} ->
+        v = State.get_global(state, name)
+        regs = :erlang.setelement(dest + 1, regs, v)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_get_field, dest, table_reg, name, name_hint} ->
+        table_val = :erlang.element(table_reg + 1, regs)
+        # Inline the tref fast path the interpreter uses for `_ENV.name`
+        # global lookups (overwhelmingly the dominant `:get_field` shape).
+        # Falling through to the helper for non-tref values, missing
+        # keys, or metatable cases keeps fidelity.
+        case table_val do
+          {:tref, id} ->
+            table = :erlang.map_get(id, state.tables)
+            data = :erlang.map_get(:data, table)
+
+            case data do
+              %{^name => value} ->
+                regs = :erlang.setelement(dest + 1, regs, value)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+              _ ->
+                case :erlang.map_get(:metatable, table) do
+                  nil ->
+                    regs = :erlang.setelement(dest + 1, regs, nil)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+                  _ ->
+                    {value, state} =
+                      Executor.dispatcher_get_field(table_val, name, state, proto, name_hint)
+
+                    regs = :erlang.setelement(dest + 1, regs, value)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+                end
+            end
+
+          _ ->
+            {value, state} =
+              Executor.dispatcher_get_field(table_val, name, state, proto, name_hint)
+
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      # ── Arithmetic ──────────────────────────────────────────────────
+      #
+      # Integer fast paths mirror the interpreter's. Numbers can't carry
+      # metatables in Lua, so the metamethod dispatch is wasted work
+      # when both operands are already numeric. The two `is_number`
+      # guards inline directly in the case body.
+
+      {@op_add, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_integer(va) and is_integer(vb) ->
+            sum = va + vb
+            wrapped = if sum >= @min_int and sum <= @max_int, do: sum, else: Numeric.to_signed_int64(sum)
+            regs = :erlang.setelement(dest + 1, regs, wrapped)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va + vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_binop(:add, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_subtract, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_integer(va) and is_integer(vb) ->
+            diff = va - vb
+            wrapped = if diff >= @min_int and diff <= @max_int, do: diff, else: Numeric.to_signed_int64(diff)
+            regs = :erlang.setelement(dest + 1, regs, wrapped)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va - vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_binop(:subtract, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_multiply, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_integer(va) and is_integer(vb) ->
+            prod = va * vb
+            wrapped = if prod >= @min_int and prod <= @max_int, do: prod, else: Numeric.to_signed_int64(prod)
+            regs = :erlang.setelement(dest + 1, regs, wrapped)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va * vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_binop(:multiply, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_divide, dest, a, b} ->
+        {value, state} =
+          Executor.dispatcher_binop(
+            :divide,
+            :erlang.element(a + 1, regs),
+            :erlang.element(b + 1, regs),
+            state,
+            proto
+          )
+
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_floor_divide, dest, a, b} ->
+        {value, state} =
+          Executor.dispatcher_binop(
+            :floor_divide,
+            :erlang.element(a + 1, regs),
+            :erlang.element(b + 1, regs),
+            state,
+            proto
+          )
+
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_modulo, dest, a, b} ->
+        {value, state} =
+          Executor.dispatcher_binop(
+            :modulo,
+            :erlang.element(a + 1, regs),
+            :erlang.element(b + 1, regs),
+            state,
+            proto
+          )
+
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_power, dest, a, b} ->
+        {value, state} =
+          Executor.dispatcher_binop(
+            :power,
+            :erlang.element(a + 1, regs),
+            :erlang.element(b + 1, regs),
+            state,
+            proto
+          )
+
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_negate, dest, src} ->
+        {value, state} =
+          Executor.dispatcher_unop(:negate, :erlang.element(src + 1, regs), state, proto)
+
+        regs = :erlang.setelement(dest + 1, regs, value)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      # ── Comparisons ─────────────────────────────────────────────────
+
+      {@op_less_than, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va < vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va < vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:less_than, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_less_equal, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va <= vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va <= vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:less_equal, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_greater_than, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va > vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va > vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:greater_than, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_greater_equal, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va >= vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va >= vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:greater_equal, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_equal, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va == vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va == vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:equal, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_not_equal, dest, a, b} ->
+        va = :erlang.element(a + 1, regs)
+        vb = :erlang.element(b + 1, regs)
+
+        cond do
+          is_number(va) and is_number(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va != vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          is_binary(va) and is_binary(vb) ->
+            regs = :erlang.setelement(dest + 1, regs, va != vb)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          true ->
+            {value, state} = Executor.dispatcher_cmp(:not_equal, va, vb, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_not, dest, src} ->
+        v = :erlang.element(src + 1, regs)
+        # Inline truthiness — Lua treats nil and false as the only falsy
+        # values. Saves a function call per `:not` opcode.
+        result = v === nil or v === false
+        regs = :erlang.setelement(dest + 1, regs, result)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      # ── Conditional branching ───────────────────────────────────────
+      #
+      # `:test` dispatches into the chosen branch's nested bytecode
+      # tuple, pushing the post-test resume `{code, pc + 1}` onto
+      # `cont`. The branch-end clause of `dispatch/8` pops it.
+
+      {@op_test, reg, then_bc, else_bc} ->
+        # Inline truthiness. The default case (anything other than `nil`
+        # or `false`) is the common path for `:test` in arithmetic-heavy
+        # workloads — booleans returned from `:less_than` etc.
+        branch =
+          case :erlang.element(reg + 1, regs) do
+            nil -> else_bc
+            false -> else_bc
+            _ -> then_bc
+          end
+
+        dispatch(branch, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames)
+
+      {@op_test_true, reg, then_bc} ->
+        case :erlang.element(reg + 1, regs) do
+          nil ->
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          false ->
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          _ ->
+            dispatch(then_bc, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames)
+        end
+
+      # ── Calls ───────────────────────────────────────────────────────
+      #
+      # `:call_one` always asks for exactly one result placed at `base`.
+      # `:compiled_closure` callees stay in the dispatcher via the
+      # frame stack — no Erlang stack growth. Everything else bridges
+      # to the interpreter through `Executor.call_function/3`, which
+      # grows the Erlang stack by one frame at the mode boundary.
+
+      {@op_call_one, base, arg_count, _name_hint} ->
+        func_value = :erlang.element(base + 1, regs)
+
+        case func_value do
+          {:compiled_closure, callee_proto, callee_upvalues} ->
+            callee_regs = init_callee_regs(callee_proto, regs, base + 1, arg_count)
+
+            callee_proto =
+              if callee_proto.is_vararg do
+                varargs = collect_varargs(regs, base + 1, arg_count, callee_proto.param_count)
+                %{callee_proto | varargs: varargs}
+              else
+                callee_proto
+              end
+
+            # Frame is a tuple, not a map: pattern-matching a tuple in
+            # `return_one/3` skips Map.fetch! lookups and lets the BEAM
+            # bind everything in a single `move` per slot.
+            frame =
+              {code, pc + 1, regs, upvalues, proto, cont, base, state.open_upvalues}
+
+            state = %{state | open_upvalues: %{}}
+
+            dispatch(
+              callee_proto.bytecode,
+              1,
+              callee_regs,
+              callee_upvalues,
+              callee_proto,
+              state,
+              [],
+              [frame | frames]
+            )
+
+          _ ->
+            args = collect_args(regs, base + 1, arg_count)
+            {results, state} = Executor.call_function(func_value, args, state)
+
+            first =
+              case results do
+                [v | _] -> v
+                [] -> nil
+              end
+
+            regs = :erlang.setelement(base + 1, regs, first)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      # ── Returns ─────────────────────────────────────────────────────
+      #
+      # In-mode `:call_one` returns thread the single value through
+      # `return_one/3` without boxing it as a list — the hot fib path
+      # never sees a list allocation for the result. The interpreter-
+      # boundary `[result]` shape is only built when unwinding past
+      # the last dispatcher frame, where the caller expects the
+      # `call_function/3` contract.
+
+      {@op_return_one, base} ->
+        return_one(:erlang.element(base + 1, regs), state, frames)
+
+      {@op_return_zero} ->
+        return_one(nil, state, frames)
+
+      # ── No-ops in execution path ────────────────────────────────────
+
+      {@op_source_line, _line, _file} ->
+        # Line tracking for dispatcher-executed code is deferred; error
+        # attribution for compiled prototypes is the subject of B5d-v2.
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+    end
+  end
+
+  # ── End-of-body handling ────────────────────────────────────────────────
+
+  defp finish_body(regs, upvalues, proto, state, [{next_code, next_pc} | rest_cont], frames) do
+    dispatch(next_code, next_pc, regs, upvalues, proto, state, rest_cont, frames)
+  end
+
+  # Body exhausted with no continuation: prototype ran off the end.
+  # Lua spec: missing return yields nil.
+  defp finish_body(_regs, _upvalues, _proto, state, [], frames) do
+    return_one(nil, state, frames)
+  end
+
+  # ── Return propagation through frames ───────────────────────────────────
+  #
+  # The bottom-of-stack return shape (`{results_list, state}`) matches
+  # the contract `Executor.call_function/3` expects, so the dispatcher's
+  # top-level `execute/3,4` callers see exactly what they would from
+  # the interpreter. Mid-stack returns skip the list wrapping entirely.
+
+  defp return_one(value, state, []) do
+    {[value], state}
+  end
+
+  defp return_one(value, state, [frame | rest_frames]) do
+    {code, pc, regs, upvalues, proto, cont, base, saved_open} = frame
+    regs = :erlang.setelement(base + 1, regs, value)
+    state = %{state | open_upvalues: saved_open}
+    dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames)
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  defp clear_nils(regs, _dest, 0), do: regs
+
+  defp clear_nils(regs, dest, n) do
+    clear_nils(:erlang.setelement(dest + 1, regs, nil), dest + 1, n - 1)
+  end
+
+  defp init_callee_regs(callee_proto, src_regs, src_off, arg_count) do
+    size = max(callee_proto.max_registers, callee_proto.param_count) + 16
+    regs = Tuple.duplicate(nil, size)
+    copy_n = min(arg_count, callee_proto.param_count)
+    copy_regs(src_regs, src_off, regs, 0, copy_n)
+  end
+
+  defp copy_regs(_src, _src_i, dst, _dst_i, 0), do: dst
+
+  defp copy_regs(src, src_i, dst, dst_i, n) do
+    v = :erlang.element(src_i + 1, src)
+    copy_regs(src, src_i + 1, :erlang.setelement(dst_i + 1, dst, v), dst_i + 1, n - 1)
+  end
+
+  defp collect_varargs(regs, base, total_args, param_count) do
+    extra = max(total_args - param_count, 0)
+    collect_args(regs, base + param_count, extra)
+  end
+
+  defp collect_args(_regs, _off, 0), do: []
+
+  defp collect_args(regs, off, count) do
+    collect_args_rev(regs, off + count - 1, count, [])
+  end
+
+  defp collect_args_rev(_regs, _off, 0, acc), do: acc
+
+  defp collect_args_rev(regs, off, count, acc) do
+    collect_args_rev(regs, off - 1, count - 1, [:erlang.element(off + 1, regs) | acc])
+  end
+end

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -107,7 +107,12 @@ defmodule Lua.VM.Dispatcher do
   end
 
   defp init_regs(proto, args) do
-    size = max(proto.max_registers, proto.param_count) + 16
+    # The interpreter sizes register tuples with a +16 buffer for
+    # multi-return expansion (`ensure_regs_capacity/2`). The
+    # dispatcher's `:call_one` always wants exactly one result and
+    # the codegen now honestly reports the peak register, so no
+    # buffer is needed at all here.
+    size = max(proto.max_registers, proto.param_count)
     regs = Tuple.duplicate(nil, size)
     copy_args(regs, 0, args, proto.param_count)
   end
@@ -619,7 +624,11 @@ defmodule Lua.VM.Dispatcher do
   end
 
   defp init_callee_regs(callee_proto, src_regs, src_off, arg_count) do
-    size = max(callee_proto.max_registers, callee_proto.param_count) + 16
+    # Same as `init_regs/2`: no buffer needed because the bytecode
+    # encoder rejects multi-return calls (which are the only thing
+    # the interpreter's +16 buffer absorbs) and codegen reports the
+    # honest peak register.
+    size = max(callee_proto.max_registers, callee_proto.param_count)
     regs = Tuple.duplicate(nil, size)
     copy_n = min(arg_count, callee_proto.param_count)
     copy_regs(src_regs, src_off, regs, 0, copy_n)

--- a/lib/lua/vm/display.ex
+++ b/lib/lua/vm/display.ex
@@ -97,6 +97,10 @@ defmodule Lua.VM.Display do
     wrap_closure(ref)
   end
 
+  def wrap_value({:compiled_closure, _, _} = ref, _state, _decode?) do
+    wrap_closure(ref)
+  end
+
   def wrap_value({:native_func, fun} = ref, _state, _decode?) do
     %NativeFunc{fun: fun, ref: ref}
   end
@@ -117,7 +121,7 @@ defmodule Lua.VM.Display do
 
   # ---- internal helpers ----
 
-  defp wrap_closure({:lua_closure, proto, _upvalues} = ref) do
+  defp wrap_closure({tag, proto, _upvalues} = ref) when tag in [:lua_closure, :compiled_closure] do
     {first_line, _last_line} = proto.lines || {0, 0}
 
     %Closure{

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -12,6 +12,7 @@ defmodule Lua.VM.Executor do
     line   — current source line (threaded to avoid State struct allocation)
   """
 
+  alias Lua.VM.Dispatcher
   alias Lua.VM.InternalError
   alias Lua.VM.Numeric
   alias Lua.VM.RuntimeError
@@ -124,6 +125,14 @@ defmodule Lua.VM.Executor do
     {results, state}
   end
 
+  def call_function({:compiled_closure, callee_proto, callee_upvalues}, args, state) do
+    # Compiled callees route through the dispatcher. The dispatcher manages
+    # its own register file setup, vararg routing, and open-upvalue save/
+    # restore — `Dispatcher.execute/4` mirrors the semantics of this
+    # function for the bytecode-encoded path.
+    Dispatcher.execute(callee_proto, args, callee_upvalues, state)
+  end
+
   def call_function({:native_func, fun}, args, state) do
     case fun.(args, state) do
       {results, %State{} = new_state} when is_list(results) ->
@@ -164,6 +173,108 @@ defmodule Lua.VM.Executor do
             call_function(call_mm, [other | args], state)
         end
     end
+  end
+
+  # ── Bridges for Lua.VM.Dispatcher ──────────────────────────────────────────
+  #
+  # The dispatcher reuses these helpers to keep metamethod fidelity in
+  # lockstep with the interpreter. Each helper takes operands plus the
+  # current `proto` (for source attribution) and returns the same
+  # `{value, state}` shape the interpreter clauses produce.
+  #
+  # Line position for raise sites is passed as `0` because the dispatcher
+  # does not yet track per-instruction line numbers — error attribution
+  # for compiled prototypes is the subject of B5d-v2. Native callbacks
+  # invoked via metamethods still get accurate positions via the
+  # process-dictionary bridge installed at the call boundary.
+
+  @doc false
+  @spec dispatcher_binop(atom(), term(), term(), State.t(), term()) :: {term(), State.t()}
+  def dispatcher_binop(:add, a, b, state, proto) do
+    try_binary_metamethod("__add", a, b, state, fn -> safe_add(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:subtract, a, b, state, proto) do
+    try_binary_metamethod("__sub", a, b, state, fn -> safe_subtract(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:multiply, a, b, state, proto) do
+    try_binary_metamethod("__mul", a, b, state, fn -> safe_multiply(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:divide, a, b, state, proto) do
+    try_binary_metamethod("__div", a, b, state, fn -> safe_divide(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:floor_divide, a, b, state, proto) do
+    try_binary_metamethod("__idiv", a, b, state, fn -> safe_floor_divide(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:modulo, a, b, state, proto) do
+    try_binary_metamethod("__mod", a, b, state, fn -> safe_modulo(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_binop(:power, a, b, state, proto) do
+    try_binary_metamethod("__pow", a, b, state, fn -> safe_power(a, b, 0, proto.source) end)
+  end
+
+  @doc false
+  @spec dispatcher_unop(atom(), term(), State.t(), term()) :: {term(), State.t()}
+  def dispatcher_unop(:negate, val, state, proto) do
+    try_unary_metamethod("__unm", val, state, fn -> safe_negate(val, 0, proto.source) end)
+  end
+
+  @doc false
+  @spec dispatcher_cmp(atom(), term(), term(), State.t(), term()) :: {term(), State.t()}
+  def dispatcher_cmp(:less_than, a, b, state, proto) do
+    try_binary_metamethod("__lt", a, b, state, fn -> safe_compare_lt(a, b, 0, proto.source) end)
+  end
+
+  def dispatcher_cmp(:less_equal, a, b, state, proto) do
+    compare_le(a, b, state, 0, proto.source)
+  end
+
+  def dispatcher_cmp(:greater_than, a, b, state, proto) do
+    # Lua 5.3 §3.4.4: a > b dispatches __lt with swapped operands.
+    try_binary_metamethod("__lt", b, a, state, fn -> safe_compare_lt(b, a, 0, proto.source) end)
+  end
+
+  def dispatcher_cmp(:greater_equal, a, b, state, proto) do
+    # Lua 5.3 §3.4.4: a >= b is rewritten to b <= a.
+    compare_le(b, a, state, 0, proto.source)
+  end
+
+  def dispatcher_cmp(:equal, a, b, state, _proto) do
+    try_equality_metamethod(a, b, state, fn -> lua_equal(a, b) end)
+  end
+
+  def dispatcher_cmp(:not_equal, a, b, state, _proto) do
+    {eq, new_state} = try_equality_metamethod(a, b, state, fn -> lua_equal(a, b) end)
+    {not eq, new_state}
+  end
+
+  @doc false
+  @spec dispatcher_get_field(term(), term(), State.t(), term(), term()) :: {term(), State.t()}
+  def dispatcher_get_field({:tref, id} = tref, name, state, proto, name_hint) do
+    # Fast path mirrors the interpreter's `:get_field` clause: skip the
+    # full `index_value` pipeline when the table has the key and either
+    # has no metatable, or the key is present at the data layer.
+    table = :erlang.map_get(id, state.tables)
+
+    case :erlang.map_get(:data, table) do
+      %{^name => value} ->
+        {value, state}
+
+      _ ->
+        case :erlang.map_get(:metatable, table) do
+          nil -> {nil, state}
+          _ -> index_value(tref, name, state, 0, proto.source, name_hint)
+        end
+    end
+  end
+
+  def dispatcher_get_field(value, name, state, proto, name_hint) do
+    index_value(value, name, state, 0, proto.source, name_hint)
   end
 
   # ── Break ──────────────────────────────────────────────────────────────────
@@ -574,7 +685,19 @@ defmodule Lua.VM.Executor do
       end)
 
     captured_upvalues = Enum.reverse(captured_upvalues_reversed)
-    closure = {:lua_closure, nested_proto, List.to_tuple(captured_upvalues)}
+    upvalues_tuple = List.to_tuple(captured_upvalues)
+
+    # Sub-prototypes are compiled to bytecode independently. The closure
+    # value tag reflects which executor path will run the function — the
+    # decision flows through the closure tag rather than back through the
+    # parent prototype, so a compiled child can be called from an
+    # interpreted parent and vice versa.
+    closure =
+      case nested_proto.bytecode do
+        nil -> {:lua_closure, nested_proto, upvalues_tuple}
+        _ -> {:compiled_closure, nested_proto, upvalues_tuple}
+      end
+
     regs = put_elem(regs, dest, closure)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
@@ -608,6 +731,17 @@ defmodule Lua.VM.Executor do
       end
 
     case func_value do
+      {:compiled_closure, callee_proto, callee_upvalues} ->
+        # Shortcut for interpreter → dispatcher hand-off: materialize the
+        # args list and route through `Dispatcher.execute/4`, which mirrors
+        # the semantics of the `:lua_closure` clause below (param/vararg
+        # setup, open-upvalue save/restore). The dispatcher's own
+        # `:call_one` clause handles dispatcher → dispatcher chains
+        # without going through this branch.
+        args = collect_args(regs, base + 1, total_args)
+        {results, state} = Dispatcher.execute(callee_proto, args, callee_upvalues, state)
+        continue_after_call(results, regs, rest, upvalues, proto, state, cont, frames, line, base, result_count)
+
       {:lua_closure, callee_proto, callee_upvalues} ->
         param_count = callee_proto.param_count
 
@@ -1690,6 +1824,12 @@ defmodule Lua.VM.Executor do
     {results, state}
   end
 
+  defp call_value({:compiled_closure, _, _} = closure, args, _proto, state, _line) do
+    # Compiled-closure callees for generic_for iterators reuse the same
+    # dispatcher bridge as `call_function/3`.
+    call_function(closure, args, state)
+  end
+
   defp call_value({:native_func, fun}, args, proto, state, line) do
     # Same source-position bridge as the `:call` opcode's native dispatch.
     # Used by `for` loop iteration when the iterator is native.
@@ -2057,6 +2197,10 @@ defmodule Lua.VM.Executor do
         {results, new_state} = call_function(func, args, state)
         {List.first(results), new_state}
 
+      {:compiled_closure, _, _} = func ->
+        {results, new_state} = call_function(func, args, state)
+        {List.first(results), new_state}
+
       _ ->
         {default_fn.(), state}
     end
@@ -2400,6 +2544,7 @@ defmodule Lua.VM.Executor do
   defp value_type(v) when is_binary(v), do: :string
   defp value_type({:tref, _}), do: :table
   defp value_type({:lua_closure, _, _}), do: :function
+  defp value_type({:compiled_closure, _, _}), do: :function
   defp value_type({:native_func, _}), do: :function
   defp value_type(_), do: :unknown
 

--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -421,6 +421,10 @@ defmodule Lua.VM.Stdlib do
     load_from_reader(reader, state)
   end
 
+  defp lua_load([{:compiled_closure, _, _} = reader | _rest], state) do
+    load_from_reader(reader, state)
+  end
+
   defp lua_load([{:native_func, _} = reader | _rest], state) do
     load_from_reader(reader, state)
   end
@@ -476,7 +480,16 @@ defmodule Lua.VM.Stdlib do
         # Compiler currently never returns errors, always succeeds — see
         # `Lua.Compiler.compile!/2` for the matching note.
         {:ok, prototype} = Lua.Compiler.compile(ast)
-        closure = {:lua_closure, prototype, {}}
+
+        # When the bytecode compiler accepts the loaded chunk, surface
+        # it as a `:compiled_closure` so the dispatcher takes over.
+        # Otherwise fall back to the standard interpreted closure.
+        closure =
+          case prototype.bytecode do
+            nil -> {:lua_closure, prototype, {}}
+            _ -> {:compiled_closure, prototype, {}}
+          end
+
         {[closure], state}
 
       {:error, reason} ->

--- a/lib/lua/vm/stdlib/debug.ex
+++ b/lib/lua/vm/stdlib/debug.ex
@@ -55,7 +55,7 @@ defmodule Lua.VM.Stdlib.Debug do
 
     info =
       case func do
-        {:lua_closure, proto, _upvalues} ->
+        {tag, proto, _upvalues} when tag in [:lua_closure, :compiled_closure] ->
           %{
             "source" => Map.get(proto, :source, "=?"),
             "currentline" => -1,

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -776,7 +776,7 @@ defmodule Lua.VM.Stdlib.String do
             {value, st}
           end
 
-        match?({:lua_closure, _, _}, repl) or match?({:native_func, _}, repl) ->
+        match?({:lua_closure, _, _}, repl) or match?({:compiled_closure, _, _}, repl) or match?({:native_func, _}, repl) ->
           fn args, st ->
             {results, st} = Executor.call_function(repl, args, st)
             result = List.first(results)

--- a/lib/lua/vm/stdlib/util.ex
+++ b/lib/lua/vm/stdlib/util.ex
@@ -12,6 +12,7 @@ defmodule Lua.VM.Stdlib.Util do
   def typeof(v) when is_binary(v), do: "string"
   def typeof({:tref, _}), do: "table"
   def typeof({:lua_closure, _, _}), do: "function"
+  def typeof({:compiled_closure, _, _}), do: "function"
   def typeof({:native_func, _}), do: "function"
   def typeof(_), do: "unknown"
 

--- a/lib/lua/vm/value.ex
+++ b/lib/lua/vm/value.ex
@@ -21,6 +21,7 @@ defmodule Lua.VM.Value do
   def type_name(v) when is_binary(v), do: "string"
   def type_name({:tref, _}), do: "table"
   def type_name({:lua_closure, _, _}), do: "function"
+  def type_name({:compiled_closure, _, _}), do: "function"
   def type_name({:native_func, _}), do: "function"
   def type_name({:udref, _}), do: "userdata"
   def type_name(_), do: "userdata"
@@ -58,6 +59,7 @@ defmodule Lua.VM.Value do
   def to_string({:tref, id}), do: "table: 0x#{String.pad_leading(Integer.to_string(id, 16), 14, "0")}"
 
   def to_string({:lua_closure, _, _}), do: "function"
+  def to_string({:compiled_closure, _, _}), do: "function"
   def to_string({:native_func, _}), do: "function"
   def to_string(other), do: inspect(other)
 

--- a/test/lua/compiler/bytecode_test.exs
+++ b/test/lua/compiler/bytecode_test.exs
@@ -1,0 +1,186 @@
+defmodule Lua.Compiler.BytecodeTest do
+  @moduledoc """
+  Tests for the bytecode encoder's coverage and fallback cascade.
+
+  The encoder must accept every opcode it claims to support and reject
+  every opcode it does not — without ever crashing, regardless of input
+  shape. These tests pin the boundary.
+
+  The fallback cascade also has a documented property: a child prototype
+  that compiles must keep its bytecode even when the parent falls back,
+  and vice versa. That independence is what lets a deeply-nested
+  function body run on the dispatcher even when the chunk it lives in
+  cannot.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Compiler.Bytecode
+  alias Lua.Compiler.Prototype
+  alias Lua.Parser
+
+  defp compile!(src) do
+    {:ok, ast} = Parser.parse(src)
+    {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+    proto
+  end
+
+  describe "supported-opcode coverage" do
+    test "a pure-arithmetic function compiles to bytecode" do
+      proto = compile!("function f(a, b) return a + b - 1 end")
+      [fn_proto] = proto.prototypes
+      assert is_tuple(fn_proto.bytecode)
+      assert tuple_size(fn_proto.bytecode) > 0
+    end
+
+    test "single-result return with comparison compiles" do
+      proto = compile!("function f(n) if n < 0 then return -n end return n end")
+      [fn_proto] = proto.prototypes
+      assert is_tuple(fn_proto.bytecode)
+    end
+
+    test "recursive function with single-result calls compiles" do
+      proto =
+        compile!("""
+        function fib(n)
+          if n < 2 then return n end
+          return fib(n - 1) + fib(n - 2)
+        end
+        """)
+
+      [fib_proto] = proto.prototypes
+      assert is_tuple(fib_proto.bytecode)
+    end
+  end
+
+  describe "fallback on unsupported opcodes" do
+    test ":closure causes the enclosing prototype to fall back" do
+      # The chunk emits `:closure` to materialize `f`, so the chunk
+      # itself falls back. The nested `f` body still compiles.
+      proto = compile!("function f() return 1 end")
+      assert proto.bytecode == nil
+      [fn_proto] = proto.prototypes
+      assert is_tuple(fn_proto.bytecode)
+    end
+
+    test ":new_table causes fallback" do
+      proto = compile!("function f() return {1, 2, 3} end")
+      [fn_proto] = proto.prototypes
+      assert fn_proto.bytecode == nil
+    end
+
+    test ":concatenate causes fallback" do
+      proto = compile!("function f(a, b) return a .. b end")
+      [fn_proto] = proto.prototypes
+      assert fn_proto.bytecode == nil
+    end
+
+    test "multi-return call causes fallback" do
+      # `return f(x)` compiles as a tail-call-style multi-return (-1),
+      # which is outside dispatcher coverage.
+      proto =
+        compile!("""
+        function caller()
+          return inner(1)
+        end
+        """)
+
+      [caller_proto] = proto.prototypes
+      assert caller_proto.bytecode == nil
+    end
+
+    test "for-loops cause fallback" do
+      proto =
+        compile!("""
+        function sum(n)
+          local total = 0
+          for i = 1, n do total = total + i end
+          return total
+        end
+        """)
+
+      [sum_proto] = proto.prototypes
+      assert sum_proto.bytecode == nil
+    end
+
+    test ":vararg opcode causes fallback" do
+      # Using `...` as an expression emits a `:vararg` opcode, which is
+      # out of scope. A vararg signature alone (without using `...`)
+      # doesn't emit anything special and is fine.
+      proto = compile!("function f(...) local first = ... return first end")
+      [fn_proto] = proto.prototypes
+      assert fn_proto.bytecode == nil
+    end
+  end
+
+  describe "cascade independence" do
+    test "child prototype compiles even when sibling falls back" do
+      proto =
+        compile!("""
+        function pure(a, b) return a + b end
+        function impure() return {1, 2, 3} end
+        """)
+
+      [pure_proto, impure_proto] = proto.prototypes
+      assert is_tuple(pure_proto.bytecode)
+      assert impure_proto.bytecode == nil
+    end
+
+    test "deeply-nested function compiles even when its parent falls back" do
+      # The outer `make` builds a table (fallback), but the inner adder
+      # is a pure-arithmetic single-result function (compiles).
+      proto =
+        compile!("""
+        function make()
+          local fns = {}
+          local function add(a, b) return a + b end
+          return add
+        end
+        """)
+
+      [make_proto] = proto.prototypes
+      [add_proto] = make_proto.prototypes
+
+      assert make_proto.bytecode == nil
+      assert is_tuple(add_proto.bytecode)
+    end
+  end
+
+  describe "edge cases" do
+    test "an empty function body falls back gracefully (return 0 args)" do
+      # Empty body codegen emits `{:return, 0, 0}` which is the
+      # zero-result form. Currently encoded as `@op_return_zero`.
+      proto = compile!("function f() end")
+      [fn_proto] = proto.prototypes
+      assert is_tuple(fn_proto.bytecode) or fn_proto.bytecode == nil
+    end
+
+    test "source_line opcodes are stripped from the encoding" do
+      proto =
+        compile!("""
+        function f(a, b)
+          return a + b
+        end
+        """)
+
+      [fn_proto] = proto.prototypes
+      # The instruction stream still has source_line entries (kept for
+      # the interpreter's error reporting); the bytecode tuple skips
+      # them entirely.
+      assert Enum.any?(fn_proto.instructions, &match?({:source_line, _, _}, &1))
+
+      bytecode_ops = fn_proto.bytecode |> Tuple.to_list() |> Enum.map(&elem(&1, 0))
+      source_line_tag = Bytecode.op_source_line()
+      refute source_line_tag in bytecode_ops
+    end
+
+    test "fallback returns a Prototype with bytecode: nil, never an error" do
+      # The encoder must not crash on any well-formed prototype.
+      proto = compile!("function f() return coroutine.yield() end")
+      [fn_proto] = proto.prototypes
+      assert %Prototype{} = fn_proto
+      assert fn_proto.bytecode == nil
+    end
+  end
+end

--- a/test/lua/compiler/max_registers_invariant_test.exs
+++ b/test/lua/compiler/max_registers_invariant_test.exs
@@ -1,0 +1,179 @@
+defmodule Lua.Compiler.MaxRegistersInvariantTest do
+  @moduledoc """
+  Pins the load-bearing invariant that `proto.max_registers` is large
+  enough to hold every register the encoded bytecode references.
+
+  The dispatcher sizes its register tuple exactly to `max_registers`
+  (no `+16` safety buffer like the interpreter), so any register write
+  beyond that bound raises `:badarg` from `:erlang.setelement/3`. The
+  invariant is enforced by `Lua.Compiler.Codegen.record_peak/1`; this
+  test pins it across the existing compilable surface so regressions
+  surface in CI rather than as a runtime crash.
+
+  The walker recurses into nested branch bodies (`:test`) and nested
+  prototypes so the bound is checked at every level.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Compiler.Bytecode
+  alias Lua.Compiler.Prototype
+  alias Lua.Parser
+
+  # Each opcode's register operand positions in its tuple, where the
+  # first element (the opcode tag) lives at position 0. Reads and writes
+  # are folded together: any out-of-bounds position would crash the
+  # dispatcher's `:erlang.element/2` or `:erlang.setelement/3`.
+  #
+  # `:load_nil` is special: it writes a *range* of registers
+  # (`dest..dest + count - 1`), so the bound has to be checked against
+  # the highest written index, not just `dest`.
+  defp register_positions(op) do
+    cond do
+      op == Bytecode.op_load_constant() -> [1]
+      op == Bytecode.op_load_boolean() -> [1]
+      op == Bytecode.op_load_nil() -> :load_nil
+      op == Bytecode.op_move() -> [1, 2]
+      op == Bytecode.op_load_env() -> [1]
+      op == Bytecode.op_get_upvalue() -> [1]
+      op == Bytecode.op_get_global() -> [1]
+      op == Bytecode.op_get_field() -> [1, 2]
+      op == Bytecode.op_add() -> [1, 2, 3]
+      op == Bytecode.op_subtract() -> [1, 2, 3]
+      op == Bytecode.op_multiply() -> [1, 2, 3]
+      op == Bytecode.op_divide() -> [1, 2, 3]
+      op == Bytecode.op_floor_divide() -> [1, 2, 3]
+      op == Bytecode.op_modulo() -> [1, 2, 3]
+      op == Bytecode.op_power() -> [1, 2, 3]
+      op == Bytecode.op_negate() -> [1, 2]
+      op == Bytecode.op_less_than() -> [1, 2, 3]
+      op == Bytecode.op_less_equal() -> [1, 2, 3]
+      op == Bytecode.op_greater_than() -> [1, 2, 3]
+      op == Bytecode.op_greater_equal() -> [1, 2, 3]
+      op == Bytecode.op_equal() -> [1, 2, 3]
+      op == Bytecode.op_not_equal() -> [1, 2, 3]
+      op == Bytecode.op_not() -> [1, 2]
+      op == Bytecode.op_test() -> [1]
+      op == Bytecode.op_call_one() -> [1]
+      op == Bytecode.op_return_one() -> [1]
+      op == Bytecode.op_return_zero() -> []
+      true -> raise "register_positions/1 is missing a case for opcode #{inspect(op)}"
+    end
+  end
+
+  defp max_register_used(bytecode) when is_tuple(bytecode) do
+    bytecode
+    |> Tuple.to_list()
+    |> Enum.reduce(-1, fn instr, acc -> max(acc, max_in_instr(instr)) end)
+  end
+
+  defp max_in_instr(instr) do
+    op = :erlang.element(1, instr)
+
+    case register_positions(op) do
+      :load_nil ->
+        # {tag, dest, count}: writes dest..dest+count-1.
+        dest = :erlang.element(2, instr)
+        count = :erlang.element(3, instr)
+        dest + count - 1
+
+      positions when is_list(positions) ->
+        direct = Enum.reduce(positions, -1, fn pos, acc -> max(acc, :erlang.element(pos + 1, instr)) end)
+
+        # `:test` carries nested bytecode tuples in positions 2 and 3 —
+        # recurse so the bound is checked there too.
+        if op == Bytecode.op_test() do
+          then_bc = :erlang.element(3, instr)
+          else_bc = :erlang.element(4, instr)
+          max(direct, max(max_register_used(then_bc), max_register_used(else_bc)))
+        else
+          direct
+        end
+    end
+  end
+
+  defp walk_protos(%Prototype{} = proto) do
+    own =
+      case proto.bytecode do
+        nil ->
+          :ok
+
+        bytecode ->
+          max_used = max_register_used(bytecode)
+
+          assert max_used < proto.max_registers,
+                 """
+                 #{proto.source} declares max_registers=#{proto.max_registers}
+                 but the encoded bytecode writes/reads index #{max_used}.
+                 The dispatcher sizes its register tuple to exactly
+                 max_registers, so this would crash with :badarg.
+                 """
+
+          :ok
+      end
+
+    Enum.each(proto.prototypes, &walk_protos/1)
+    own
+  end
+
+  defp compile!(src) do
+    {:ok, ast} = Parser.parse(src)
+    {:ok, proto} = Compiler.compile(ast, source: "invariant-test.lua")
+    proto
+  end
+
+  # Each program below exercises a different shape of register allocation.
+  # The set is intentionally small but representative: anything more
+  # exotic that compiles should ride on these guards in the existing
+  # dispatcher tests.
+  @corpus [
+    {"plain arithmetic", "function f(a, b) return a + b end"},
+    {"comparison + branch (:test)", "function f(n) if n < 0 then return -n end return n end"},
+    {"recursive call",
+     """
+     function fib(n)
+       if n < 2 then return n end
+       return fib(n - 1) + fib(n - 2)
+     end
+     """},
+    {"deep temp chain (string.upper)",
+     """
+     function f(s)
+       local u = string.upper(s)
+       return u
+     end
+     """},
+    {"nested upvalue capture",
+     """
+     local function make()
+       local x = 1
+       return function() return x + 1 end
+     end
+     return make
+     """},
+    {"global lookup through _ENV",
+     """
+     x = 99
+     function f() return x end
+     """},
+    {"many locals exercising peak",
+     """
+     function f(a, b, c, d)
+       local x = a + b
+       local y = c + d
+       local z = x * y
+       return z
+     end
+     """}
+  ]
+
+  describe "max_registers bounds every encoded register index" do
+    for {label, src} <- @corpus do
+      test "#{label}" do
+        proto = compile!(unquote(src))
+        walk_protos(proto)
+      end
+    end
+  end
+end

--- a/test/lua/vm/dispatcher_test.exs
+++ b/test/lua/vm/dispatcher_test.exs
@@ -1,0 +1,377 @@
+defmodule Lua.VM.DispatcherTest do
+  @moduledoc """
+  Per-opcode golden tests for `Lua.VM.Dispatcher`.
+
+  Each test compiles a small Lua source that exercises one opcode the
+  dispatcher claims to support, then asserts that:
+
+    * The compiled prototype (or the relevant sub-prototype) actually
+      received a `bytecode` encoding — confirming the bytecode compiler
+      did not bail out via `:fallback`.
+
+    * The compiled program produces the same result as a freshly
+      computed reference value.
+
+  These tests pin the dispatcher's observable contract against the
+  interpreter's. Any divergence — wrong arithmetic, wrong comparison,
+  missing fallback — surfaces here before it can leak into a higher-
+  level test that runs against either executor opaquely.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Compiler.Prototype
+  alias Lua.Parser
+  alias Lua.VM
+  alias Lua.VM.State
+  alias Lua.VM.Stdlib
+
+  defp run!(code) do
+    {:ok, ast} = Parser.parse(code)
+    {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+    state = Stdlib.install(State.new())
+    {:ok, results, _state} = VM.execute(proto, state)
+    {proto, results}
+  end
+
+  # Pulls out the first sub-prototype — the one wrapping a `function`
+  # body the dispatcher is expected to run.
+  defp first_sub(%Prototype{prototypes: [fp | _]}), do: fp
+
+  describe "arithmetic opcodes (dispatcher-compiled body)" do
+    test ":add — integer fast path" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a + b end
+        return f(40, 2)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [42]
+    end
+
+    test ":subtract — integer fast path" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a - b end
+        return f(50, 8)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [42]
+    end
+
+    test ":multiply — integer fast path" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a * b end
+        return f(6, 7)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [42]
+    end
+
+    test ":divide — float result" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a / b end
+        return f(10, 4)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [2.5]
+    end
+
+    test ":floor_divide — integer result" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a // b end
+        return f(10, 4)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [2]
+    end
+
+    test ":modulo" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a % b end
+        return f(10, 3)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [1]
+    end
+
+    test ":power" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a ^ b end
+        return f(2, 10)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [1024.0]
+    end
+
+    test ":negate" do
+      {proto, results} =
+        run!("""
+        function f(a) return -a end
+        return f(7)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [-7]
+    end
+
+    test ":add — integer wrap at int64 boundary" do
+      # 2^63 - 1 + 1 wraps to -2^63 (Lua 5.3 §3.4.1).
+      {proto, results} =
+        run!("""
+        function f(a) return a + 1 end
+        return f(9223372036854775807)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [-9_223_372_036_854_775_808]
+    end
+  end
+
+  describe "comparison opcodes" do
+    test ":less_than with numbers" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a < b end
+        return f(3, 5)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true]
+    end
+
+    test ":less_equal with numbers" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a <= b end
+        return f(5, 5)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true]
+    end
+
+    test ":greater_than with numbers" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a > b end
+        return f(5, 3)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true]
+    end
+
+    test ":greater_equal with numbers" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a >= b end
+        return f(5, 5)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true]
+    end
+
+    test ":equal — number-vs-number fast path" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a == b end
+        return f(5, 5), f(5, 6)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true, false]
+    end
+
+    test ":not_equal" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a ~= b end
+        return f(5, 6), f(5, 5)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true, false]
+    end
+
+    test "string ordering uses byte comparison" do
+      {proto, results} =
+        run!("""
+        function f(a, b) return a < b end
+        return f("apple", "banana")
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true]
+    end
+  end
+
+  describe "logical opcodes" do
+    test ":not on falsy and truthy values" do
+      {proto, results} =
+        run!("""
+        function f(a) return not a end
+        return f(nil), f(false), f(0), f("")
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [true, true, false, false]
+    end
+  end
+
+  describe "control flow" do
+    test ":test selects the then branch when condition is truthy" do
+      {proto, results} =
+        run!("""
+        function f(n) if n > 0 then return 1 end return -1 end
+        return f(5), f(-3)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [1, -1]
+    end
+
+    test ":test with nil and false both fall through to else" do
+      {proto, results} =
+        run!("""
+        function f(x) if x then return "truthy" else return "falsy" end end
+        return f(nil), f(false), f(0)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == ["falsy", "falsy", "truthy"]
+    end
+  end
+
+  describe "register movement / loads" do
+    test ":load_constant + :move + :return_one" do
+      {proto, results} =
+        run!("""
+        function f() return 42 end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [42]
+    end
+
+    test ":load_boolean" do
+      {proto, results} =
+        run!("""
+        function f() return true, false end
+        return f()
+        """)
+
+      # `return true, false` is a multi-return — encoder rejects it, so
+      # the prototype falls back. Still verifies the load opcodes work
+      # through the interpreter path.
+      _ = proto
+      assert results == [true, false]
+    end
+  end
+
+  describe "calls" do
+    test "single-result recursive call (:call_one + :return_one)" do
+      {proto, results} =
+        run!("""
+        function fib(n)
+          if n < 2 then return n end
+          return fib(n - 1) + fib(n - 2)
+        end
+        return fib(10)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [55]
+    end
+
+    test "compiled-to-native call: dispatcher hands off to Executor.call_function/3" do
+      # A direct `local y = native(...)` (single-result call, no return-
+      # position multi-return) compiles to bytecode and routes the
+      # native callee through `Executor.call_function/3`.
+      {proto, results} =
+        run!("""
+        function f(s)
+          local upper = string.upper(s)
+          return upper
+        end
+        return f("hi")
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == ["HI"]
+    end
+  end
+
+  describe "field access" do
+    test ":get_field reads from _ENV (global lookup)" do
+      {proto, results} =
+        run!("""
+        x = 99
+        function f() return x end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [99]
+    end
+
+    test ":get_field returns nil for missing key with no metatable" do
+      {proto, results} =
+        run!("""
+        function f() return missing_global end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [nil]
+    end
+  end
+
+  describe "interop with interpreter" do
+    test "compiled callee returns to interpreted caller correctly" do
+      # The outer chunk's `:call` (multi-return into `return`) is not
+      # bytecode-compilable, so it stays on the interpreter. The inner
+      # `add` function compiles. This exercises the interpreter →
+      # dispatcher → interpreter round-trip.
+      {proto, results} =
+        run!("""
+        function add(a, b) return a + b end
+        return add(2, 3)
+        """)
+
+      assert proto.bytecode == nil, "outer chunk should fall back"
+      assert first_sub(proto).bytecode != nil, "inner fn should compile"
+      assert results == [5]
+    end
+
+    test "compiled metamethod invoked through interpreter call_function" do
+      {proto, results} =
+        run!("""
+        local mt = {__add = function(a, b) return a.v + b.v end}
+        local x = setmetatable({v = 10}, mt)
+        local y = setmetatable({v = 20}, mt)
+        return (x + y)
+        """)
+
+      # The __add closure compiles; the chunk falls back due to
+      # setmetatable/table-construction opcodes outside coverage.
+      _ = proto
+      assert results == [30]
+    end
+  end
+end

--- a/test/lua/vm/dispatcher_test.exs
+++ b/test/lua/vm/dispatcher_test.exs
@@ -21,9 +21,11 @@ defmodule Lua.VM.DispatcherTest do
   use ExUnit.Case, async: true
 
   alias Lua.Compiler
+  alias Lua.Compiler.Bytecode
   alias Lua.Compiler.Prototype
   alias Lua.Parser
   alias Lua.VM
+  alias Lua.VM.Dispatcher
   alias Lua.VM.State
   alias Lua.VM.Stdlib
 
@@ -372,6 +374,57 @@ defmodule Lua.VM.DispatcherTest do
       # setmetatable/table-construction opcodes outside coverage.
       _ = proto
       assert results == [30]
+    end
+  end
+
+  describe "upvalues" do
+    test ":get_upvalue reads a captured local through a compiled closure" do
+      # Exercises the dispatcher's :get_upvalue path end-to-end. The
+      # inner `inc` body compiles; the outer closure provides the
+      # cell.
+      {_proto, results} =
+        run!("""
+        local function make()
+          local x = 41
+          return function() return x + 1 end
+        end
+        local inc = make()
+        return inc()
+        """)
+
+      assert results == [42]
+    end
+
+    test ":get_upvalue returns nil for a dangling cell (parity with interpreter)" do
+      # Pins the contract that the dispatcher's :get_upvalue mirrors the
+      # interpreter's Map.get/2 semantics for a missing cell: nil, not a
+      # :badkey raise. Compiled closures should never carry stale refs
+      # in practice, but if one ever does, both executors have to
+      # diverge identically.
+      #
+      # Built by hand because the compiler will not produce a stale ref
+      # — this asserts the dispatcher's *shape*, not a reachable bug.
+      proto = %Prototype{
+        instructions: [
+          {:get_upvalue, 0, 0},
+          {:return, 0, 1}
+        ],
+        bytecode: {
+          {Bytecode.op_get_upvalue(), 0, 0},
+          {Bytecode.op_return_one(), 0}
+        },
+        param_count: 0,
+        max_registers: 1,
+        source: "test-synthetic"
+      }
+
+      # Forge a cell ref that is *not* present in state.upvalue_cells.
+      dangling = make_ref()
+      upvalues = {dangling}
+      state = State.new()
+
+      {results, _state} = Dispatcher.execute(proto, [], upvalues, state)
+      assert results == [nil]
     end
   end
 end

--- a/test/lua/vm/display_test.exs
+++ b/test/lua/vm/display_test.exs
@@ -68,13 +68,8 @@ defmodule Lua.VM.DisplayTest do
     test "wraps Lua closures returned in default decode mode" do
       {[c], _} = Lua.eval!(Lua.new(), "return function(a, b) return a + b end")
 
-      assert %Closure{
-               source: "<eval>",
-               line: 1,
-               arity: 2,
-               vararg?: false,
-               ref: {:lua_closure, _, _}
-             } = c
+      assert %Closure{source: "<eval>", line: 1, arity: 2, vararg?: false, ref: ref} = c
+      assert match?({:lua_closure, _, _}, ref) or match?({:compiled_closure, _, _}, ref)
 
       assert inspect(c) == "#Lua.Closure<source: \"<eval>\", line: 1, arity: 2>"
     end
@@ -82,7 +77,8 @@ defmodule Lua.VM.DisplayTest do
     test "wraps Lua closures returned in decode: false mode" do
       {[c], _} = Lua.eval!(Lua.new(), "return function() end", decode: false)
 
-      assert %Closure{ref: {:lua_closure, _, _}} = c
+      assert %Closure{ref: ref} = c
+      assert match?({:lua_closure, _, _}, ref) or match?({:compiled_closure, _, _}, ref)
       assert inspect(c) =~ "#Lua.Closure<"
     end
 
@@ -158,7 +154,8 @@ defmodule Lua.VM.DisplayTest do
     test "returns the underlying lua_closure for closures" do
       {[c], _} = Lua.eval!(Lua.new(), "return function() end")
 
-      assert match?({:lua_closure, _, _}, Lua.unwrap(c))
+      assert match?({:lua_closure, _, _}, Lua.unwrap(c)) or
+               match?({:compiled_closure, _, _}, Lua.unwrap(c))
     end
 
     test "returns the underlying native_func for native funcs" do

--- a/test/lua/vm/leak_regression_test.exs
+++ b/test/lua/vm/leak_regression_test.exs
@@ -1,0 +1,101 @@
+defmodule Lua.VM.LeakRegressionTest do
+  @moduledoc """
+  Pins the non-leak guarantee of the bytecode compiler + dispatcher.
+
+  The whole point of moving away from per-prototype BEAM module generation
+  was to keep `Lua.eval/2` from minting atoms or loading code modules at
+  runtime. These tests assert that property holds: running large batches
+  of distinct Lua sources — both via `Lua.eval!` directly and via the
+  Lua `load()` stdlib — grows neither the atom table nor the
+  loaded-module count by more than a small noise threshold.
+
+  This is the test that should have existed when the prior `:compile.forms`
+  experiment was originally explored. Treating leak-freedom as a property
+  the test suite enforces keeps future codegen experiments honest.
+  """
+
+  use ExUnit.Case, async: false
+
+  test "compiling N distinct prototypes via Lua.eval! does not grow atom table" do
+    # Warm-up loop: the parser/lexer/codegen pipeline interns some atoms
+    # the first time each AST/op shape is seen. After ~100 distinct
+    # sources the table stabilises. The measurement window starts after
+    # warm-up so the test only captures genuine per-iteration growth.
+    lua = Lua.new()
+
+    for i <- 1..200 do
+      {[_v], _state} = Lua.eval!(lua, "return #{i} + 1")
+    end
+
+    :erlang.garbage_collect()
+    before_atoms = :erlang.system_info(:atom_count)
+    before_modules = length(:code.all_loaded())
+
+    for i <- 1..1_000 do
+      {[_v], _state} = Lua.eval!(lua, "return #{i + 10_000} + 1")
+    end
+
+    :erlang.garbage_collect()
+
+    after_atoms = :erlang.system_info(:atom_count)
+    after_modules = length(:code.all_loaded())
+
+    # Per-iteration atom growth must be ~zero. Allow a small headroom
+    # for incidental interning during the run (formatter strings, etc).
+    assert after_atoms - before_atoms < 50,
+           "atom count grew by #{after_atoms - before_atoms} over 1000 evals"
+
+    # The dispatcher must not generate per-prototype modules. The
+    # test runner loads ancillary modules lazily during a run
+    # (Inspect protocol consolidations, exception formatters,
+    # benchmark plumbing if it ran first), so we allow a small fixed
+    # headroom and assert sub-linear-in-N growth — if each iteration
+    # loaded even one module, the count would grow by 1000.
+    growth = after_modules - before_modules
+    assert growth < 20, "loaded module count grew by #{growth} (expected < 20)"
+  end
+
+  test "load() with unique sources does not grow atom table" do
+    # `load` is sandboxed by default; allow it explicitly so we can
+    # exercise the runtime-compile path.
+    lua = Lua.new(sandboxed: [])
+    # Warm-up call to settle any first-call atom interning.
+    {_, _} = Lua.eval!(lua, "return 0")
+
+    before_atoms = :erlang.system_info(:atom_count)
+    before_modules = length(:code.all_loaded())
+
+    {_, _lua} =
+      Lua.eval!(lua, """
+      for i = 1, 1000 do
+        load("return " .. i)()
+      end
+      """)
+
+    :erlang.garbage_collect()
+
+    after_atoms = :erlang.system_info(:atom_count)
+    after_modules = length(:code.all_loaded())
+
+    assert after_atoms - before_atoms < 50,
+           "atom count grew by #{after_atoms - before_atoms} over 1000 load() calls"
+
+    growth = after_modules - before_modules
+    assert growth < 20, "loaded module count grew by #{growth} (expected < 20)"
+  end
+
+  test "bytecode prototypes are plain tuples, not modules" do
+    # Direct shape check: a compiled prototype's bytecode is a tuple of
+    # tuples — no module reference, no `make_ref/0`, no anything that
+    # ties it to a particular code version. Hot-reloading the dispatcher
+    # would invalidate nothing but the function pointer in the calling
+    # process, which is the same property any normal Elixir module has.
+    {:ok, ast} = Lua.Parser.parse("function f(a, b) return a + b end")
+    {:ok, proto} = Lua.Compiler.compile(ast)
+    [fn_proto] = proto.prototypes
+
+    assert is_tuple(fn_proto.bytecode)
+    refute is_atom(fn_proto.bytecode)
+    refute is_reference(fn_proto.bytecode)
+  end
+end


### PR DESCRIPTION
## Dispatcher foundation — single hand-written executor over dense bytecode

Plan: [`.agents/plans/B5a-v2-dispatcher-foundation.md`](.agents/plans/B5a-v2-dispatcher-foundation.md)

### Goal

Land the foundation for B5's new approach: a single hand-written dispatcher
module that interprets a dense bytecode representation of `%Prototype{}` values.
No runtime BEAM module generation. No atoms minted per compile. No
`:compile.forms`, no `:code.load_binary`. Same dispatch shape as the BEAM's
standard case-jump-table idiom.

Scope mirrors the original B5a: arithmetic, comparison, logical ops,
conditional `:test`, single-result `:call`, single-value `:return`, plus the
common `_ENV.name` lookup path. Tables, closures, multi-return, loops, varargs
all fall back to the existing list-of-tuples interpreter.

### Success criteria

- [x] `Lua.VM.Dispatcher` module exists at `lib/lua/vm/dispatcher.ex`, hand-
      written, exports `execute(proto, args, state)` returning
      `{results, state}`. Single recursive function with one case branch per
      opcode integer.
- [x] `Lua.Compiler.Bytecode` module exists at `lib/lua/compiler/bytecode.ex`,
      walks a `%Prototype{}` and produces `{:ok, bytecode_tuple}` or `:fallback`.
- [x] `%Prototype{}` gains a `bytecode :: tuple() | nil` field. Set when the
      bytecode compiler accepts the prototype, nil otherwise.
- [x] `Lua.VM.Executor.call_function/3` learns a clause for
      `{:compiled_closure, proto, upvalues}` that dispatches to
      `Lua.VM.Dispatcher.execute/4`.
- [x] The `:call` opcode in the interpreter learns the same shortcut for
      `:compiled_closure` callees.
- [x] Opcode coverage matches the plan: `:load_constant`, `:load_boolean`,
      `:load_nil`, `:move`, `:get_upvalue`, `:get_global`, `:load_env`,
      `:get_field`, `:add`, `:subtract`, `:multiply`, `:divide`,
      `:floor_divide`, `:modulo`, `:power`, `:negate`, `:less_than`,
      `:less_equal`, `:greater_than`, `:greater_equal`, `:equal`,
      `:not_equal`, `:not`, `:test`, `:test_true`, `:call` (single result),
      `:return` (single value), and `:source_line` (stripped at encode time
      since dispatcher line tracking is deferred to B5d-v2).
- [x] Uncovered opcodes return `:fallback` from the bytecode compiler; the
      prototype stays interpreted. No crashes.
- [x] `mix test`: **1705 → 1749 tests** (44 new), 0 failures, 51 properties,
      55 doctests.
- [x] `mix test --only lua53`: 29 tests, 0 failures.
- [x] **Leak regression test passes**: 1000 distinct `Lua.eval!` calls grow
      atom count by <50 and module count by <20 (test-runtime variance).
- [⚠️] **fib(25) gate**: 1.17x median (range 1.14 – 1.21 across runs). Plan
      asked for ≥1.2x. Stretch goal (Luerl parity ±10%): met — fib(30)
      beats Luerl on a good run.
- [x] No workload regresses by more than 10% (smoke-checked all 5 benchmarks).

### Performance

`benchmarks/dispatcher_vs_interpreter.exs` (added) compares dispatcher vs.
interpreter on the same VM state, with `proto.bytecode` stripped to force the
interpreter path. fib(25), Benchee full mode (10s window, median of three runs):

| Path        | Avg     | Median  | Memory  |
|-------------|---------|---------|---------|
| Dispatcher  | ~65 ms  | ~65 ms  | 600 MB  |
| Interpreter | ~76 ms  | ~76 ms  | 673 MB  |
| **Δ**       | **1.17x faster** | **1.17x** | **1.12x less** |

fib(30) against Luerl (`benchmarks/fibonacci.exs`):

| Impl              | Median (ms) |
|-------------------|-------------|
| C Lua (luaport)   | 28          |
| **lua (chunk)**   | **748**     |
| Luerl             | 737         |

(Run-to-run variance puts us anywhere from 5% ahead to 5% behind Luerl on fib(30).
The plan called for parity ±10%, which we hit.)

#### Profile attribution after all optimization passes

- `Dispatcher.dispatch/8`: 50% (the case-jump-table)
- `:erlang.setelement/3`: 30% (register writes — unavoidable)
- `copy_regs/5` + `init_callee_regs/4`: 9% (call setup tuple allocation)
- `return_one/3`: 4% (frame unwinding)

Further gains require structural changes explicitly out of scope: mutable
register storage, flat-PC bytecode with label resolution, or direct-threaded
dispatch. Each becomes its own follow-up plan if Direction B continues.

#### Optimization iterations log (1.05x → 1.17x)

1. **Initial baseline:** 1.05x (two-level `dispatch/8` + `step/9` chain).
2. **Inlined `step/9` into `dispatch/8`:** 1.09x.
3. **Tuple frames + unboxed `return_one/3`:** 1.09x.
4. **Stripped `:source_line` from bytecode:** 1.15x (~5% — 228k fewer dispatches on fib(25)).
5. **Inlined int64-bounds guard + truthy check:** 1.17x median.
6. **Tried open_upvalues empty-map elision:** -3% regression, reverted.

### Changes

```
 .agents/plans/B5a-v2-dispatcher-foundation.md |   (status: review, discoveries appended)
 benchmarks/dispatcher_vs_interpreter.exs      |  +56  (new)
 lib/lua.ex                                    |   ±14
 lib/lua/api.ex                                |   ±3
 lib/lua/compiler.ex                           |   ±13
 lib/lua/compiler/bytecode.ex                  | +213  (new — encoder)
 lib/lua/compiler/prototype.ex                 |   ±12
 lib/lua/util.ex                               |   ±1
 lib/lua/vm/dispatcher.ex                      | +652  (new — hot loop)
 lib/lua/vm/display.ex                         |   ±6
 lib/lua/vm/executor.ex                        | +147  (binop/cmp/get_field bridges, :compiled_closure clauses)
 lib/lua/vm/stdlib.ex                          |   ±15
 lib/lua/vm/stdlib/{debug,string,util}.ex      |   ±4
 lib/lua/vm/value.ex                           |   ±2
 test/lua/compiler/bytecode_test.exs           | +178  (new — 14 cascade tests)
 test/lua/vm/dispatcher_test.exs               | +330  (new — 27 opcode goldens)
 test/lua/vm/display_test.exs                  |   ±15
 test/lua/vm/leak_regression_test.exs          | +103  (new — 3 leak guards)
```

### Discoveries

The plan was drafted against a flat-IR mental model. Five mismatches with the
actual codebase were worked around without scope expansion:

1. **IR is structured, not flat.** `:test` carries nested instruction lists;
   loops use CPS continuation markers. Adapted: bytecode for `:test` carries
   nested bytecode sub-tuples; dispatcher pushes `{code, pc}` resume points
   onto a local continuation stack.
2. **No constants pool.** Constants are inlined as opcode operands. The
   encoded shape preserves this.
3. **Opcode signatures differ.** `:return` is `{base, count}`, `:call` is
   5-tuple, `:load_env` carries `dest`, `:source_line` carries `file`.
   `:scope` is vestigial — never emitted. Bytecode encoder matches the real
   shapes.
4. **`proto.subprotos` is named `prototypes`.** Used the real field name.
5. **`:source_line` strip.** Removed from bytecode (no-op dispatch cost ~5%
   on fib). Original instruction stream untouched; interpreter error
   reporting still works for non-compiled prototypes.

The `:compiled_closure` value tag has more touch points than expected — ~12
sites across `Executor`, `Value`, stdlib, display, and the public API needed
parallel pattern-match clauses. A future refactor could collapse the two tags
into a single `:lua_closure` with `proto.bytecode != nil` flagging dispatcher
routing. Left as-is for B5a-v2 since the explicit tag keeps the routing
decision local to `call_function/3`.

See `Discoveries` section of the plan for the full per-iteration profile loop.

### Verification

```
mix format
mix compile --warnings-as-errors                  ✓
mix test                                          ✓ 1749 tests, 0 failures
mix test --only lua53                             ✓ 29 tests, 0 failures
mix test test/lua/vm/dispatcher_test.exs          ✓ 27 tests
mix test test/lua/compiler/bytecode_test.exs      ✓ 14 tests
mix test test/lua/vm/leak_regression_test.exs     ✓ 3 tests

LUA_BENCH_MODE=full MIX_ENV=benchmark \
  mix run benchmarks/dispatcher_vs_interpreter.exs    # 1.17x median
MIX_ENV=benchmark mix run benchmarks/fibonacci.exs    # Luerl ±5%
MIX_ENV=benchmark mix run benchmarks/{oop,closures,table_ops,string_ops}.exs
# All within ±10% of pre-change numbers
```

### Out of scope (intentional)

- Tables (B5b-v2)
- Closures, varargs, multi-return (B5c-v2)
- Error position fidelity in the dispatcher (B5d-v2)
- SSA / register promotion
- Direct-threaded dispatch
- Mutable register storage
- Mixed-mode mid-stream (one prototype crossing the dispatcher↔interpreter
  boundary mid-execution — it's all-or-nothing per prototype)

### Reviewer note: perf gate decision

The plan's risk section says **"If the dispatcher does not beat the current
interpreter by at least 1.2x on fib(25), the whole Direction-B premise is
wrong and we should redirect to data-shape work (B6/B7) instead."**

We sit at 1.17x median, brushing 1.2x on some runs. Strictly the gate is
not met. But:

1. The fib(30) full benchmark hits Luerl parity (the stretch goal).
2. Memory is 12% lower.
3. The architectural property the rewrite was meant to deliver — no atom
   leaks, no per-prototype modules, no `:compile.forms` lifecycle hazard —
   holds, and is enforced by the new leak regression suite.
4. Further dispatcher gains are achievable via the deferred follow-ups
   (mutable registers, flat PC, direct-threaded dispatch), each its own
   plan with bounded risk.

**My recommendation:** treat this as a soft pass — ship as the foundation,
proceed cautiously into B5b-v2 (tables) and B5c-v2 (closures) with another
gate check after each. If neither moves the needle on tables/closures
workloads, then redirect to B6/B7.

Open to overriding.