### PR TITLE
fix(vm): close open upvalues at do-block exit

### DIFF
--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -91,6 +91,7 @@ defmodule Lua.Compiler.Bytecode do
   @op_while_loop 49
   @op_repeat_loop 50
   @op_generic_for 51
+  @op_close_upvalues 52
 
   @doc """
   Compile a prototype, populating its `bytecode` field on success.
@@ -344,6 +345,8 @@ defmodule Lua.Compiler.Bytecode do
   defp encode({:get_open_upvalue, dest, reg}), do: {:ok, {@op_get_open_upvalue, dest, reg}}
 
   defp encode({:set_open_upvalue, reg, source}), do: {:ok, {@op_set_open_upvalue, reg, source}}
+
+  defp encode({:close_upvalues, threshold}), do: {:ok, {@op_close_upvalues, threshold}}
 
   defp encode({:vararg, base, count}), do: {:ok, {@op_vararg, base, count}}
 

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -730,9 +730,17 @@ defmodule Lua.Compiler.Codegen do
   end
 
   # Do: do...end block
-  defp gen_statement(%Statement.Do{body: body}, ctx) do
-    # Simply generate code for the inner block
-    gen_block(body, ctx)
+  defp gen_statement(%Statement.Do{body: body} = do_stmt, ctx) do
+    {body_instructions, ctx} = gen_block(body, ctx)
+
+    # Close any open-upvalue cells over registers the block's locals occupied
+    # before the slots are reused by the next statement (Lua 5.3 §3.4.10).
+    # The threshold is the `next_register` watermark stashed by scope analysis
+    # at block entry; emitting unconditionally is cheap — the executor's
+    # close helper short-circuits when `open_upvalues` is empty, which is the
+    # overwhelming common case.
+    threshold = Map.fetch!(ctx.scope.var_map, {:do_close_threshold, do_stmt})
+    {body_instructions ++ [Instruction.close_upvalues(threshold)], ctx}
   end
 
   # Break statement

--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -17,6 +17,12 @@ defmodule Lua.Compiler.Instruction do
   def set_upvalue(index, source), do: {:set_upvalue, index, source}
   def get_open_upvalue(dest, reg), do: {:get_open_upvalue, dest, reg}
   def set_open_upvalue(reg, source), do: {:set_open_upvalue, reg, source}
+
+  # Close any open-upvalue cells whose source register is at or above
+  # `threshold`. Lua 5.3 §3.4.10: locals going out of scope (block exit) must
+  # have their captured cells detached from the register so subsequent
+  # re-uses of those registers don't read through the stale cell.
+  def close_upvalues(threshold), do: {:close_upvalues, threshold}
   def get_global(dest, name), do: {:get_global, dest, name}
   def set_global(name, source), do: {:set_global, name, source}
 

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -356,12 +356,19 @@ defmodule Lua.Compiler.Scope do
     resolve_function_scope(local_func, params, body, state)
   end
 
-  defp resolve_statement(%Statement.Do{body: body}, state) do
+  defp resolve_statement(%Statement.Do{body: body} = do_stmt, state) do
     # Do blocks create a new scope - save and restore locals/next_register
     saved_locals = state.locals
     saved_next_register = state.next_register
 
     state = resolve_block(body, state)
+
+    # Stash the pre-block register watermark so codegen can emit a
+    # `:close_upvalues` at block exit. Per Lua 5.3 §3.4.10 any open-upvalue
+    # cell over a register that goes out of scope here must be detached so
+    # the next statement that reuses the slot does not read or write through
+    # the stale cell — see locals.lua:148-154 for the symptom this prevents.
+    state = %{state | var_map: Map.put(state.var_map, {:do_close_threshold, do_stmt}, saved_next_register)}
 
     # Restore outer scope (inner locals don't leak out)
     %{state | locals: saved_locals, next_register: saved_next_register}

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -98,6 +98,7 @@ defmodule Lua.VM.Dispatcher do
   @op_while_loop 49
   @op_repeat_loop 50
   @op_generic_for 51
+  @op_close_upvalues 52
 
   @doc """
   Execute a compiled prototype against `args` and `state`.
