### PR TITLE
suite: triage and promote literals/goto/events/nextvar files

### DIFF
--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -118,6 +118,18 @@ defmodule Lua.Compiler.Scope do
     Enum.reduce(stmts, state, &resolve_statement/2)
   end
 
+  # Per Lua 5.3 §3.3.4, each control-flow block (then/else, while/repeat
+  # body, for body) is its own lexical scope: locals declared inside it
+  # must not leak past the block's end.
+  defp with_block_scope(state, fun) do
+    saved_locals = state.locals
+    saved_next_register = state.next_register
+
+    state = fun.(state)
+
+    %{state | locals: saved_locals, next_register: saved_next_register}
+  end
+
   defp resolve_statement(%Statement.Return{values: values}, state) do
     Enum.reduce(values, state, &resolve_expr/2)
   end
@@ -169,75 +181,66 @@ defmodule Lua.Compiler.Scope do
          %Statement.If{condition: condition, then_block: then_block, elseifs: elseifs, else_block: else_block},
          state
        ) do
-    # Resolve the main condition
+    # Per Lua 5.3 §3.3.4, each branch of an `if` is its own block, so locals
+    # declared inside it do not leak past `end`.
     state = resolve_expr(condition, state)
+    state = with_block_scope(state, &resolve_block(then_block, &1))
 
-    # Resolve the then block
-    state = resolve_block(then_block, state)
-
-    # Resolve all elseif clauses
     state =
       Enum.reduce(elseifs, state, fn {elseif_cond, elseif_block}, state ->
         state = resolve_expr(elseif_cond, state)
-        resolve_block(elseif_block, state)
+        with_block_scope(state, &resolve_block(elseif_block, &1))
       end)
 
-    # Resolve the else block if present
     if else_block do
-      resolve_block(else_block, state)
+      with_block_scope(state, &resolve_block(else_block, &1))
     else
       state
     end
   end
 
   defp resolve_statement(%Statement.While{condition: condition, body: body}, state) do
-    # Resolve the condition
     state = resolve_expr(condition, state)
-    # Resolve the body
-    resolve_block(body, state)
+    with_block_scope(state, &resolve_block(body, &1))
   end
 
   defp resolve_statement(%Statement.Repeat{body: body, condition: condition}, state) do
-    # Resolve the body first (in Lua, the condition can reference variables declared in the body)
+    # In Lua, repeat-until's condition is part of the body's scope so it can
+    # reference locals declared inside the loop. Restore the outer scope only
+    # after the condition has been resolved.
+    saved_locals = state.locals
+    saved_next_register = state.next_register
+
     state = resolve_block(body, state)
-    # Resolve the condition
-    resolve_expr(condition, state)
+    state = resolve_expr(condition, state)
+
+    %{state | locals: saved_locals, next_register: saved_next_register}
   end
 
   defp resolve_statement(
          %Statement.ForNum{var: var, start: start_expr, limit: limit_expr, step: step_expr, body: body} = for_stmt,
          state
        ) do
-    # Resolve start, limit, and step expressions with current scope
     state = resolve_expr(start_expr, state)
     state = resolve_expr(limit_expr, state)
     state = if step_expr, do: resolve_expr(step_expr, state), else: state
 
-    # The loop variable is a local within the loop body
-    # Assign it a register
+    saved_locals = state.locals
+    saved_next_register = state.next_register
+
     loop_var_reg = state.next_register
     state = %{state | locals: Map.put(state.locals, var, loop_var_reg)}
-    # Reserve 3 registers: the loop variable shares with the internal counter,
-    # plus limit and step registers (codegen allocates base, base+1, base+2)
     state = %{state | next_register: loop_var_reg + 3}
 
-    # Store this loop's variable register in var_map so codegen can find the
-    # correct register even when consecutive `for` statements share a variable
-    # name (each loop binds the same name to a fresh register, but
-    # `state.locals[var]` only retains the most recent binding).
     state = %{state | var_map: Map.put(state.var_map, {:for_num_var_reg, for_stmt}, loop_var_reg)}
 
-    # Update max_register
     func_scope = state.functions[state.current_function]
     func_scope = %{func_scope | max_register: max(func_scope.max_register, state.next_register)}
     state = %{state | functions: Map.put(state.functions, state.current_function, func_scope)}
 
-    # Resolve the body with the loop variable in scope
     state = resolve_block(body, state)
 
