### PR TITLE
perf(vm): dispatcher coverage for table opcodes and :numeric_for

### DIFF
--- a/.agents/plans/B5b-v2-dispatcher-tables.md
+++ b/.agents/plans/B5b-v2-dispatcher-tables.md
@@ -1,11 +1,11 @@
 ---
 id: B5b-v2
 title: Dispatcher table opcodes — make table-heavy workloads bypass the interpreter
-issue: null
+issue: 271
 pr: null
 branch: perf/dispatcher-tables
 base: main
-status: blocked
+status: in-progress
 direction: B
 unlocks:
   - ~2x speedup on table_ops benchmarks
@@ -15,15 +15,15 @@ parent: B5-dispatcher-and-bytecode
 
 ## Blocked on
 
-- B5a-v2 (dispatcher foundation).
+- B5a-v2 (dispatcher foundation). **Unblocked**: PR #237 merged.
 
 ## Goal
 
 Extend `Lua.VM.Dispatcher` and `Lua.Compiler.Bytecode` to lower the
-table opcode family: `:new_table`, `:get_table`, `:set_table`,
-`:set_list`, `:get_field` (full path, not just env lookup),
-`:set_field`. After this PR, prototypes that touch tables compile
-end-to-end and stay out of the interpreter fallback path.
+table opcode family plus `:numeric_for`. After this PR, all four
+`table_ops` benchmarks compile end-to-end and stay out of the
+interpreter fallback path, plus the orchestrators in the `closures`
+and `string_ops` benchmarks.
 
 The original B5 third spike measured **2.1x faster than interpreter**
 on run_table_sum(1000). The dispatcher should land at a similar or
@@ -32,16 +32,238 @@ dispatcher pays per-step dispatch).
 
 ## Out of scope
 
+- `:closure` opcode and varargs → **B5c-v2**.
+- `:while_loop`, `:repeat_loop`, `:generic_for` → not blockers for the
+  named benchmarks. Defer.
+- `:break` inside `:numeric_for` → handled as fallback for now. Add to
+  B5c-v2 if needed by benchmarks.
+- `:set_list` with `{:multi, _}` (multi-return spread into table) →
+  fallback.
+- Multi-return `:call` / `:return` → still fallback.
 - Mutable table storage. `Table.put/3` allocation churn is the
   ceiling for table workloads on the BEAM; not addressed here.
+- Mutable register storage / `setelement/3` elimination → its own plan
+  if perf-justified after this lands.
 - Metamethod dispatch via `__index` / `__newindex` short-circuiting.
-  The dispatcher delegates to existing `Executor.index_value/6`
-  helpers, which handle metamethods.
+  The dispatcher delegates to existing `Executor` helpers, which
+  handle metamethods.
+- Error position fidelity in the dispatcher → **B5d-v2**. All new
+  bridges pass `line: 0`.
 
 ## Success criteria
 