@@ -952,6 +953,10 @@ defmodule Lua.VM.Dispatcher do
               %{state | upvalue_cells: Map.put(state.upvalue_cells, cell_ref, value)}
           end
 
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
+
+      {@op_close_upvalues, threshold} ->
+        state = Executor.dispatcher_close_open_upvalues_at_or_above(state, threshold)
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
 
       # ── Vararg ────────────────────────────────────────────────────

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -696,6 +696,20 @@ defmodule Lua.VM.Executor do
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 
+  # ── close_upvalues ─────────────────────────────────────────────────────────
+  #
+  # Emitted at the end of a block scope (e.g. `do…end`) whose locals could
+  # have been captured by a closure created inside the block. Per Lua 5.3
+  # §3.4.10, those upvalue cells must be detached from the register as the
+  # locals go out of scope so the next statement reusing those register
+  # slots does not read or overwrite the stale cell. Loop bodies do this on
+  # each iteration boundary in the continuation handlers above; this is the
+  # same operation for non-loop block exits.
+  defp do_execute([{:close_upvalues, threshold} | rest], regs, upvalues, proto, state, cont, frames, line) do
+    state = close_open_upvalues_at_or_above(state, threshold)
+    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
+  end
+
   # ── set_open_upvalue ───────────────────────────────────────────────────────
 
   # Write a captured-local value through the upvalue cell when one exists.

--- a/test/lua/vm/env_semantics_test.exs
+++ b/test/lua/vm/env_semantics_test.exs
@@ -82,4 +82,39 @@ defmodule Lua.VM.EnvSemanticsTest do
       assert {[true], _} = Lua.eval!(lua, "return _G == _ENV")
     end
   end
+
+  describe "open-upvalue cells are closed when a block scope ends" do
+    # A nested function declaration inside `do local _ENV = ... end` captures
+    # the inner `_ENV` via the open-upvalue mechanism. When the `do` block
+    # exits, the cell over that register must be detached so a subsequent
+    # `do local _ENV = ... end` that reuses the same slot is not read through
+    # the stale cell. Lua 5.3 §3.4.10.
+    test "fresh local _ENV in a sibling block is not read through a prior cell", %{lua: lua} do
+      code = """
+      do local _ENV = {}
+        function foo() end
+      end
+      do local _ENV = {assert=assert, A=20}
+        assert(A == 20)
+      end
+      return true
+      """
+
+      assert {[true], _} = Lua.eval!(lua, code)
+    end
+
+    test "nested local _ENV redirection sees the inner table at each level", %{lua: lua} do
+      code = """
+      do local _ENV = {assert=assert, A=10}
+        do local _ENV = {assert=assert, A=20}
+          assert(A == 20)
+        end
+        assert(A == 10)
+      end
+      return true
+      """
+
+      assert {[true], _} = Lua.eval!(lua, code)
+    end
+  end
 end

--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -164,15 +164,7 @@
       issue: nil
     }
   ],
-  "locals.lua" => [
-    %{
-      lines: 148..154,
-      category: :semantic,
-      reason:
-        "nested `local _ENV = {assert=assert, ...}` redirection leaks scope: free-name `assert` resolves to nil at line 150 (debug.getupvalue/setupvalue and _ENV introspection now pass)",
-      issue: 284
-    }
-  ],
+  "locals.lua" => [],
   "math.lua" => [
     %{
       lines: :all,


### PR DESCRIPTION
## Summary

Per Lua 5.3 §3.4.10, when a local goes out of scope its open-upvalue cell must be detached from the register so the slot can be safely reused. Loop bodies already do this between iterations; non-loop block exits (specifically `do…end`) did not. The result:

```lua
do local _ENV = {}
  function foo() end     -- captures the inner _ENV, opens a cell over reg 1
end
do local _ENV = {assert=assert}  -- writes reg 1, but the cell still holds `{}`
  assert(true)           -- _ENV resolves via the stale cell — assert is nil
end
```

This is exactly the failure that the `lines: 148..154` partial-skip on `locals.lua` was masking (introduced by the upvalue-names PR that closed #256).

## Changes

- **`instruction.ex`** — new `:close_upvalues threshold` constructor.
- **`scope.ex`** — `Statement.Do` stashes the pre-block `next_register` watermark in `var_map` under `{:do_close_threshold, do_stmt}`.
- **`codegen.ex`** — emits `:close_upvalues threshold` after every `do` block's body. Unconditional emission is cheap: the executor's close helper short-circuits on the empty-map fast path.
- **`executor.ex` / `dispatcher.ex` / `bytecode.ex`** — handle the new opcode in both VMs.

## Verification

- New regression tests in `test/lua/vm/env_semantics_test.exs` pin the two failure shapes (sibling-block stale cell, nested redirection).
- **`locals.lua` partial-skip removed** — the file now passes in full.
- Full suite: **2037 passed, 22 skipped**. Clean compile under `--warnings-as-errors`; `mix format` clean.

Closes #284.