-    # Remove the loop variable from scope after the loop
-    # (In real implementation, we'd need scope stack management, but for now this is fine)
-    state
+    %{state | locals: saved_locals, next_register: saved_next_register}
   end
 
   defp resolve_statement(
@@ -293,10 +296,11 @@ defmodule Lua.Compiler.Scope do
   end
 
   defp resolve_statement(%Statement.ForIn{vars: vars, iterators: iterators, body: body} = for_stmt, state) do
-    # Resolve iterator expressions with current scope
     state = Enum.reduce(iterators, state, &resolve_expr/2)
 
-    # Assign registers for loop variables (same pattern as ForNum)
+    saved_locals = state.locals
+    saved_next_register = state.next_register
+
     {state, _, var_regs} =
       Enum.reduce(vars, {state, state.next_register, []}, fn name, {state, reg, acc} ->
         state = %{state | locals: Map.put(state.locals, name, reg)}
@@ -304,19 +308,15 @@ defmodule Lua.Compiler.Scope do
         {state, reg + 1, [reg | acc]}
       end)
 
-    # Store this loop's variable registers in var_map so codegen can find the
-    # correct registers even when consecutive `for` statements share variable
-    # names (each loop binds the same names to fresh registers, but
-    # `state.locals[name]` only retains the most recent binding).
     state = %{state | var_map: Map.put(state.var_map, {:for_in_var_regs, for_stmt}, Enum.reverse(var_regs))}
 
-    # Update max_register
     func_scope = state.functions[state.current_function]
     func_scope = %{func_scope | max_register: max(func_scope.max_register, state.next_register)}
     state = %{state | functions: Map.put(state.functions, state.current_function, func_scope)}
 
-    # Resolve the body with loop variables in scope
-    resolve_block(body, state)
+    state = resolve_block(body, state)
+
+    %{state | locals: saved_locals, next_register: saved_next_register}
   end
 
   defp resolve_statement(%Statement.LocalFunc{name: name, params: params, body: body} = local_func, state) do

--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -133,7 +133,10 @@ defmodule Lua.Lexer do
   defp do_tokenize(<<"[", rest::binary>>, acc, pos) do
     case scan_long_bracket(rest, 0) do
       {:ok, equals, after_bracket} ->
-        scan_long_string(after_bracket, "", acc, advance_column(pos, 2 + equals), pos, equals)
+        start_pos = pos
+        open_pos = advance_column(pos, 2 + equals)
+        {body_rest, body_pos} = drop_leading_newline(after_bracket, open_pos)
+        scan_long_string(body_rest, "", acc, body_pos, start_pos, equals)
 
       :error ->
         # Not a long string, treat as delimiter
@@ -582,7 +585,19 @@ defmodule Lua.Lexer do
     end
   end
 
-  defp scan_long_string(<<?\n, rest::binary>>, str_acc, acc, pos, start_pos, level) do
+  # Per Lua 5.3 §3.1, long strings normalize end-of-line sequences (`\r`,
+  # `\n`, `\r\n`, `\n\r`) to a single `\n`.
+  defp scan_long_string(<<?\r, ?\n, rest::binary>>, str_acc, acc, pos, start_pos, level) do
+    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
+    scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
+  end
+
+  defp scan_long_string(<<?\n, ?\r, rest::binary>>, str_acc, acc, pos, start_pos, level) do
+    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
+    scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
+  end
+
+  defp scan_long_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, level) when c == ?\n or c == ?\r do
     new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
     scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
   end
@@ -594,6 +609,20 @@ defmodule Lua.Lexer do
   defp scan_long_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, level) do
     scan_long_string(rest, str_acc <> <<c>>, acc, advance_column(pos, 1), start_pos, level)
   end
+
+  # Per Lua 5.3 §3.1: "when the opening long bracket is immediately followed
+  # by a newline, the newline is not included in the string." Applies to any
+  # line-break sequence (`\n`, `\r`, `\r\n`, `\n\r`).
+  defp drop_leading_newline(<<?\r, ?\n, rest::binary>>, pos),
+    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}}
+
+  defp drop_leading_newline(<<?\n, ?\r, rest::binary>>, pos),
+    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}}
+
+  defp drop_leading_newline(<<c, rest::binary>>, pos) when c == ?\n or c == ?\r,
+    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}}
+
+  defp drop_leading_newline(rest, pos), do: {rest, pos}
 
   # Scan identifier or keyword
   defp scan_identifier(<<c, rest::binary>>, id_acc, acc, pos, start_pos)

--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -610,22 +610,47 @@ defmodule Lua.Parser do
   end
 
   defp parse_assignment(targets, [{:operator, :assign, pos} | rest]) do
-    case parse_expr_list(rest) do
-      {:ok, values, rest2} ->
-        # Create meta from first target's position
-        meta =
-          if hd(targets).meta do
-            %{hd(targets).meta | start: hd(targets).meta.start || pos}
-          else
-            Meta.new(pos)
-          end
+    case validate_assign_targets(targets) do
+      :ok ->
+        case parse_expr_list(rest) do
+          {:ok, values, rest2} ->
+            # Create meta from first target's position
+            meta =
+              if hd(targets).meta do
+                %{hd(targets).meta | start: hd(targets).meta.start || pos}
+              else
+                Meta.new(pos)
+              end
 
