### PR TITLE
fix(stdlib): convert dots to path separators in require()

### DIFF
--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -750,8 +750,10 @@ defmodule Lua.VM.Stdlib do
 
   # Find a module file by searching the patterns
   defp find_module_file(modname, patterns) do
+    resolved = String.replace(modname, ".", "/")
+
     Enum.find_value(patterns, {:error, :not_found}, fn pattern ->
-      file_path = String.replace(pattern, "?", modname)
+      file_path = String.replace(pattern, "?", resolved)
 
       case File.read(file_path) do
         {:ok, content} -> {:ok, file_path, content}

--- a/test/lua/vm/stdlib/package_test.exs
+++ b/test/lua/vm/stdlib/package_test.exs
@@ -123,4 +123,22 @@ defmodule Lua.VM.Stdlib.PackageTest do
       assert {[true, 1], _} = eval_with_path(code, tmp_dir)
     end
   end
+
+  describe "dotted module names" do
+    @tag :tmp_dir
+    test "require('foo.bar') resolves dots to directory separators", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "foo"))
+
+      File.write!(Path.join([tmp_dir, "foo", "bar.lua"]), """
+      return { ok = true }
+      """)
+
+      code = ~S"""
+      local m = require("foo.bar")
+      return m.ok
+      """
+
+      assert {[true], _} = eval_with_path(code, tmp_dir)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `require("foo.bar")` was resolving to `<package.path>/foo.bar.lua` instead of `<package.path>/foo/bar.lua`. Lua 5.3 §6.3 (`package.searchpath`) requires that every `.` in the module name be replaced with the directory separator **before** substitution into the `?` slot of each `package.path` template. The new VM was skipping that step, so any disk-loaded dotted require would look in the wrong place.
- Fix is a two-line change in `find_module_file/2`: hoist `String.replace(modname, ".", "/")` above the pattern loop and substitute the result. The default `package.path` already hardcodes `/` as the separator (`lib/lua/vm/stdlib.ex:597`), so this introduces no new configuration surface.
- Adds a regression test that exercises the disk-load path with a dotted module name. Existing tests in `package_test.exs` only used single-segment names, so the substitution path was unexercised.

## Downstream impact

Caught by a downstream `sidecar` consumer bumping to `1.0.0-rc.0`. Its bootstrap goes `require("luassert")` → `luassert/init.lua` → `require("luassert.assert")`, which is exactly the broken path. With this fix and a `1.0.0-rc.1` release, that consumer can bump.

## Out of scope (intentionally)

The investigation surfaced broader package-compliance gaps that are **not** part of this PR — keeping the fix minimal. Track separately if/when needed:

- `package.config` (the 5-line config string) is not exposed.
- `package.searchpath/2` is not implemented (would share the same `.` → `/` logic; worth extracting a helper at that point).
- `package.cpath` / C-loader semantics.
- The official `lua53_tests/attrib.lua` suite remains skipped — it depends on `package.searchpath` and C submodules in addition to this fix.

## Test plan

- [x] `mix test test/lua/vm/stdlib/package_test.exs` — new dotted-require test passes
- [x] `mix test` — full suite: 1,848 passed, 30 skipped (no new skips, no regressions)
- [ ] Manual: point a downstream consumer at this branch (`{:lua, github: "tv-labs/lua", branch: "fix/require-dotted-module-name"}`) and confirm its `luassert`-chained requires resolve