### PR TITLE
fix: line number attribution for first line

### DIFF
--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -576,10 +576,10 @@ defmodule Lua.Parser do
             # It's a call statement (or error if not a call)
             case expr do
               %Expr.Call{} = call ->
-                {:ok, %Statement.CallStmt{call: call, meta: nil}, rest}
+                {:ok, %Statement.CallStmt{call: call, meta: Meta.new(starting_pos)}, rest}
 
               %Expr.MethodCall{} = call ->
-                {:ok, %Statement.CallStmt{call: call, meta: nil}, rest}
+                {:ok, %Statement.CallStmt{call: call, meta: Meta.new(starting_pos)}, rest}
 
               other ->
                 # Prefer the AST node's meta when populated; some postfix

--- a/test/lua/compiler/source_line_test.exs
+++ b/test/lua/compiler/source_line_test.exs
@@ -84,6 +84,25 @@ defmodule Lua.Compiler.SourceLineTest do
       assert last >= 4
     end
 
+    test "emits source_line for a leading bare-call statement" do
+      # Regression: CallStmt used to be constructed with `meta: nil`, which
+      # caused codegen to skip the leading `:source_line` marker. Without
+      # it, every instruction up to the first non-call statement was
+      # rendered with no associated source line in the playground.
+      code = "print(1)\nreturn 2\n"
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      line_numbers =
+        proto.instructions
+        |> Enum.filter(&match?({:source_line, _, _}, &1))
+        |> Enum.map(fn {:source_line, line, _} -> line end)
+
+      assert 1 in line_numbers
+      assert 2 in line_numbers
+    end
+
     test "computes line range for nested functions" do
       code = """
       local x = function()

--- a/test/lua/parser/statement_test.exs
+++ b/test/lua/parser/statement_test.exs
@@ -132,6 +132,26 @@ defmodule Lua.Parser.StatementTest do
                block: %{stmts: [%Statement.CallStmt{call: %Expr.MethodCall{method: "method"}}]}
              } = chunk
     end
+
+    test "call-statement meta carries the source line of the leading token" do
+      assert {:ok, chunk} = Parser.parse("\nprint(1)\n")
+
+      assert %{
+               block: %{
+                 stmts: [%Statement.CallStmt{meta: %{start: %{line: 2}}}]
+               }
+             } = chunk
+    end
+
+    test "method-call-statement meta carries the source line of the leading token" do
+      assert {:ok, chunk} = Parser.parse("\n\nobj:method()\n")
+
+      assert %{
+               block: %{
+                 stmts: [%Statement.CallStmt{meta: %{start: %{line: 3}}}]
+               }
+             } = chunk
+    end
   end
 
   describe "if statements" do


### PR DESCRIPTION
We were setting meta as the default, so the first line wasn't getting picked up