-        {:ok, %Statement.Assign{targets: targets, values: values, meta: meta}, rest2}
+            {:ok, %Statement.Assign{targets: targets, values: values, meta: meta}, rest2}
 
-      {:error, reason} ->
-        {:error, reason}
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, _} = err ->
+        err
     end
   end
+
+  # Per Lua 5.3 §3.3.3, the lhs of an assignment must be a `var`:
+  # Name | prefixexp '[' exp ']' | prefixexp '.' Name. Anything else
+  # (number, string, function call, parenthesised expression) is a
+  # syntax error.
+  defp validate_assign_targets(targets) do
+    Enum.reduce_while(targets, :ok, fn target, :ok ->
+      case target do
+        %Expr.Var{} -> {:cont, :ok}
+        %Expr.Property{} -> {:cont, :ok}
+        %Expr.Index{} -> {:cont, :ok}
+        other -> {:halt, {:error, {:invalid_assign_target, target_position(other), other.__struct__}}}
+      end
+    end)
+  end
+
+  defp target_position(%{meta: %Meta{start: %{} = pos}}), do: pos
+  defp target_position(%{meta: %{start: %{} = pos}}), do: pos
+  defp target_position(_), do: nil
 
   # Helper: parse list of names (for local declarations, for loops)
   defp parse_name_list(tokens) do
@@ -1286,6 +1311,15 @@ defmodule Lua.Parser do
   defp convert_error({:bare_expression, pos, expr_struct}, _code) do
     {message, suggestion} = bare_expression_message(expr_struct)
     Error.new(:invalid_syntax, message, pos, suggestion: suggestion)
+  end
+
+  defp convert_error({:invalid_assign_target, pos, _expr_struct}, _code) do
+    Error.new(
+      :invalid_syntax,
+      "syntax error near '='",
+      pos,
+      suggestion: "Only variables, table fields, and table indexes can appear on the left of '='."
+    )
   end
 
   defp convert_error(other, _code) do

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -2182,16 +2182,29 @@ defmodule Lua.VM.Executor do
     invoke_metamethod(metamethod, [a], state, default_fn)
   end
 
+  # Per Lua 5.3 §3.4.4, __eq is only consulted when both operands have the
+  # same primitive type and rawequal returns false. Lua looks at the first
+  # operand's __eq, falling back to the second operand's. The two metamethods
+  # do *not* need to be the same function (that was Lua 5.1 behaviour).
   defp try_equality_metamethod(a, b, state, default_fn) do
-    eq_a = lookup_metamethod(a, "__eq", state)
-    eq_b = lookup_metamethod(b, "__eq", state)
+    if eq_metamethod_eligible?(a, b) do
+      case lookup_metamethod(a, "__eq", state) do
+        nil ->
+          case lookup_metamethod(b, "__eq", state) do
+            nil -> {default_fn.(), state}
+            eq -> invoke_metamethod(eq, [a, b], state, default_fn)
+          end
 
-    if not is_nil(eq_a) and eq_a == eq_b do
-      invoke_metamethod(eq_a, [a, b], state, default_fn)
+        eq ->
+          invoke_metamethod(eq, [a, b], state, default_fn)
+      end
     else
       {default_fn.(), state}
     end
   end
+
+  defp eq_metamethod_eligible?({:tref, _}, {:tref, _}), do: true
+  defp eq_metamethod_eligible?(_, _), do: false
 
   # Invokes a metamethod (native or Lua closure) with the given args, falling
   # back to default_fn when the metamethod is missing or unsupported. Delegates
@@ -2361,10 +2374,21 @@ defmodule Lua.VM.Executor do
   defp safe_power(a, b, line, source) do
     with {:ok, na} <- to_number(a),
          {:ok, nb} <- to_number(b) do
-      :math.pow(na, nb)
+      pow_ieee(na, nb)
     else
       {:error, val} -> raise_arith_type_error(val, line, source)
     end
+  end
+
+  # `:math.pow` raises ArithmeticError on 0^(negative), inf ^ 0, etc.
+  # Lua 5.3 follows IEEE 754: 0^(-x) is +inf for positive x; we approximate
+  # inf with our sentinel float (`1.0e308`) since BEAM has no float inf.
+  defp pow_ieee(base, exp) when base == 0 and is_number(exp) and exp < 0, do: 1.0e308
+
+  defp pow_ieee(base, exp) do
+    :math.pow(base / 1, exp / 1)
+  rescue
+    ArithmeticError -> :nan
   end
 
   defp safe_negate(a, line, source) do
@@ -2394,6 +2418,10 @@ defmodule Lua.VM.Executor do
 
   # ── Type-safe comparison ───────────────────────────────────────────────────
 
+  # IEEE 754 §5.11: any ordered comparison involving NaN is false.
+  defp safe_compare_lt(:nan, _, _, _), do: false
+  defp safe_compare_lt(_, :nan, _, _), do: false
+
   defp safe_compare_lt(a, b, line, source) do
     cond do
       is_number(a) and is_number(b) ->