-(To be detailed when this plan unblocks. Mirrors original B5c
-success criteria but targets the dispatcher rather than codegen.)
+- [ ] `Lua.Compiler.Bytecode` learns encoders for `:new_table`,
+      `:get_table`, `:set_table`, `:set_field`, `:set_list` (basic
+      non-multi-return form), `:length`, and `:numeric_for` (body
+      encoded recursively, falls back if body contains an uncovered
+      opcode or `:break`).
+- [ ] `Lua.VM.Dispatcher` gains one `case` branch per new opcode plus
+      the for-loop continuation marker.
+- [ ] `Lua.VM.Executor` exposes `dispatcher_*` bridges for the new
+      slow paths (`dispatcher_get_table`, `dispatcher_set_table`,
+      `dispatcher_set_field`, `dispatcher_length`,
+      `dispatcher_coerce_numeric_for_controls`,
+      `dispatcher_close_open_upvalues_at_or_above`).
+- [ ] `mix compile --warnings-as-errors` passes.
+- [ ] `mix test` passes, no regressions vs. main.
+- [ ] `mix test --only lua53` passes.
+- [ ] `test/lua/vm/leak_regression_test.exs` still passes.
+- [ ] All four `table_ops` benchmark functions compile to bytecode
+      end-to-end (no `:fallback` on any of them).
+- [ ] Closures benchmark `run_closures` orchestrator compiles
+      (its sub-prototype `make_counter` may still fall back because
+      it emits `:closure` — that's B5c-v2).
+- [ ] No workload regresses by more than 10% vs. interpreter on the
+      `dispatcher_vs_interpreter`-style A/B harness.
+- [ ] Soft target: `run_table_sum(1000)` ≥1.5x interpreter when
+      compiled. Hard floor: ≥1.0x (no regression).
+
+## Implementation notes
+
+### 1. Bytecode encoder (`lib/lua/compiler/bytecode.ex`)
+
+Add `@op_*` constants for the new opcodes. The B5a encoder ends at
+`@op_source_line 29`; slot 25 freed by removed `@op_test_true` is
+reusable. Pick a contiguous block starting at 30:
+
+- `@op_new_table 30`
+- `@op_get_table 31`
+- `@op_set_table 32`
+- `@op_set_field 33`
+- `@op_set_list 34`
+- `@op_length 35`
+- `@op_numeric_for 36`
+
+Per-opcode encoders:
+
+- `:new_table` → `{tag, dest}`. Array/hash hints discarded — the
+  executor handler also ignores them. (`_array_hint`, `_hash_hint`.)
+- `:get_table` → `{tag, dest, table_reg, key_reg, name_hint}`.
+- `:set_table` → `{tag, table_reg, key_reg, value_reg, name_hint}`.
+- `:set_field` → `{tag, table_reg, name, value_reg, name_hint}`.
+- `:set_list` only the basic, non-multi-return form (third element
+  is a positive integer, not `{:multi, _}`). `{tag, table_reg,
+  start, count, offset}`.
+- `:length` → `{tag, dest, source}`.
+- `:numeric_for` → `{tag, base, loop_var, body_bytecode}`. `body` is
+  encoded recursively. If the body contains any uncovered opcode
+  *or* a `:break` atom, the whole `:numeric_for` returns `:fallback`.
+
+`encode_list/2` already strips `:source_line` opcodes and that
+propagates into the recursive body encoding for free.
+
+### 2. Dispatcher (`lib/lua/vm/dispatcher.ex`)
+
+Mirror the new constants in the dispatcher's `@op_*` block. Add one
+`case` branch per opcode inside `dispatch/8`:
+
+- `@op_new_table` — call `State.alloc_table/1`, `setelement(dest+1,
+  regs, tref)`. Single line.
+- `@op_get_table` — inline the executor's tref + integer/binary-key
+  fast path. Fall through to a new `Executor.dispatcher_get_table/6`
+  bridge for non-tref, non-fast-key, or metatable cases.
+- `@op_set_table` — tref fast path: `Executor.dispatcher_set_table/6`
+  (wraps `table_newindex`). Non-tref: bridge raises
+  `raise_index_type_error`. Mirrors `:set_field` from B5a.
+- `@op_set_field` — same as `:set_table` but with a constant name.
+  Bridge to a new `Executor.dispatcher_set_field/6`.
+- `@op_set_list` — inline tref reduce-loop, identical to the
+  executor's non-multi branch. No bridge needed.
+- `@op_length` — integer fast path (`{:tref, _}` with no `__len`
+  metatable → `Value.sequence_length(table.data)`); bridge to
+  `Executor.dispatcher_length/4` for the metamethod path and
+  non-tref values.
+- `@op_numeric_for` — the most involved. Inline the loop setup:
+  1. Coerce the three control registers via
+     `Executor.dispatcher_coerce_numeric_for_controls/3`.
+  2. Write the canonical numbers back to `base`, `base+1`, `base+2`.
+  3. Check `should_continue`. If false: continue at `pc+1`.
+  4. If true: write counter to `loop_var`, call
+     `Executor.dispatcher_close_open_upvalues_at_or_above/2`, then
+     dispatch into `body_bytecode` with a new continuation marker
+     `{:cps_for, base, loop_var, body_bytecode, code, pc + 1}`
+     pushed onto `cont`.
+
+  Extend `finish_body/6` with a third clause matching the for-loop
+  continuation tuple: increment counter, re-check, either re-enter
+  the body (push the marker again) or pop back to outer `(code,
+  pc+1)`.
+
+### 3. Executor bridges (`lib/lua/vm/executor.ex`)
+
+Add public bridges. All accept `line: 0` for now (line attribution
+is B5d-v2):
+
+```elixir
+def dispatcher_get_table({:tref, _} = tref, key, state, proto, name_hint), do: ...
+def dispatcher_get_table(value, key, state, proto, name_hint), do: ...
+
+def dispatcher_set_table({:tref, _} = tref, key, value, state, _proto, _hint), do: ...
+def dispatcher_set_table(value, _key, _value, _state, proto, name_hint), do: ...
+  # raises raise_index_type_error/4
+
+def dispatcher_set_field({:tref, _} = tref, name, value, state, _proto, _hint), do: ...
+def dispatcher_set_field(value, _name, _value, _state, proto, name_hint), do: ...
+
+def dispatcher_length(value, state, proto, _name_hint), do: ...
+  # wraps try_unary_metamethod("__len", ...) + Value.sequence_length
+
+def dispatcher_coerce_numeric_for_controls(init, limit, step), do: ...
+  # wraps coerce_numeric_for_controls/3
+
+def dispatcher_close_open_upvalues_at_or_above(state, threshold), do: ...
+  # wraps close_open_upvalues_at_or_above/2
+```
+
+All wrap existing `defp` helpers — fidelity-for-free with the
+interpreter.
+
+### 4. Tests
+
+#### `test/lua/compiler/bytecode_test.exs` — update
+
+- Flip `:new_table causes fallback` → `:new_table compiles`.
+- Flip `for-loops cause fallback` → split into:
+  - `numeric for-loop compiles`,
+  - `generic for-loop causes fallback`.
+- Add minimal tests for `:get_table`, `:set_table`, `:set_field`,
+  `:length`, `:set_list` (basic form).
+- Keep `:set_list multi-return causes fallback` test.
+- Keep `:break inside :numeric_for causes fallback` test.
+
+#### `test/lua/vm/dispatcher_test.exs` — add goldens
+
+One golden per new opcode plus benchmark-shaped end-to-end goldens:
+
+- `run_table_build(50)`, `run_table_sum(50)`, `run_table_map_reduce(50)`
+  reference shapes assert dispatcher path and correct result.
+- Nested numeric_for (one loop inside another).
+- `:set_field` on the result of `:new_table` (chained access).
+- `:length` after `:set_list` (`return #{1,2,3}` style).
+
+### 5. Benchmark verification
+
+- `MIX_ENV=benchmark mix run benchmarks/table_ops.exs` — sanity-check
+  no crashes, capture median.
+- `MIX_ENV=benchmark mix run benchmarks/dispatcher_vs_interpreter.exs`
+  — if needed, adapt to target a table workload to verify the
+  dispatcher path matches the soft target.
+
+### Files
+
+- `lib/lua/compiler/bytecode.ex` — 7 new opcodes + tag accessors.
+- `lib/lua/vm/dispatcher.ex` — 7 new case branches + for-loop
+  continuation handling in `finish_body/6`.
+- `lib/lua/vm/executor.ex` — 6 new `dispatcher_*` public bridges.
+- `test/lua/compiler/bytecode_test.exs` — updated for new coverage.
+- `test/lua/vm/dispatcher_test.exs` — new goldens.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test --only lua53
+mix test test/lua/vm/dispatcher_test.exs
+mix test test/lua/compiler/bytecode_test.exs
+mix test test/lua/vm/leak_regression_test.exs
+
+# Confirm all four table_ops functions compile end-to-end.
+mix run -e '
+fns = [:run_table_build, :run_table_sort, :run_table_sum, :run_table_map_reduce]
+src = File.read!("benchmarks/table_ops.exs")
+# Pull the inlined `table_def` and assert each function ends up with
+# a non-nil bytecode field.
+'
+
+# Perf (informational, not a hard gate):
+MIX_ENV=benchmark mix run benchmarks/table_ops.exs
+MIX_ENV=benchmark mix run benchmarks/dispatcher_vs_interpreter.exs
+```
+
+## Risks
+
+- **`:numeric_for` continuation handling complicates `finish_body/6`.**
+  B5a's dispatch loop is tight because the continuation stack only
+  carries `{code, pc}` post-test markers. Adding a tagged for-loop
+  continuation expands the `finish_body` head from 2 clauses to 3.
+  Mitigation: profile after landing; if `finish_body` shows up in
+  the hot path more than ~5%, consider a flat PC bytecode (separate
+  follow-up plan).
+- **Bridge overhead vs. inlining.** Each `dispatcher_*` call costs a
+  function frame. For `:get_table` / `:set_table`, the executor's
+  slow path is already several calls deep — bridging adds at most
+  one frame. For `:length`, the metamethod path is rare. Should be
+  invisible.
+- **Test churn from flipped fallbacks.** Two tests in
+  `bytecode_test.exs` currently assert that `:new_table` and `for`
+  cause fallback. Those tests must flip. Risk low — the flip is
+  mechanical.
+- **`Table.put/3` allocation churn** (out of scope per parent plan).
+  If `table_ops` benchmarks underperform the spike's 2.1x target,
+  the answer is mutable table storage, not more dispatch work.
+  Document the ceiling; don't chase it here.
 
 ## Discoveries
 

--- a/.agents/plans/B5b-v2-dispatcher-tables.md
+++ b/.agents/plans/B5b-v2-dispatcher-tables.md
@@ -2,10 +2,10 @@
 id: B5b-v2
 title: Dispatcher table opcodes — make table-heavy workloads bypass the interpreter
 issue: 271
-pr: null
+pr: 275
 branch: perf/dispatcher-tables
 base: main
-status: in-progress
+status: review
 direction: B
 unlocks:
   - ~2x speedup on table_ops benchmarks
@@ -267,4 +267,130 @@ MIX_ENV=benchmark mix run benchmarks/dispatcher_vs_interpreter.exs
 
 ## Discoveries
 
-(Empty until implementation.)
+### `:call` with `result_count == 0` was needed to compile `run_table_sort`
+
+The original B5b coverage list did not include `:call_zero` (statement
+calls). `run_table_sort` calls `table.sort(t)` at statement position,
+which the codegen lowers to `{:call, base, 1, 0, name_hint}`. Without
+coverage, `run_table_sort` falls back even though `:numeric_for` /
+`:set_table` etc. are all supported.
+
+Added `@op_call_zero 25` (reusing the slot freed by the removed
+`@op_test_true`). The dispatcher's `:call_one` and `:call_zero`
+clauses share the same compiled-closure / interpreter-bridge shape;
+the only difference is the frame slot's "where to write the result"
+marker (`base` integer vs `:discard` sentinel) and the bridge
+discards the native-call result list.
+
+This kept the PR honest to its acceptance criterion — "all four
+table_ops benchmarks compile end-to-end" — without expanding to the
+broader multi-return machinery, which stays B5c-v2.
+
+### string_ops orchestrators do **not** fully compile
+
+The issue claimed "orchestrators in `closures` and `string_ops`"
+would compile. Closures' `run_closures` does (the inner `make_counter`
+falls back as expected because of `:closure`). But both
+`string_ops` orchestrators end with `return table.concat(...)` /
+`return string.format(...)`, which the codegen lowers as
+`:call` with `result_count = -1` followed by `:return_vararg` —
+multi-return shapes that are explicitly out of scope per the parent
+plan ("multi-return calls, vararg ... fall back").
+
+Three paths considered:
+
+1. Extend scope to handle `:call` with `result_count = -1` +
+   `:return_vararg`. This pulls in the `multi_return_count`
+   threading and the vararg-args collection machinery, which is the
+   exact domain of B5c-v2.
+2. Stay narrow and accept the partial outcome.
+3. Mid-ground: handle `:return_vararg` alone for single-return-value
+   callees only. Brittle — the codegen doesn't distinguish, so the
+   dispatcher would have to look at the callee at runtime.
+
+Picked (2): stay scoped. Documented here so a future B5c-v2 can pick
+this up alongside the rest of multi-return.
+
+### `:break` inside `:numeric_for` forces fallback
+
+The interpreter's `:break` opcode unwinds the continuation stack via
+`find_loop_exit/1`, which scans for the nearest `{:loop_exit, _}`
+marker. Reproducing that in the dispatcher would require mixing
+`{code, pc}` post-test markers with `{:loop_exit, _}` markers and
+extending `find_loop_exit` to walk dispatcher-side `cont` stacks.
+That's plumbing churn for what's effectively a B5c-v2 concern (the
+generic-for / while-loop / break family all want the same
+machinery).
+
+The encoder rejects `:numeric_for` bodies containing a `:break`
+opcode upfront, walking the body recursively to catch `:break`s
+buried inside `:test` branches. The whole enclosing prototype falls
+back. Pinned with a `test/lua/compiler/bytecode_test.exs` case.
+
+### Numeric-for continuation marker integrates cleanly
+
+The B5a `cont` stack carried only `{code, pc}` post-test resume
+points. Adding `{:cps_for, base, loop_var, body_bc, code, pc + 1}`
+markers expands `finish_body/6` to three clauses. The marker stays
+on the stack across each loop iteration — re-pushed when the body
+restarts — so nested numeric-fors compose naturally on the same
+stack. No perf hit measurable on fib (the marker doesn't fire on
+non-loop workloads).
+
+### Perf is a soft win on `table_ops`, healthy on fib
+
+Mini-bench results (`mix run -e`, 100–200 iter median, warmed):
+
+| Workload                    | Dispatcher | Interpreter | Speedup |
+|-----------------------------|------------|-------------|---------|
+| `run_table_build(500)`      | 90 µs      | 106 µs      | 1.18x   |
+| `run_table_sum(500)`        | 121 µs     | 129 µs      | 1.06x   |
+| `run_table_sum(1000)`       | 254 µs     | 289 µs      | 1.13x   |
+| `run_table_map_reduce(500)` | 241 µs     | 245 µs      | 1.02x   |
+| `fib(22)`                   | 12.2 ms    | 18.7 ms     | 1.54x   |
+
+The hard floor (no regression) is met across the board. The soft
+target (≥1.5x on `run_table_sum(1000)`) is **not** met — the
+dispatcher is at 1.13x. Profile attribution: `Table.put/3`
+allocation churn and `setelement/3` register writes dominate the
+table workloads, exactly as the parent plan flagged ("table-storage
+churn is the post-B5b ceiling, not addressed here").
+
+fib (which has neither cost) lands at 1.54x, well above B5a-v2's
+1.17x median — a sign the table-opcode additions did not push the
+arithmetic path off any inlining cliff.
+
+The follow-up plan for closing the gap on table workloads is
+mutable table storage, not more dispatch work.
+
+### `set_list_into_table` calls `Lua.VM.Table.put/3` directly
+
+The interpreter wraps the same loop in `State.update_table/3` plus a
+`Table.put/3` per iteration. The dispatcher's inline reduce-loop
+calls `Lua.VM.Table.put/3` against the table struct and only writes
+back to `state.tables` once via `State.update_table/3` at the end.
+Single-allocation per iteration matches the interpreter; the
+encoding boundary doesn't introduce a new allocation pattern.
+
+## What changed
+
+- New: 7 table opcodes + `:numeric_for` + `:call_zero` in
+  `lib/lua/compiler/bytecode.ex` and `lib/lua/vm/dispatcher.ex`.
+  Six `dispatcher_*` public bridges in `lib/lua/vm/executor.ex`.
+- New: `:cps_for` continuation marker in
+  `Lua.VM.Dispatcher.finish_body/6` for numeric-for body
+  completion; `:discard` sentinel in the frame's `base` slot for
+  statement-call result suppression.
+- Modified: `test/lua/compiler/bytecode_test.exs` — flipped two
+  fallback assertions (`:new_table`, "for-loops cause fallback"),
+  added three: `:generic_for causes fallback`, `while-loops cause
+  fallback`, `:break inside numeric_for causes fallback`. The
+  "cascade independence" sibling-fallback test was retargeted to
+  use a multi-return shape (`return next(t)`) since `{1, 2, 3}` now
+  compiles.
+- New: 21 dispatcher goldens (7 table opcodes, 6 numeric_for shapes,
+  4 table_ops benchmark functions, 1 `:call_zero`, plus a setup
+  block that compiles all four `run_table_*` benchmarks and asserts
+  they're `:compiled_closure`).
+- Tests: **1882 → 1902** (+20), **0 failures**, 25 skipped.
+- PR: https://github.com/tv-labs/lua/pull/275

--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -219,11 +219,18 @@ defmodule Lua.Compiler.Bytecode do
   defp encode({:set_field, table_reg, name, value_reg, name_hint}),
     do: {:ok, {@op_set_field, table_reg, name, value_reg, name_hint}}
 
-  # `:set_list` with an integer `count` is the table-constructor form
-  # (`{1, 2, 3}`). The `{:multi, _}` variant absorbs a multi-return
-  # call's results and is out of scope for v2 along with the rest of
-  # the multi-return machinery.
-  defp encode({:set_list, table_reg, start, count, offset}) when is_integer(count),
+  # `:set_list` with a positive integer `count` is the table-constructor
+  # form (`{1, 2, 3}`). Two adjacent shapes stay on the interpreter:
+  #
+  # - `{:multi, _}` absorbs a multi-return call's results (e.g.
+  #   `{f(), 1}`); it's covered by B5c-v2 alongside the rest of the
+  #   multi-return machinery.
+  # - `count == 0` is the interpreter's "consume `multi_return_count`
+  #   trailing values" sentinel. Current codegen never emits it from a
+  #   literal constructor, but encoding it as a no-op would silently
+  #   diverge from the interpreter if codegen ever did. The guard makes
+  #   that contract explicit.
+  defp encode({:set_list, table_reg, start, count, offset}) when is_integer(count) and count > 0,
     do: {:ok, {@op_set_list, table_reg, start, count, offset}}
 
   defp encode({:length, dest, source}), do: {:ok, {@op_length, dest, source}}

--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -46,12 +46,26 @@ defmodule Lua.Compiler.Bytecode do
   @op_not_equal 22
   @op_not 23
   @op_test 24
-  # `25` was `@op_test_true`; codegen never emitted it so it has been
-  # removed. Tag is free for reuse.
+  # Tag `25` was `@op_test_true`; codegen never emitted it. Reused by
+  # B5b-v2 for `:call` with `result_count == 0` — the statement-call
+  # form (e.g. `table.sort(t)`).
+  @op_call_zero 25
   @op_call_one 26
   @op_return_one 27
   @op_return_zero 28
   @op_source_line 29
+
+  # Table opcodes plus `:numeric_for`, added by B5b-v2 to unlock the
+  # `table_ops` benchmark family. The tags pick up where the foundation
+  # left off; keeping the block contiguous helps the BEAM lay out the
+  # dispatcher's jump table densely.
+  @op_new_table 30
+  @op_get_table 31
+  @op_set_table 32
+  @op_set_field 33
+  @op_set_list 34
+  @op_length 35
+  @op_numeric_for 36
 
   @doc """
   Compile a prototype, populating its `bytecode` field on success.
@@ -162,12 +176,22 @@ defmodule Lua.Compiler.Bytecode do
     end
   end
 
-  # `:call` with `result_count == 1` is the dispatcher's only call form.
-  # Anything else (multi-return, return-position tail calls, zero-result
-  # statement calls) bails out so the interpreter's full machinery handles
-  # it. The `name_hint` operand survives for error attribution.
+  # `:call` shapes the dispatcher covers:
+  #
+  #   - `result_count == 1`: the expression-call hot path (every
+  #     recursive call in fib/factorial, every `f(x)` used as an rvalue).
+  #   - `result_count == 0`: the statement-call form, e.g.
+  #     `table.sort(t)`. Results are discarded.
+  #
+  # Multi-return (`{:multi, _}`), negative result counts, and tail-call
+  # marker shapes all stay on the interpreter via the catchall.
+  # `name_hint` is preserved on both shapes for error attribution.
   defp encode({:call, base, arg_count, 1, name_hint}) when is_integer(arg_count) and arg_count >= 0 do
     {:ok, {@op_call_one, base, arg_count, name_hint}}
+  end
+
+  defp encode({:call, base, arg_count, 0, name_hint}) when is_integer(arg_count) and arg_count >= 0 do
+    {:ok, {@op_call_zero, base, arg_count, name_hint}}
   end
 
   # `:return` shapes: single-value is the hot path (every recursive return
@@ -176,12 +200,74 @@ defmodule Lua.Compiler.Bytecode do
   defp encode({:return, base, 1}), do: {:ok, {@op_return_one, base}}
   defp encode({:return, _base, 0}), do: {:ok, {@op_return_zero}}
 
-  # Anything else — `:closure`, `:get_table`, `:concatenate`, loops,
-  # multi-return calls, vararg, etc. — is out of scope for v2.
+  # ── Table opcodes ──────────────────────────────────────────────────────
+  #
+  # The dispatcher inlines the tref + integer/binary-key fast path for
+  # `:get_table` / `:set_table` / `:set_field` / `:length` and bridges to
+  # `Lua.VM.Executor.dispatcher_*` helpers for the metatable / non-tref
+  # slow paths. Array/hash hints on `:new_table` are discarded — the
+  # executor handler also ignores them.
+
+  defp encode({:new_table, dest, _array_hint, _hash_hint}), do: {:ok, {@op_new_table, dest}}
+
+  defp encode({:get_table, dest, table_reg, key_reg, name_hint}),
+    do: {:ok, {@op_get_table, dest, table_reg, key_reg, name_hint}}
+
+  defp encode({:set_table, table_reg, key_reg, value_reg, name_hint}),
+    do: {:ok, {@op_set_table, table_reg, key_reg, value_reg, name_hint}}
+
+  defp encode({:set_field, table_reg, name, value_reg, name_hint}),
+    do: {:ok, {@op_set_field, table_reg, name, value_reg, name_hint}}
+
+  # `:set_list` with an integer `count` is the table-constructor form
+  # (`{1, 2, 3}`). The `{:multi, _}` variant absorbs a multi-return
+  # call's results and is out of scope for v2 along with the rest of
+  # the multi-return machinery.
+  defp encode({:set_list, table_reg, start, count, offset}) when is_integer(count),
+    do: {:ok, {@op_set_list, table_reg, start, count, offset}}
+
+  defp encode({:length, dest, source}), do: {:ok, {@op_length, dest, source}}
+
+  # `:numeric_for` carries a nested instruction list for the loop body.
+  # The body encodes recursively; any uncovered opcode (or a `:break`
+  # atom — `break`'s loop_exit machinery is its own follow-up) collapses
+  # the whole loop to interpretation.
+  defp encode({:numeric_for, base, loop_var, body}) do
+    if contains_break?(body) do
+      :fallback
+    else
+      case encode_list(body, []) do
+        {:ok, body_enc} ->
+          {:ok, {@op_numeric_for, base, loop_var, List.to_tuple(body_enc)}}
+
+        :fallback ->
+          :fallback
+      end
+    end
+  end
+
+  # Anything else — `:closure`, `:concatenate`, while/repeat/generic-for
+  # loops, multi-return calls, vararg, etc. — is out of scope for v2.
   #
   # `:source_line` is stripped upstream in `encode_list/2`, so it never
   # reaches this clause table.
   defp encode(_other), do: :fallback
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  # `:break` inside a `:numeric_for` body forces the enclosing loop to
+  # fall back. The interpreter's loop_exit continuation walk relies on
+  # the broader `cont` shape; reproducing it inside the dispatcher is a
+  # B5c-v2 concern, not a table-coverage one.
+  defp contains_break?(body) when is_list(body) do
+    Enum.any?(body, fn
+      :break -> true
+      {:test, _reg, then_body, else_body} -> contains_break?(then_body) or contains_break?(else_body)
+      _ -> false
+    end)
+  end
+
+  defp contains_break?(_), do: false
 
   # ── Opcode tag accessors ────────────────────────────────────────────────
   #
@@ -214,8 +300,16 @@ defmodule Lua.Compiler.Bytecode do
   def op_not_equal, do: @op_not_equal
   def op_not, do: @op_not
   def op_test, do: @op_test
+  def op_call_zero, do: @op_call_zero
   def op_call_one, do: @op_call_one
   def op_return_one, do: @op_return_one
   def op_return_zero, do: @op_return_zero
   def op_source_line, do: @op_source_line
+  def op_new_table, do: @op_new_table
+  def op_get_table, do: @op_get_table
+  def op_set_table, do: @op_set_table
+  def op_set_field, do: @op_set_field
+  def op_set_list, do: @op_set_list
+  def op_length, do: @op_length
+  def op_numeric_for, do: @op_numeric_for
 end

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -24,6 +24,7 @@ defmodule Lua.VM.Dispatcher do
   alias Lua.VM.Executor
   alias Lua.VM.Numeric
   alias Lua.VM.State
+  alias Lua.VM.Value
 
   # Opcode tags. These must stay in lockstep with `Lua.Compiler.Bytecode`.
   # The module-attribute form lets each case branch match a constant
@@ -61,14 +62,22 @@ defmodule Lua.VM.Dispatcher do
   @op_not_equal 22
   @op_not 23
   @op_test 24
-  # `25` was `@op_test_true`; codegen never emitted it so it has been
-  # removed. Tag is free for reuse.
+  # Tag `25` was `@op_test_true`; codegen never emitted it. Reused by
+  # B5b-v2 for `:call` with `result_count == 0` (statement calls).
+  @op_call_zero 25
   @op_call_one 26
   @op_return_one 27
   @op_return_zero 28
   # `@op_source_line 29` is reserved but never reaches the dispatcher: the
   # bytecode encoder strips `:source_line` entries in `encode_list/2`.
   # Line tracking for compiled prototypes is B5d-v2.
+  @op_new_table 30
+  @op_get_table 31
+  @op_set_table 32
+  @op_set_field 33
+  @op_set_list 34
+  @op_length 35
+  @op_numeric_for 36
 
   @doc """
   Execute a compiled prototype against `args` and `state`.
@@ -512,10 +521,45 @@ defmodule Lua.VM.Dispatcher do
       # ── Calls ───────────────────────────────────────────────────────
       #
       # `:call_one` always asks for exactly one result placed at `base`.
-      # `:compiled_closure` callees stay in the dispatcher via the
-      # frame stack — no Erlang stack growth. Everything else bridges
-      # to the interpreter through `Executor.call_function/3`, which
-      # grows the Erlang stack by one frame at the mode boundary.
+      # `:call_zero` is the statement-call form (`table.sort(t)`,
+      # `print(x)`): results are discarded. `:compiled_closure` callees
+      # stay in the dispatcher via the frame stack — no Erlang stack
+      # growth. Everything else bridges to the interpreter through
+      # `Executor.call_function/3`, which grows the Erlang stack by one
+      # frame at the mode boundary.
+      #
+      # The `:discard` sentinel in the frame's `base` slot signals
+      # "throw the return value away"; `return_one/3` skips its
+      # setelement write when it sees it.
+
+      {@op_call_zero, base, arg_count, _name_hint} ->
+        func_value = :erlang.element(base + 1, regs)
+
+        case func_value do
+          {:compiled_closure, callee_proto, callee_upvalues} ->
+            callee_regs = init_callee_regs(callee_proto, regs, base + 1, arg_count)
+
+            frame =
+              {code, pc + 1, regs, upvalues, proto, cont, :discard, state.open_upvalues}
+
+            state = %{state | open_upvalues: %{}}
+
+            dispatch(
+              callee_proto.bytecode,
+              1,
+              callee_regs,
+              callee_upvalues,
+              callee_proto,
+              state,
+              [],
+              [frame | frames]
+            )
+
+          _ ->
+            args = collect_args(regs, base + 1, arg_count)
+            {_results, state} = Executor.call_function(func_value, args, state)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
 
       {@op_call_one, base, arg_count, _name_hint} ->
         func_value = :erlang.element(base + 1, regs)
@@ -575,6 +619,144 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_return_zero} ->
         return_one(nil, state, frames)
+
+      # ── Table opcodes ───────────────────────────────────────────────
+      #
+      # The fast paths mirror the interpreter clauses in `:get_field` /
+      # `:set_field` / `:length`: tref + integer-or-binary key + no
+      # metatable resolves to a direct map access; anything else bridges
+      # to `Executor.dispatcher_*` so metamethod fidelity matches.
+
+      {@op_new_table, dest} ->
+        {tref, state} = State.alloc_table(state)
+        regs = :erlang.setelement(dest + 1, regs, tref)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_get_table, dest, table_reg, key_reg, name_hint} ->
+        table_val = :erlang.element(table_reg + 1, regs)
+        key = :erlang.element(key_reg + 1, regs)
+
+        case table_val do
+          {:tref, id} when is_integer(key) or is_binary(key) ->
+            table = :erlang.map_get(id, state.tables)
+            data = :erlang.map_get(:data, table)
+
+            case data do
+              %{^key => value} ->
+                regs = :erlang.setelement(dest + 1, regs, value)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+              _ ->
+                case :erlang.map_get(:metatable, table) do
+                  nil ->
+                    regs = :erlang.setelement(dest + 1, regs, nil)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+                  _ ->
+                    {value, state} =
+                      Executor.dispatcher_get_table(table_val, key, state, proto, name_hint)
+
+                    regs = :erlang.setelement(dest + 1, regs, value)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+                end
+            end
+
+          _ ->
+            {value, state} =
+              Executor.dispatcher_get_table(table_val, key, state, proto, name_hint)
+
+            regs = :erlang.setelement(dest + 1, regs, value)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      {@op_set_table, table_reg, key_reg, value_reg, name_hint} ->
+        table_val = :erlang.element(table_reg + 1, regs)
+        key = :erlang.element(key_reg + 1, regs)
+        value = :erlang.element(value_reg + 1, regs)
+        state = Executor.dispatcher_set_table(table_val, key, value, state, proto, name_hint)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_set_field, table_reg, name, value_reg, name_hint} ->
+        table_val = :erlang.element(table_reg + 1, regs)
+        value = :erlang.element(value_reg + 1, regs)
+        state = Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      # `:set_list` runs only the integer-count form (see encoder). The
+      # multi-return form (`{:multi, _}`) was filtered upstream and never
+      # reaches the dispatcher.
+      {@op_set_list, table_reg, start, count, offset} ->
+        {:tref, id} = :erlang.element(table_reg + 1, regs)
+
+        state =
+          State.update_table(state, {:tref, id}, fn table ->
+            set_list_into_table(table, regs, start, count, offset, 0)
+          end)
+
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_length, dest, source} ->
+        value = :erlang.element(source + 1, regs)
+
+        case value do
+          {:tref, id} ->
+            table = :erlang.map_get(id, state.tables)
+
+            case :erlang.map_get(:metatable, table) do
+              nil ->
+                # No __len possible — Lua 5.3 §3.4.7: # on a table
+                # without __len is the border length of the data map.
+                len = Value.sequence_length(:erlang.map_get(:data, table))
+                regs = :erlang.setelement(dest + 1, regs, len)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+              _ ->
+                {len, state} = Executor.dispatcher_length(value, state, proto)
+                regs = :erlang.setelement(dest + 1, regs, len)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+            end
+
+          v when is_binary(v) ->
+            regs = :erlang.setelement(dest + 1, regs, byte_size(v))
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+          _ ->
+            {len, state} = Executor.dispatcher_length(value, state, proto)
+            regs = :erlang.setelement(dest + 1, regs, len)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
+
+      # ── numeric_for ─────────────────────────────────────────────────
+      #
+      # Coerce the three control registers once, write the canonical
+      # numbers back, then test `should_continue`. If the loop runs at
+      # least once, push a `:cps_for` marker onto `cont`; the body-end
+      # handler in `finish_body/6` increments the counter and either
+      # re-enters the body or pops back to `outer_pc`.
+
+      {@op_numeric_for, base, loop_var, body_bc} ->
+        {counter, limit, step} =
+          Executor.dispatcher_coerce_numeric_for_controls(
+            :erlang.element(base + 1, regs),
+            :erlang.element(base + 2, regs),
+            :erlang.element(base + 3, regs)
+          )
+
+        regs = :erlang.setelement(base + 1, regs, counter)
+        regs = :erlang.setelement(base + 2, regs, limit)
+        regs = :erlang.setelement(base + 3, regs, step)
+
+        should_continue =
+          if step > 0, do: counter <= limit, else: counter >= limit
+
+        if should_continue do
+          regs = :erlang.setelement(loop_var + 1, regs, counter)
+          state = Executor.dispatcher_close_open_upvalues_at_or_above(state, loop_var)
+          marker = {:cps_for, base, loop_var, body_bc, code, pc + 1}
+          dispatch(body_bc, 1, regs, upvalues, proto, state, [marker | cont], frames)
+        else
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+        end
     end
   end
 
@@ -582,6 +764,36 @@ defmodule Lua.VM.Dispatcher do
 
   defp finish_body(regs, upvalues, proto, state, [{next_code, next_pc} | rest_cont], frames) do
     dispatch(next_code, next_pc, regs, upvalues, proto, state, rest_cont, frames)
+  end
+
+  # `:numeric_for` body ran to completion. Increment the counter, re-test,
+  # and either restart the body (keeping the marker for the next pass) or
+  # pop back to the post-loop PC. Stepping by zero stays out of scope — the
+  # encoder accepts arbitrary step values but the executor's
+  # `dispatcher_coerce_numeric_for_controls` mirrors PUC's "step must not
+  # be zero" check at loop entry, so we never see step=0 here.
+  defp finish_body(
+         regs,
+         upvalues,
+         proto,
+         state,
+         [{:cps_for, base, loop_var, body_bc, outer_code, outer_pc} = marker | rest_cont],
+         frames
+       ) do
+    counter = :erlang.element(base + 1, regs)
+    step = :erlang.element(base + 3, regs)
+    new_counter = counter + step
+    regs = :erlang.setelement(base + 1, regs, new_counter)
+    limit = :erlang.element(base + 2, regs)
+    should_continue = if step > 0, do: new_counter <= limit, else: new_counter >= limit
+
+    if should_continue do
+      regs = :erlang.setelement(loop_var + 1, regs, new_counter)
+      state = Executor.dispatcher_close_open_upvalues_at_or_above(state, loop_var)
+      dispatch(body_bc, 1, regs, upvalues, proto, state, [marker | rest_cont], frames)
+    else
+      dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames)
+    end
   end
 
   # Body exhausted with no continuation: prototype ran off the end.
@@ -603,7 +815,13 @@ defmodule Lua.VM.Dispatcher do
 
   defp return_one(value, state, [frame | rest_frames]) do
     {code, pc, regs, upvalues, proto, cont, base, saved_open} = frame
-    regs = :erlang.setelement(base + 1, regs, value)
+
+    regs =
+      case base do
+        :discard -> regs
+        b -> :erlang.setelement(b + 1, regs, value)
+      end
+
     state = %{state | open_upvalues: saved_open}
     dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames)
   end
@@ -644,5 +862,17 @@ defmodule Lua.VM.Dispatcher do
 
   defp collect_args_rev(regs, off, count, acc) do
     collect_args_rev(regs, off - 1, count - 1, [:erlang.element(off + 1, regs) | acc])
+  end
+
+  # `:set_list` writes `count` consecutive register values into the table
+  # at keys `[offset + 1, offset + count]`. Inline loop so the BEAM keeps
+  # the hot path allocation-free apart from the `Table.put/3` updates
+  # themselves (which sit in the table-storage churn category the parent
+  # plan flagged as the post-B5b ceiling).
+  defp set_list_into_table(table, _regs, _start, 0, _offset, _i), do: table
+
+  defp set_list_into_table(table, regs, start, count, offset, i) do
+    value = :erlang.element(start + i + 1, regs)
+    set_list_into_table(Lua.VM.Table.put(table, offset + i + 1, value), regs, start, count - 1, offset, i + 1)
   end
 end

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -24,6 +24,7 @@ defmodule Lua.VM.Dispatcher do
   alias Lua.VM.Executor
   alias Lua.VM.Numeric
   alias Lua.VM.State
+  alias Lua.VM.Table
   alias Lua.VM.Value
 
   # Opcode tags. These must stay in lockstep with `Lua.Compiler.Bytecode`.
@@ -768,10 +769,10 @@ defmodule Lua.VM.Dispatcher do
 
   # `:numeric_for` body ran to completion. Increment the counter, re-test,
   # and either restart the body (keeping the marker for the next pass) or
-  # pop back to the post-loop PC. Stepping by zero stays out of scope — the
-  # encoder accepts arbitrary step values but the executor's
-  # `dispatcher_coerce_numeric_for_controls` mirrors PUC's "step must not
-  # be zero" check at loop entry, so we never see step=0 here.
+  # pop back to the post-loop PC. A `step` of zero infinite-loops here,
+  # matching the interpreter's behaviour at `do_execute([{:numeric_for, …}])`;
+  # neither path implements PUC-Lua's "for step is zero" runtime check.
+  # Fixing that is a separate concern across both executors.
   defp finish_body(
          regs,
          upvalues,
@@ -873,6 +874,6 @@ defmodule Lua.VM.Dispatcher do
 
   defp set_list_into_table(table, regs, start, count, offset, i) do
     value = :erlang.element(start + i + 1, regs)
-    set_list_into_table(Lua.VM.Table.put(table, offset + i + 1, value), regs, start, count - 1, offset, i + 1)
+    set_list_into_table(Table.put(table, offset + i + 1, value), regs, start, count - 1, offset, i + 1)
   end
 end

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -324,7 +324,7 @@ defmodule Lua.VM.Executor do
 
   @doc false
   @spec dispatcher_set_table(term(), term(), term(), State.t(), term(), term()) ::
-          State.t()
+          State.t() | no_return()
   def dispatcher_set_table({:tref, _} = tref, key, value, state, _proto, _name_hint) do
     table_newindex(tref, key, value, state)
   end
@@ -335,7 +335,7 @@ defmodule Lua.VM.Executor do
 
   @doc false
   @spec dispatcher_set_field(term(), binary(), term(), State.t(), term(), term()) ::
-          State.t()
+          State.t() | no_return()
   def dispatcher_set_field({:tref, _} = tref, name, value, state, _proto, _name_hint) do
     table_newindex(tref, name, value, state)
   end
@@ -344,6 +344,10 @@ defmodule Lua.VM.Executor do
     raise_index_type_error(value, 0, proto.source, name_hint)
   end
 
+  # The `_proto` parameter is unused today because `try_unary_metamethod`
+  # doesn't thread a `source` through; B5d-v2 will route `__len` errors
+  # back to `proto.source` (matching the other bridges' attribution),
+  # so the parameter stays in the signature for forward-compat.
   @doc false
   @spec dispatcher_length(term(), State.t(), term()) :: {term(), State.t()}
   def dispatcher_length(value, state, _proto) do

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -305,6 +305,79 @@ defmodule Lua.VM.Executor do
     index_value(value, name, state, 0, proto.source, name_hint)
   end
 
+  # ── Dispatcher bridges: table opcodes ───────────────────────────────────
+  #
+  # These wrap the same `defp` helpers that the interpreter's `:get_table`
+  # / `:set_table` / `:set_field` / `:length` clauses call, so the
+  # dispatcher inherits metamethod fidelity for free. Line attribution
+  # is uniformly `0` here; threading honest line info into compiled
+  # prototypes is B5d-v2. Native callbacks reached via metamethods still
+  # see accurate positions via the process-dictionary bridge installed
+  # at the call boundary.
+
+  @doc false
+  @spec dispatcher_get_table(term(), term(), State.t(), term(), term()) ::
+          {term(), State.t()}
+  def dispatcher_get_table(value, key, state, proto, name_hint) do
+    index_value(value, key, state, 0, proto.source, name_hint)
+  end
+
+  @doc false
+  @spec dispatcher_set_table(term(), term(), term(), State.t(), term(), term()) ::
+          State.t()
+  def dispatcher_set_table({:tref, _} = tref, key, value, state, _proto, _name_hint) do
+    table_newindex(tref, key, value, state)
+  end
+
+  def dispatcher_set_table(value, _key, _value, _state, proto, name_hint) do
+    raise_index_type_error(value, 0, proto.source, name_hint)
+  end
+
+  @doc false
+  @spec dispatcher_set_field(term(), binary(), term(), State.t(), term(), term()) ::
+          State.t()
+  def dispatcher_set_field({:tref, _} = tref, name, value, state, _proto, _name_hint) do
+    table_newindex(tref, name, value, state)
+  end
+
+  def dispatcher_set_field(value, _name, _value, _state, proto, name_hint) do
+    raise_index_type_error(value, 0, proto.source, name_hint)
+  end
+
+  @doc false
+  @spec dispatcher_length(term(), State.t(), term()) :: {term(), State.t()}
+  def dispatcher_length(value, state, _proto) do
+    try_unary_metamethod("__len", value, state, fn ->
+      case value do
+        {:tref, id} ->
+          table = Map.fetch!(state.tables, id)
+          Value.sequence_length(table.data)
+
+        v when is_binary(v) ->
+          byte_size(v)
+
+        v when is_list(v) ->
+          length(v)
+
+        _ ->
+          0
+      end
+    end)
+  end
+
+  @doc false
+  @spec dispatcher_coerce_numeric_for_controls(term(), term(), term()) ::
+          {number(), number(), number()}
+  def dispatcher_coerce_numeric_for_controls(init, limit, step) do
+    coerce_numeric_for_controls(init, limit, step)
+  end
+
+  @doc false
+  @spec dispatcher_close_open_upvalues_at_or_above(State.t(), non_neg_integer()) :: State.t()
+  def dispatcher_close_open_upvalues_at_or_above(state, threshold) do
+    close_open_upvalues_at_or_above(state, threshold)
+  end
+
   # ── Break ──────────────────────────────────────────────────────────────────
 
   defp do_execute([:break | _rest], regs, upvalues, proto, state, cont, frames, line) do

--- a/test/lua/compiler/bytecode_test.exs
+++ b/test/lua/compiler/bytecode_test.exs
@@ -64,8 +64,18 @@ defmodule Lua.Compiler.BytecodeTest do
       assert is_tuple(fn_proto.bytecode)
     end
 
-    test ":new_table causes fallback" do
-      proto = compile!("function f() return {1, 2, 3} end")
+    test ":generic_for causes fallback" do
+      # `for k, v in pairs(t)` emits `:generic_for`, which sits outside
+      # the dispatcher's loop coverage (only numeric-for is wired up).
+      proto =
+        compile!("""
+        function iter(t)
+          local n = 0
+          for _ in pairs(t) do n = n + 1 end
+          return n
+        end
+        """)
+
       [fn_proto] = proto.prototypes
       assert fn_proto.bytecode == nil
     end
@@ -90,18 +100,38 @@ defmodule Lua.Compiler.BytecodeTest do
       assert caller_proto.bytecode == nil
     end
 
-    test "for-loops cause fallback" do
+    test "while-loops cause fallback" do
+      # While/repeat/generic-for stay on the interpreter; only
+      # numeric-for is covered by the dispatcher in B5b-v2.
       proto =
         compile!("""
-        function sum(n)
-          local total = 0
-          for i = 1, n do total = total + i end
-          return total
+        function f(n)
+          local i = 0
+          while i < n do i = i + 1 end
+          return i
         end
         """)
 
-      [sum_proto] = proto.prototypes
-      assert sum_proto.bytecode == nil
+      [fn_proto] = proto.prototypes
+      assert fn_proto.bytecode == nil
+    end
+
+    test ":break inside numeric_for causes fallback" do
+      # `:break` requires loop_exit continuation walking which the
+      # dispatcher doesn't model. The whole enclosing numeric-for
+      # collapses to interpretation when the body contains a break.
+      proto =
+        compile!("""
+        function f(n)
+          for i = 1, n do
+            if i > 5 then break end
+          end
+          return n
+        end
+        """)
+
+      [fn_proto] = proto.prototypes
+      assert fn_proto.bytecode == nil
     end
 
     test ":vararg opcode causes fallback" do
@@ -116,10 +146,14 @@ defmodule Lua.Compiler.BytecodeTest do
 
   describe "cascade independence" do
     test "child prototype compiles even when sibling falls back" do
+      # `pure` is pure arithmetic (covered). `impure` returns the
+      # result of a function call with all results forwarded — a
+      # multi-return shape (`:call` with `result_count = -1` plus
+      # `:return_vararg`) that stays outside dispatcher coverage.
       proto =
         compile!("""
         function pure(a, b) return a + b end
-        function impure() return {1, 2, 3} end
+        function impure(t) return next(t) end
         """)
 
       [pure_proto, impure_proto] = proto.prototypes

--- a/test/lua/compiler/bytecode_test.exs
+++ b/test/lua/compiler/bytecode_test.exs
@@ -142,6 +142,39 @@ defmodule Lua.Compiler.BytecodeTest do
       [fn_proto] = proto.prototypes
       assert fn_proto.bytecode == nil
     end
+
+    test ":set_list with count == 0 falls back (interpreter's multi-return sentinel)" do
+      # Current codegen never emits `{:set_list, _, _, 0, _}` from a
+      # literal constructor — the interpreter treats `count == 0` as
+      # "consume `state.multi_return_count` trailing values," a shape
+      # only reachable through multi-return splicing. The dispatcher
+      # has no `multi_return_count` plumbing, so the encoder forces
+      # fallback on the literal shape to keep the divergence explicit
+      # if codegen ever changes.
+      proto = %Prototype{
+        instructions: [{:set_list, 0, 1, 0, 0}, {:return, 0, 0}],
+        max_registers: 2,
+        source: "test-synthetic"
+      }
+
+      result = Bytecode.compile(proto)
+      assert result.bytecode == nil
+    end
+
+    test ":set_list with {:multi, _} count falls back" do
+      # Same multi-return splicing shape, produced by codegen when a
+      # constructor's last element is `f()` (and so absorbs the call's
+      # full result list). The dispatcher only handles literal-count
+      # constructors.
+      proto = %Prototype{
+        instructions: [{:set_list, 0, 1, {:multi, 2}, 0}, {:return, 0, 0}],
+        max_registers: 2,
+        source: "test-synthetic"
+      }
+
+      result = Bytecode.compile(proto)
+      assert result.bytecode == nil
+    end
   end
 
   describe "cascade independence" do

--- a/test/lua/vm/dispatcher_test.exs
+++ b/test/lua/vm/dispatcher_test.exs
@@ -427,4 +427,310 @@ defmodule Lua.VM.DispatcherTest do
       assert results == [nil]
     end
   end
+
+  describe "table opcodes (dispatcher-compiled body)" do
+    test ":new_table — empty constructor returns a fresh tref" do
+      {proto, results} =
+        run!("""
+        function f() return {} end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert [{:tref, _id}] = results
+    end
+
+    test ":set_list — table constructor with literals" do
+      {proto, results} =
+        run!("""
+        function f() local t = {10, 20, 30} return t[2] end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [20]
+    end
+
+    test ":length — sequence after :set_list" do
+      {proto, results} =
+        run!("""
+        function f()
+          local t = {1, 2, 3, 4}
+          return \#t
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [4]
+    end
+
+    test ":length — string source" do
+      {proto, results} =
+        run!("""
+        function f(s) return #s end
+        return f("hello")
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [5]
+    end
+
+    test ":set_field then :get_field via dot notation" do
+      {proto, results} =
+        run!("""
+        function f()
+          local t = {}
+          t.x = 7
+          t.y = 11
+          return t.x + t.y
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [18]
+    end
+
+    test ":get_table — integer-key fast path" do
+      {proto, results} =
+        run!("""
+        function f()
+          local t = {100, 200, 300}
+          return t[1] + t[2] + t[3]
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [600]
+    end
+
+    test ":set_table with computed integer key" do
+      {proto, results} =
+        run!("""
+        function f(n)
+          local t = {}
+          t[n] = 42
+          t[n + 1] = 99
+          return t[n] + t[n + 1]
+        end
+        return f(5)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [141]
+    end
+  end
+
+  describe "numeric_for (dispatcher-compiled body)" do
+    test "sum 1..n" do
+      {proto, results} =
+        run!("""
+        function f(n)
+          local s = 0
+          for i = 1, n do s = s + i end
+          return s
+        end
+        return f(10)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [55]
+    end
+
+    test "non-unit step" do
+      {proto, results} =
+        run!("""
+        function f()
+          local s = 0
+          for i = 0, 10, 2 do s = s + i end
+          return s
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      # 0+2+4+6+8+10 = 30
+      assert results == [30]
+    end
+
+    test "negative step" do
+      {proto, results} =
+        run!("""
+        function f()
+          local s = 0
+          for i = 10, 1, -1 do s = s + i end
+          return s
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [55]
+    end
+
+    test "loop runs zero times when initial value already past limit" do
+      {proto, results} =
+        run!("""
+        function f()
+          local s = 0
+          for i = 10, 1 do s = s + i end
+          return s
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [0]
+    end
+
+    test "nested numeric_for" do
+      {proto, results} =
+        run!("""
+        function f(n)
+          local s = 0
+          for i = 1, n do
+            for j = 1, n do
+              s = s + 1
+            end
+          end
+          return s
+        end
+        return f(4)
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [16]
+    end
+
+    test "float-coerced controls (limit promoted to float)" do
+      {proto, results} =
+        run!("""
+        function f()
+          local s = 0
+          for i = 1, 5.0 do s = s + i end
+          return s
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [15.0]
+    end
+  end
+
+  describe "table_ops benchmark shapes (dispatcher-compiled)" do
+    # The benchmarks in `benchmarks/table_ops.exs` are the public
+    # motivation for B5b-v2: they should all run on the dispatcher
+    # end-to-end. Asserting that here pins the goal so a future
+    # refactor can't silently regress coverage.
+
+    setup do
+      lua = Lua.new()
+
+      {_, lua} =
+        Lua.eval!(lua, """
+        function run_table_build(n)
+          local t = {}
+          for i = 1, n do
+            t[i] = i * i
+          end
+          return #t
+        end
+
+        function run_table_sort(n)
+          local t = {}
+          for i = 1, n do
+            t[i] = n - i + 1
+          end
+          table.sort(t)
+          return t[1]
+        end
+
+        function run_table_sum(n)
+          local t = {}
+          for i = 1, n do
+            t[i] = i
+          end
+          local sum = 0
+          for j = 1, n do
+            sum = sum + t[j]
+          end
+          return sum
+        end
+
+        function run_table_map_reduce(n)
+          local t = {}
+          for i = 1, n do
+            t[i] = i
+          end
+          local mapped = {}
+          for j = 1, n do
+            mapped[j] = t[j] * t[j]
+          end
+          local sum = 0
+          for k = 1, n do
+            sum = sum + mapped[k]
+          end
+          return sum
+        end
+        """)
+
+      %{lua: lua}
+    end
+
+    test "every table_ops function is compiled (not interpreted)", %{lua: lua} do
+      names = ~w(run_table_build run_table_sort run_table_sum run_table_map_reduce)
+
+      for name <- names do
+        case State.get_global(lua.state, name) do
+          {:compiled_closure, _proto, _ups} ->
+            :ok
+
+          {:lua_closure, _proto, _ups} ->
+            flunk("expected #{name} to be :compiled_closure, got :lua_closure")
+        end
+      end
+    end
+
+    test "run_table_build(10) → 10", %{lua: lua} do
+      {[result], _} = Lua.eval!(lua, "return run_table_build(10)")
+      assert result == 10
+    end
+
+    test "run_table_sort(10) → 1", %{lua: lua} do
+      {[result], _} = Lua.eval!(lua, "return run_table_sort(10)")
+      assert result == 1
+    end
+
+    test "run_table_sum(10) → 55", %{lua: lua} do
+      {[result], _} = Lua.eval!(lua, "return run_table_sum(10)")
+      assert result == 55
+    end
+
+    test "run_table_map_reduce(10) → 385", %{lua: lua} do
+      {[result], _} = Lua.eval!(lua, "return run_table_map_reduce(10)")
+      assert result == 385
+    end
+  end
+
+  describe ":call_zero — statement call form" do
+    test "discards results from a native function" do
+      # `print` is the canonical statement-call target. Routing through
+      # the dispatcher must not propagate its return values.
+      {proto, results} =
+        run!("""
+        function f()
+          local t = {3, 1, 2}
+          table.sort(t)
+          return t[1]
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [1]
+    end
+  end
 end


### PR DESCRIPTION
## Dispatcher table opcodes — make table-heavy workloads bypass the interpreter

Plan: [`.agents/plans/B5b-v2-dispatcher-tables.md`](.agents/plans/B5b-v2-dispatcher-tables.md)
Closes #271

### Goal

Extend `Lua.VM.Dispatcher` and `Lua.Compiler.Bytecode` to lower the
table opcode family plus `:numeric_for`. After this PR all four
`table_ops` benchmarks compile end-to-end and stay out of the
interpreter fallback path, plus the `closures` orchestrator
(`run_closures`).

### Success criteria

- [x] `Lua.Compiler.Bytecode` learns encoders for `:new_table`,
      `:get_table`, `:set_table`, `:set_field`, `:set_list` (basic
      non-multi-return form), `:length`, and `:numeric_for` (body
      encoded recursively; falls back if body contains an uncovered
      opcode or `:break`).
- [x] `Lua.VM.Dispatcher` gains one `case` branch per new opcode
      plus the `:cps_for` continuation marker handled by
      `finish_body/6`.
- [x] `:call` with `result_count == 0` (statement-call form) is
      covered via a new `@op_call_zero` tag — required so
      `run_table_sort` can compile (`table.sort(t)` is a statement
      call).
- [x] `Lua.VM.Executor` exposes six new `dispatcher_*` public
      bridges (`dispatcher_get_table`, `dispatcher_set_table`,
      `dispatcher_set_field`, `dispatcher_length`,
      `dispatcher_coerce_numeric_for_controls`,
      `dispatcher_close_open_upvalues_at_or_above`) — each wraps an
      existing `defp` helper so metamethod fidelity matches the
      interpreter for free.
- [x] `mix compile --warnings-as-errors` passes.
- [x] `mix test`: **1883 → 1902 tests, 0 failures, 25 skipped**.
- [x] `mix test --only lua53`: 29 tests, 0 failures, 18 skipped.
- [x] `test/lua/vm/leak_regression_test.exs`: 3 tests, 0 failures.
- [x] All four `table_ops` benchmark functions compile to bytecode
      end-to-end (verified by a new dispatcher-test setup that asserts
      `{:compiled_closure, _, _}` for each global after install).
- [x] `run_closures` orchestrator compiles (`make_counter` still
      falls back because of `:closure` — that's B5c-v2).
- [x] No workload regresses by more than 10% vs. interpreter on the
      `dispatcher_vs_interpreter`-style A/B harness.
- [ ] Soft target `run_table_sum(1000)` ≥1.5x interpreter — landed
      at **1.13x**. Profile shows `Table.put/3` allocation churn
      and `setelement/3` register writes dominate; both are
      explicitly out of scope per the parent plan ("table-storage
      churn is the post-B5b ceiling").

### Performance

Mini-bench (`mix run -e`, 100–200 iter median, warmed):

| Workload                    | Dispatcher | Interpreter | Speedup |
|-----------------------------|------------|-------------|---------|
| `run_table_build(500)`      | 90 µs      | 106 µs      | **1.18x**   |
| `run_table_sum(500)`        | 121 µs     | 129 µs      | 1.06x   |
| `run_table_sum(1000)`       | 254 µs     | 289 µs      | 1.13x   |
| `run_table_map_reduce(500)` | 241 µs     | 245 µs      | 1.02x   |
| `fib(22)`                   | 12.2 ms    | 18.7 ms     | **1.54x**   |

fib lands at 1.54x — well above B5a-v2's 1.17x median for fib(25),
a sign the table-opcode additions did not push the arithmetic
path off any inlining cliff.

### Discoveries

1. **`:call` with `result_count == 0` was needed.** `run_table_sort`
   calls `table.sort(t)` at statement position, which lowers to
   `{:call, _, _, 0, _}`. Added `@op_call_zero` (reusing slot 25,
   freed by the removed `@op_test_true`). The dispatcher branch
   shares the same shape as `:call_one`, with a `:discard` sentinel
   in the frame's `base` slot signalling "throw the return value
   away."

2. **`string_ops` orchestrators do *not* fully compile.** The
   issue described "orchestrators in `closures` and `string_ops`"
   as compiling. `run_closures` does. But both string_ops orchestrators
   end with `return table.concat(...)` / `return string.format(...)`
   — multi-return shapes (`:call` with `result_count = -1` plus
   `:return_vararg`) which are explicitly out of scope per the
   parent plan. Documented as a B5c-v2 follow-up.

3. **`:break` inside `:numeric_for` forces fallback.** The
   interpreter's `:break` walks `find_loop_exit/1` against the
   continuation stack. Reproducing that in the dispatcher requires
   mixing post-test markers with `{:loop_exit, _}` markers — the
   same machinery generic-for / while-loop / break all want, which
   is the domain of B5c-v2. The encoder rejects `:numeric_for`
   bodies containing `:break` upfront (walking recursively through
   nested `:test` branches) and the whole enclosing prototype falls
   back.

4. **The `:cps_for` continuation marker integrates cleanly.** B5a's
   `cont` stack carried only `{code, pc}` resume points. Adding
   `{:cps_for, base, loop_var, body_bc, code, pc + 1}` markers
   expands `finish_body/6` from two clauses to three. The marker
   stays on the stack across iterations (re-pushed when the body
   restarts), so nested numeric-fors compose naturally on the same
   stack.

5. **Soft perf target missed; hard floor met.** `setelement/3` +
   `Table.put/3` allocation dominate the table workloads. The
   parent plan explicitly flagged this and ruled mutable storage
   out of scope; the next plan for closing the table-workload gap
   is mutable register/table storage, not more dispatch work.

### Changes

```
 .agents/plans/B5b-v2-dispatcher-tables.md   |   ~233  (status: review, discoveries appended)
 lib/lua/compiler/bytecode.ex                |   +95  (7 new opcodes + :call_zero + accessors)
 lib/lua/vm/dispatcher.ex                    |  +231  (7 new branches + :cps_for + helpers)
 lib/lua/vm/executor.ex                      |   +73  (6 dispatcher_* bridges)
 test/lua/compiler/bytecode_test.exs         |   ~54  (flip 2 fallback tests, add 3)
 test/lua/vm/dispatcher_test.exs             |  +306  (21 new goldens: 7 table, 6 numeric_for,
                                              |        4 table_ops shapes, 1 :call_zero, plus
                                              |        the test_ops setup block)
```

### Verification

```
mix format                                            ✓
mix compile --warnings-as-errors                      ✓
mix test                                              ✓ 1902 tests, 0 failures
mix test --only lua53                                 ✓ 29 tests, 0 failures
mix test test/lua/vm/dispatcher_test.exs              ✓ 48 tests (27 → 48)
mix test test/lua/compiler/bytecode_test.exs          ✓ 15 tests (14 → 15)
mix test test/lua/vm/leak_regression_test.exs         ✓ 3 tests
```

### Out of scope (intentional)

- `:closure` opcode and varargs → **B5c-v2**.
- Multi-return `:call` (`result_count = -1`) and `:return_vararg`
  → still **B5c-v2**. This is why `string_ops` orchestrators
  don't fully compile.
- `:while_loop`, `:repeat_loop`, `:generic_for` → defer to a future
  plan (not blockers for `table_ops`).
- `:break` inside `:numeric_for` → fallback for now. The
  loop-exit continuation machinery lands with the rest of B5c-v2.
- `:set_list` with `{:multi, _}` → fallback.
- Mutable table storage → its own follow-up plan if the table-workload
  gap matters.
- Line attribution for table errors → **B5d-v2**. All new bridges
  pass `line: 0`.