@@ -2406,6 +2434,9 @@ defmodule Lua.VM.Executor do
         raise_compare_type_error(a, b, line, source)
     end
   end
+
+  defp safe_compare_le(:nan, _, _, _), do: false
+  defp safe_compare_le(_, :nan, _, _), do: false
 
   defp safe_compare_le(a, b, line, source) do
     cond do

--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -110,7 +110,7 @@ defmodule Lua.VM.Stdlib do
 
   # type(v) — returns the type of v as a string
   defp lua_type([value | _], state), do: {[Value.type_name(value)], state}
-  defp lua_type([], state), do: {["nil"], state}
+  defp lua_type([], _state), do: raise(ArgumentError.value_expected("type", 1))
 
   # tostring(v) — converts a value to its string representation
   defp lua_tostring([value | _], state) do
@@ -352,16 +352,16 @@ defmodule Lua.VM.Stdlib do
 
   # ipairs(table) — returns iterator function, table, 0
   defp lua_ipairs([{:tref, _} = tref | _], state) do
+    # Per Lua 5.3 §6.1, ipairs reads through the indexing operator, so
+    # __index is honoured. Iteration stops at the first nil.
     iterator =
       {:native_func,
        fn [table_ref, index], state ->
          i = index + 1
-         {:tref, id} = table_ref
-         table = Map.fetch!(state.tables, id)
 
-         case Map.get(table.data, i) do
-           nil -> {[nil], state}
-           v -> {[i, v], state}
+         case Executor.table_index(table_ref, i, state) do
+           {nil, state} -> {[nil], state}
+           {v, state} -> {[i, v], state}
          end
        end}
 

--- a/lib/lua/vm/stdlib/debug.ex
+++ b/lib/lua/vm/stdlib/debug.ex
@@ -23,6 +23,7 @@ defmodule Lua.VM.Stdlib.Debug do
 
   @behaviour Lua.VM.Stdlib.Library
 
+  alias Lua.VM.Executor
   alias Lua.VM.State
   alias Lua.VM.Value
 
@@ -76,13 +77,7 @@ defmodule Lua.VM.Stdlib.Debug do
           }
 
         n when is_integer(n) ->
-          # Stack level - return info about calling function
-          %{
-            "source" => "=?",
-            "currentline" => -1,
-            "what" => "main",
-            "name" => nil
-          }
+          stack_info_for_level(n, state)
 
         _ ->
           %{
@@ -108,6 +103,46 @@ defmodule Lua.VM.Stdlib.Debug do
 
     {[info_tref], state}
   end
+
+  # Per Lua 5.3, debug.getinfo(level) reports info about the function `level`
+  # frames up the stack. Level 1 is the function that called `getinfo` (the
+  # currently-running Lua chunk from the native callback's perspective).
+  # Higher levels walk the saved call frames.
+  defp stack_info_for_level(level, state) do
+    case stack_position_for_level(level, state) do
+      {line, source} ->
+        %{
+          "source" => source || "=?",
+          "currentline" => line || -1,
+          "what" => "Lua",
+          "name" => nil
+        }
+
+      nil ->
+        %{
+          "source" => "=?",
+          "currentline" => -1,
+          "what" => "main",
+          "name" => nil
+        }
+    end
+  end
+
+  defp stack_position_for_level(1, _state) do
+    case Executor.current_position() do
+      {nil, nil} -> nil
+      pos -> pos
+    end
+  end
+
+  defp stack_position_for_level(level, state) when level > 1 do
+    case Enum.at(state.call_stack, level - 2) do
+      nil -> nil
+      frame -> {Map.get(frame, :line), Map.get(frame, :source)}
+    end
+  end
+
+  defp stack_position_for_level(_, _state), do: nil
 
   # debug.traceback([message [, level]]) — returns traceback string
   defp debug_traceback(args, state) do

--- a/lib/lua/vm/stdlib/math.ex
+++ b/lib/lua/vm/stdlib/math.ex
@@ -34,6 +34,8 @@ defmodule Lua.VM.Stdlib.Math do
 
   @behaviour Lua.VM.Stdlib.Library
 
+  import Bitwise
+
   alias Lua.VM.ArgumentError
   alias Lua.VM.State
   alias Lua.VM.Stdlib.Util
@@ -56,6 +58,7 @@ defmodule Lua.VM.Stdlib.Math do
       "log" => {:native_func, &math_log/2},
       "max" => {:native_func, &math_max/2},
       "min" => {:native_func, &math_min/2},
+      "modf" => {:native_func, &math_modf/2},
       "pi" => :math.pi(),
       "random" => {:native_func, &math_random/2},
       "randomseed" => {:native_func, &math_randomseed/2},
@@ -64,6 +67,7 @@ defmodule Lua.VM.Stdlib.Math do
       "tan" => {:native_func, &math_tan/2},
       "tointeger" => {:native_func, &math_tointeger/2},
       "type" => {:native_func, &math_type/2},
+      "ult" => {:native_func, &math_ult/2},
       "huge" => 1.0e308,
       "maxinteger" => 9_223_372_036_854_775_807,
       "mininteger" => -9_223_372_036_854_775_808
@@ -515,5 +519,70 @@ defmodule Lua.VM.Stdlib.Math do
 
   defp math_type([], _state) do
     raise ArgumentError.value_expected("math.type", 1)
+  end
+
+  # math.modf(x) — returns the integer and fractional parts of x.
+  # Per Lua 5.3 §6.7: integer input returns itself plus 0.0 (float);
+  # float input returns floor/ceil-toward-zero as a float plus the
+  # fractional remainder.
+  defp math_modf([:nan | _], state), do: {[:nan, :nan], state}
+
+  defp math_modf([x | _], state) when is_integer(x) do
+    {[x, 0.0], state}
+  end
+
+  defp math_modf([x | _], state) when is_float(x) do
+    cond do
+      x == 0.0 ->
+        {[x, x], state}
+
+      x > 0.0 ->
+        i = Float.floor(x)
+        {[i, x - i], state}
+
+      true ->
+        i = Float.ceil(x)
+        {[i, x - i], state}
+    end
+  end
+
+  defp math_modf([x | _], _state) do
+    raise ArgumentError,
+      function_name: "math.modf",
+      arg_num: 1,
+      expected: "number",
+      got: Util.typeof(x)
+  end
+
+  defp math_modf([], _state) do
+    raise ArgumentError.value_expected("math.modf", 1)
+  end
+
+  # math.ult(a, b) — unsigned 64-bit comparison of two integers.
+  defp math_ult([a, b | _], state) when is_integer(a) and is_integer(b) do
+    mask = 0xFFFFFFFFFFFFFFFF
+    ua = a &&& mask
+    ub = b &&& mask
+    {[ua < ub], state}
+  end
+
+  defp math_ult([a, _ | _], _state) when not is_integer(a) do
+    raise ArgumentError,
+      function_name: "math.ult",
+      arg_num: 1,
+      expected: "integer",
+      got: Util.typeof(a)
+  end
+
+  defp math_ult([_, b | _], _state) do
+    raise ArgumentError,
+      function_name: "math.ult",
+      arg_num: 2,
+      expected: "integer",
+      got: Util.typeof(b)
+  end
+
+  defp math_ult(_args, _state) do
+    raise ArgumentError.value_expected("math.ult", 1)
   end
 end

--- a/lib/lua/vm/stdlib/pattern.ex
+++ b/lib/lua/vm/stdlib/pattern.ex
@@ -18,18 +18,34 @@ defmodule Lua.VM.Stdlib.Pattern do
   Returns `{start, stop, captures}` or `:nomatch`.
   """
   def find(subject, pattern, init \\ 1) do
-    {anchored, pattern_elems} = compile(pattern)
-    start_pos = max(init - 1, 0)
+    len = byte_size(subject)
 
-    if anchored do
-      case match_pattern(subject, start_pos, pattern_elems, subject) do
-        {:match, end_pos, captures} -> {start_pos + 1, end_pos, captures}
-        :nomatch -> :nomatch
-      end
-    else
-      find_from(subject, start_pos, byte_size(subject), pattern_elems)
+    case normalize_init(init, len) do
+      :out_of_range ->
+        :nomatch
+
+      start_pos ->
+        {anchored, pattern_elems} = compile(pattern)
+
+        if anchored do
+          case match_pattern(subject, start_pos, pattern_elems, subject) do
+            {:match, end_pos, captures} -> {start_pos + 1, end_pos, captures}
+            :nomatch -> :nomatch
+          end
+        else
+          find_from(subject, start_pos, len, pattern_elems)
+        end
     end
   end
+
+  # Per Lua 5.3 §6.4, init follows the same indexing rules as string.sub:
+  # negative values count from the end; out-of-range low values clamp to 1.
+  # A positive init beyond `len + 1` yields no match — even the empty
+  # pattern doesn't match past that point.
+  defp normalize_init(init, len) when init > len + 1, do: :out_of_range
+  defp normalize_init(init, _len) when init > 0, do: init - 1
+  defp normalize_init(init, len) when init < 0, do: max(len + init, 0)
+  defp normalize_init(_init, _len), do: 0
 
   defp find_from(_subject, pos, len, _pattern) when pos > len, do: :nomatch
 

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -251,18 +251,18 @@ defmodule Lua.VM.Stdlib.String do
         expected: "number"
     end
 
+    # Per Lua 5.3 §6.4.2, string.byte semantics: posi = max(i, 1) (after
+    # normalising negative indices); posj = min(j, #s). If posj < posi the
+    # call returns no bytes.
     len = byte_size(str)
-    start_idx = normalize_index(i, len)
-    end_idx = normalize_index(j, len)
+    posi = if i < 0, do: max(len + i + 1, 1), else: max(i, 1)
+    posj = if j < 0, do: len + j + 1, else: min(j, len)
 
     bytes =
-      if start_idx > end_idx or start_idx >= len do
+      if posj < posi or posi > len or posj < 1 do
         []
       else
-        start_byte = max(0, start_idx)
-        end_byte = min(len - 1, end_idx)
-
-        Enum.map(start_byte..end_byte, fn idx -> :binary.at(str, idx) end)
+        Enum.map(posi..posj//1, fn idx -> :binary.at(str, idx - 1) end)
       end
 
     {bytes, state}
@@ -679,16 +679,27 @@ defmodule Lua.VM.Stdlib.String do
 
     init = if is_number(init), do: trunc(init), else: 1
 
-    if plain == true do
+    if plain != nil and plain != false do
       # Plain substring search
-      search_pos = max(init - 1, 0)
+      len = byte_size(s)
 
-      case :binary.match(s, pattern, scope: {search_pos, byte_size(s) - search_pos}) do
-        {start, len} ->
-          {[start + 1, start + len], state}
+      if init > len + 1 do
+        {[nil], state}
+      else
+        search_pos =
+          cond do
+            init > 0 -> init - 1
+            init < 0 -> max(len + init, 0)
+            true -> 0
+          end
 
-        :nomatch ->
-          {[nil], state}
+        case :binary.match(s, pattern, scope: {search_pos, len - search_pos}) do
+          {start, found_len} ->
+            {[start + 1, start + found_len], state}
+
+          :nomatch ->
+            {[nil], state}
+        end
       end
     else
       case Pattern.find(s, pattern, init) do
@@ -826,9 +837,6 @@ defmodule Lua.VM.Stdlib.String do
   end
 
   # Helper: convert Lua 1-based index to 0-based, handle negative indices
-  defp normalize_index(idx, _len) when idx > 0, do: idx - 1
-  defp normalize_index(idx, len) when idx < 0, do: len + idx
-  defp normalize_index(0, _len), do: 0
 
   # PUC-Lua's posrelat: keep 1-based positions, translate negatives.
   # Negative indices are relative to len+1 (so -1 = len). If a negative is

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -83,6 +83,10 @@ defmodule Lua.VM.Stdlib.Table do
     {[], state}
   end
 
+  defp table_insert(args, _state) when length(args) > 3 do
+    raise Lua.VM.RuntimeError, value: "wrong number of arguments to 'insert'"
+  end
+
   defp table_insert([tref | _], _state) do
     raise ArgumentError,
       function_name: "table.insert",

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -234,13 +234,50 @@ defmodule Lua.LexerTest do
       #
       #   "'\]])
       #
-      # The long string body is a literal newline, blank line, then "'\, then
-      # ]] closes. The trailing ]) is a literal `]` followed by `)` that closes
-      # the assert call. Inside a long string, `\` has no escape meaning.
+      # Per Lua 5.3 §3.1, the opening `[[` is immediately followed by a
+      # newline, which is dropped. The remaining body is `\n"'\`, matching
+      # the short string `'\n\"\'\\'` (4 bytes).
       assert {:ok, [{:string, body, _}, {:delimiter, :rparen, _}, {:eof, _}]} =
                Lexer.tokenize("[[\n\n\"'\\]])")
 
-      assert body == "\n\n\"'\\"
+      assert body == "\n\"'\\"
+    end
+
+    test "long strings drop a single leading newline" do
+      # §3.1: "when the opening long bracket is immediately followed by a
+      # newline, the newline is not included in the string."
+      assert {:ok, [{:string, "alo\nalo\n\n", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\nalo\nalo\n\n]]")
+    end
+
+    test "long strings drop a single leading carriage return" do
+      assert {:ok, [{:string, "alo", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\ralo]]")
+    end
+
+    test "long strings drop leading CRLF as one line break" do
+      assert {:ok, [{:string, "alo", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\r\nalo]]")
+    end
+
+    test "long strings drop leading LFCR as one line break" do
+      assert {:ok, [{:string, "alo", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\n\ralo]]")
+    end
+
+    test "long strings normalize \\r to \\n in body" do
+      assert {:ok, [{:string, "alo\nalo\n\n", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\nalo\ralo\n\n]]")
+    end
+
+    test "long strings normalize \\r\\n to a single \\n in body" do
+      assert {:ok, [{:string, "alo\nalo\n", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\nalo\ralo\r\n]]")
+    end
+
+    test "long strings normalize \\n\\r to a single \\n in body" do
+      assert {:ok, [{:string, "alo\nalo\n", _}, {:eof, _}]} =
+               Lexer.tokenize("[[\ralo\n\ralo\r\n]]")
     end
   end
 

--- a/test/lua/vm/metatable_test.exs
+++ b/test/lua/vm/metatable_test.exs
@@ -294,7 +294,7 @@ defmodule Lua.VM.MetatableTest do
       assert {:ok, [true, false], _state} = VM.execute(proto, state)
     end
 
-    test "__eq only triggers if both have same metamethod" do
+    test "__eq is called when only the first operand defines it (§3.4.4)" do
       code = """
       local a = {value = 10}
       local b = {value = 10}
@@ -317,8 +317,35 @@ defmodule Lua.VM.MetatableTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = Stdlib.install(State.new())
 
-      # Different metamethods, so falls back to reference equality (false)
-      assert {:ok, [false], _state} = VM.execute(proto, state)
+      # Lua 5.3 dropped the same-metamethod requirement from Lua 5.1.
+      assert {:ok, [true], _state} = VM.execute(proto, state)
+    end
+
+    test "__eq is called when only the first operand has a metatable" do
+      code = """
+      local a = setmetatable({}, {__eq = function() return true end})
+      local b = {}
+      return a == b
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [true], _state} = VM.execute(proto, state)
+    end
+
+    test "__eq is not consulted for table-vs-non-table comparisons" do
+      code = """
+      local a = setmetatable({}, {__eq = function() return true end})
+      return a == 5, a == "x", a == nil, a == true
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      state = Stdlib.install(State.new())
+
+      assert {:ok, [false, false, false, false], _state} = VM.execute(proto, state)
     end
 
     test "~= dispatches through __eq metamethod" do
@@ -386,7 +413,7 @@ defmodule Lua.VM.MetatableTest do
                VM.execute(proto, state)
     end
 
-    test "~= falls back to raw inequality when metamethods differ" do
+    test "~= dispatches through __eq even when metamethods differ (§3.4.4)" do
       code = """
       local a = {value = 10}
       local b = {value = 10}
@@ -394,8 +421,6 @@ defmodule Lua.VM.MetatableTest do
       local mt2 = { __eq = function() return true end }
       setmetatable(a, mt1)
       setmetatable(b, mt2)
-      -- Different __eq metamethods → fall back to raw equality.
-      -- Two distinct tables are raw-unequal, so ~= is true.
       return a ~= b
       """
 
@@ -403,7 +428,8 @@ defmodule Lua.VM.MetatableTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = Stdlib.install(State.new())
 
-      assert {:ok, [true], _state} = VM.execute(proto, state)
+      # The first operand's __eq returns true, so ~= is false.
+      assert {:ok, [false], _state} = VM.execute(proto, state)
     end
 
     test "__lt metamethod" do

--- a/test/lua/vm/nextvar_semantics_test.exs
+++ b/test/lua/vm/nextvar_semantics_test.exs
@@ -149,4 +149,20 @@ defmodule Lua.VM.NextvarSemanticsTest do
       end
     end
   end
+
+  describe "ipairs honours __index (§6.1)" do
+    test "ipairs walks values produced by __index until the first nil" do
+      code = """
+      local a = {n=3}
+      setmetatable(a, {__index = function (t,k)
+        if k <= t.n then return k * 10 end
+      end})
+      local seen = {}
+      for k, v in ipairs(a) do seen[k] = v end
+      return seen[1], seen[2], seen[3], seen[4]
+      """
+
+      assert run!(code) == [10, 20, 30, nil]
+    end
+  end
 end

--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -41,7 +41,13 @@
     }
   ],
   "calls.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :semantic,
+      reason:
+        "FuncDecl target name resolved at codegen against post-block scope; print does not call user-overridden tostring",
+      issue: nil
+    }
   ],
   "closure.lua" => [
     %{
@@ -52,7 +58,12 @@
     }
   ],
   "constructs.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :semantic,
+      reason: "parenthesized call/vararg does not adjust to a single value (Lua 5.3 §3.4)",
+      issue: nil
+    }
   ],
   "coroutine.lua" => [
     %{lines: :all, category: :unimplemented, reason: "coroutines not implemented", issue: nil}
@@ -61,48 +72,110 @@
     %{lines: :all, category: :unimplemented, reason: "full debug library not implemented", issue: nil}
   ],
   "errors.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :stdlib,
+      reason: "checkmessage/checksyntax/checkerr helpers expect PUC-Lua error message formats throughout",
+      issue: nil
+    }
   ],
   "events.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: 403..432,
+      category: :unimplemented,
+      reason: "debug.setmetatable on primitive types (number, boolean, nil) not supported",
+      issue: nil
+    }
   ],
   "gc.lua" => [
     %{lines: :all, category: :unimplemented, reason: "garbage collection / weak tables not implemented", issue: nil}
   ],
   "goto.lua" => [
     %{
-      lines: :all,
-      category: :unimplemented,
-      reason: "backward goto / goto-out-of-conditional not implemented",
+      lines: 12..40,
+      category: :stdlib,
+      reason: "load() parse-error messages do not match PUC-Lua 'label/local' format",
       issue: nil
     }
   ],
   "literals.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: 40..47,
+      category: :semantic,
+      reason: "debug.getinfo(1).currentline reports per-statement line, not per-call-site",
+      issue: nil
+    },
+    %{
+      lines: 72..112,
+      category: :stdlib,
+      reason: "load() parse-error messages do not match PUC-Lua 'near ...' format",
+      issue: nil
+    },
+    %{
+      lines: 219..223,
+      category: :semantic,
+      reason: "debug.getinfo(1).currentline reports per-statement line, not per-call-site",
+      issue: nil
+    },
+    %{
+      lines: 247..261,
+      category: :unimplemented,
+      reason: "coroutine.wrap / yield not implemented",
+      issue: nil
+    },
+    %{
+      lines: 264..288,
+      category: :unimplemented,
+      reason: "os.setlocale not implemented; locale-dependent number parsing",
+      issue: nil
+    },
+    %{
+      lines: 297..302,
+      category: :stdlib,
+      reason: "load() parse-error format for unterminated strings differs from PUC-Lua",
+      issue: nil
+    }
   ],
   "locals.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :unimplemented,
+      reason: "debug.getupvalue not implemented; _ENV introspection via debug library missing",
+      issue: nil
+    }
   ],
   "math.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
-  ],
-  "nextvar.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :stdlib,
+      reason: "math.huge is finite (1.0e308) and many checkerror tests expect PUC-Lua-specific error messages",
+      issue: nil
+    }
   ],
   "pm.lua" => [
     %{lines: :all, category: :unimplemented, reason: "pending initial triage (pattern engine work in A9)", issue: nil}
   ],
   "sort.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :stdlib,
+      reason: "checkerror() expects PUC-Lua error message formats; os.clock not implemented",
+      issue: nil
+    }
   ],
   "strings.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "pending initial triage", issue: nil}
+    %{
+      lines: :all,
+      category: :stdlib,
+      reason: "string.rep with large counts and checkerror format mismatches; pending finer triage",
+      issue: nil
+    }
   ],
   "utf8.lua" => [
     %{
       lines: :all,
       category: :unimplemented,
-      reason: "pending initial triage (suspected timeout per ROADMAP A10)",
+      reason: "utf8 standard library not implemented",
       issue: nil
     }
   ]


### PR DESCRIPTION
## Summary

Triage of the Lua 5.3 official suite, fixing concrete gaps and promoting four files out of the broad `:all` skip:

- **`nextvar.lua`** — fully passing (was `:all`)
- **`events.lua`** — runs with one targeted skip range (was `:all`)
- **`goto.lua`** — runs with one targeted skip range (was `:all`)
- **`literals.lua`** — runs with six targeted skip ranges (was `:all`)

Remaining `:all` files now carry specific reasons in `test/lua53_skips.exs` (e.g. `checkerror` format mismatches, missing `utf8` library, coroutines unimplemented) instead of "pending initial triage".

## Behavioural fixes

- **lexer**: long strings drop a leading newline and normalise `\r`/`\r\n`/`\n\r` to `\n` per §3.1.
- **parser**: reject non-lvalue assignment targets (e.g. `0 = 1`) with a syntax error instead of crashing codegen.
- **scope**: `if`/`while`/`repeat`/`for` bodies are now their own lexical scopes — locals declared inside no longer leak past the block (§3.3.4).
- **executor `__eq`**: Lua 5.3 selection rules — first operand's metamethod, falling back to the second's; the same-function constraint from Lua 5.1 is dropped; only consulted for table-vs-table.
- **executor numeric**: `0^(-n)` yields the inf sentinel; NaN comparisons return `false` per IEEE 754.
- **`table.insert`**: raise "wrong number of arguments" with more than 3 args.
- **`ipairs`**: route lookups through `__index` so user metamethods drive iteration (§6.1).
- **`type()`**: raise "value expected" with no args (was returning `"nil"`).
- **`debug.getinfo(N)`**: return the calling frame's line and source via the executor's `current_position` + `call_stack`.
- **`math`**: add `math.modf` (preserves integer parts) and `math.ult`.
- **`string.find`**: handle negative `init`, `init > #s + 1`, and truthy (non-`true`) plain flag.
- **`string.byte`**: PUC-Lua `posrelat` semantics for `i` and `j`.

## Test plan

- [x] `mix test` — 1914 passing, 0 failures, 26 skipped (was 1907 passing before this PR)
- [x] `mix compile --warnings-as-errors`
- [x] `mix format` (no diff)
- [x] `mix lua.suite --status` shows 4 files promoted out of `:all`
- [x] New unit tests in `test/lua/lexer_test.exs`, `test/lua/vm/metatable_test.exs`, `test/lua/vm/nextvar_semantics_test.exs` pin each fix