### PR TITLE
test(suite): narrow gc.lua skip to the collectgarbage no-op region

### DIFF
--- a/.agents/plans/A22a-gc-collectgarbage-stub.md
+++ b/.agents/plans/A22a-gc-collectgarbage-stub.md
@@ -1,0 +1,93 @@
+---
+id: A22a
+title: "Triage gc.lua — narrow skip to the collectgarbage no-op region"
+issue: 260
+pr: null
+branch: fix/gc-vm-errors
+base: main
+status: in-progress
+direction: A
+unlocks:
+  - gc.lua
+---
+
+## Goal
+
+Narrow `gc.lua`'s whole-file skip to the region that depends on a real
+garbage collector, so the file's early allocation smoke tests run and
+report conformance.
+
+## Out of scope
+
+- Implementing a real garbage collector (step/stop/restart pacing,
+  `count` shrinkage, weak tables, `__gc` finalizers). That is a large
+  feature, deferred well past 1.0.
+- `attrib.lua` — permanently deferred (filesystem/package I/O), tracked
+  under the parent cluster.
+
+## Success criteria
+
+- [ ] `gc.lua` is no longer a whole-file `:all` skip; it runs with a
+      narrowed range and passes.
+- [ ] A regression test pins the `collectgarbage` stub behaviour and
+      documents the PUC-Lua divergences:
+      `test/lua/vm/stdlib/collectgarbage_test.exs`.
+- [ ] `mix test` passes.
+- [ ] `mix test test/lua53_suite_test.exs --only lua53` passes.
+
+## Implementation notes
+
+Parent cluster: A22 (issue #260). The parent hypothesised a leaked
+Elixir `MatchError` in the executor; that no longer reproduces —
+intervening VM work resolved it. The current first failure in `gc.lua`
+is a Lua-level assertion, not a leaked match.
+
+Root cause: `collectgarbage` is a no-op stub
+(`lib/lua/vm/stdlib.ex`). `isrunning` always returns `true`,
+`count` returns `0.0`, and every other mode returns `0`. The first
+failing assertion is `gc.lua:168` (`assert(not collectgarbage("isrunning"))`)
+reached via `dosteps(0)` at `gc.lua:186`, because the stub cannot honour
+`collectgarbage("stop")`.
+
+From the `dosteps` helper (line 167) onward the file is pervasively
+GC-dependent: step pacing returning a boolean cycle flag, `gcinfo()`
+shrinking after a collection, weak tables, `__gc` finalizers, threads,
+and emergency collections. Lines 1–165 (basic allocation) and the
+trailing `print('OK')` do not depend on a real collector.
+
+Decision: defer (triage skill §6.C). Narrow the `gc.lua` skip from
+`:all` to `167..622` with a precise reason and issue #260, and leave a
+regression test documenting the stub.
+
+The long string `[[ ... ]]` at lines 125–134 is fully inside the
+passing prefix, so the range boundary at 167 does not split it. Nothing
+declared inside 167..622 is referenced after line 622.
+
+### Files
+
+- `test/lua53_skips.exs` — narrow `gc.lua` range.
+- `test/lua/vm/stdlib/collectgarbage_test.exs` — regression test.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test test/lua53_suite_test.exs --only lua53
+```
+
+`gc.lua` flips from `(pending initial triage)` (whole-file skip) to
+`(456 lines skipped, 1 ranges)` and passes.
+
+## Risks
+
+- The narrowed prefix passes only because the stub is a permissive
+  no-op; if a real collector lands it must satisfy the expectations the
+  regression test enumerates, and the skip range will shrink.
+
+## Discoveries
+
+- The parent plan's `MatchError` hypothesis for `gc.lua` is stale; the
+  current failure mode is a Lua-level assertion driven by the
+  `collectgarbage` no-op stub.

--- a/.agents/plans/A22a-gc-collectgarbage-stub.md
+++ b/.agents/plans/A22a-gc-collectgarbage-stub.md
@@ -2,10 +2,10 @@
 id: A22a
 title: "Triage gc.lua — narrow skip to the collectgarbage no-op region"
 issue: 260
-pr: null
+pr: 287
 branch: fix/gc-vm-errors
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - gc.lua

--- a/test/lua/vm/stdlib/collectgarbage_test.exs
+++ b/test/lua/vm/stdlib/collectgarbage_test.exs
@@ -1,0 +1,52 @@
+defmodule Lua.VM.Stdlib.CollectgarbageTest do
+  use ExUnit.Case, async: true
+
+  # Regression coverage for the `collectgarbage` stub. The embedded VM
+  # does not implement a real garbage collector, so `collectgarbage` is
+  # a no-op that accepts every standard mode. These tests pin the stub's
+  # observable behaviour and document where it diverges from PUC-Lua's
+  # real collector.
+  #
+  # Lua 5.3 suite: gc.lua. The bulk of that file (the `dosteps` helper
+  # and everything after it) asserts on real GC step/stop/restart pacing
+  # and weak-table/finalizer semantics that this stub cannot satisfy, so
+  # that region stays skipped in test/lua53_skips.exs. When a real
+  # collector lands, these expectations flip and the skip range shrinks.
+
+  test "collectgarbage with no argument defaults to 'collect' and returns 0" do
+    assert {[0], _} = Lua.eval!(~S[return collectgarbage()])
+  end
+
+  test "collectgarbage('count') returns 0.0 kbytes and 0 byte remainder" do
+    assert {[+0.0, 0], _} = Lua.eval!(~S[return collectgarbage("count")])
+  end
+
+  test "collectgarbage('isrunning') always reports true" do
+    assert {[true], _} = Lua.eval!(~S[return collectgarbage("isrunning")])
+  end
+
+  test "step/stop/restart/setpause/setstepmul are accepted no-ops returning 0" do
+    for mode <- ~w(collect stop restart step setpause setstepmul generational incremental) do
+      assert {[0], _} = Lua.eval!(~s[return collectgarbage("#{mode}")]),
+             "expected collectgarbage(#{inspect(mode)}) to return 0"
+    end
+  end
+
+  # Divergence from PUC-Lua, kept explicit so a future real collector has
+  # a checklist of expectations to satisfy.
+
+  test "stub does NOT toggle isrunning on stop (real GC would report false)" do
+    # PUC-Lua: collectgarbage("isrunning") is false after "stop".
+    assert {[true], _} =
+             Lua.eval!(~S"""
+             collectgarbage("stop")
+             return collectgarbage("isrunning")
+             """)
+  end
+
+  test "stub returns 0 for step, not the boolean cycle-completion flag" do
+    # PUC-Lua: collectgarbage("step", n) returns true when a collection
+    # cycle completes. The stub returns a numeric 0 regardless.
+    assert {[0], _} = Lua.eval!(~S[return collectgarbage("step", 20000)])
+  end
+end

--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -116,7 +116,13 @@
     }
   ],
   "gc.lua" => [
-    %{lines: :all, category: :unimplemented, reason: "garbage collection / weak tables not implemented", issue: nil}
+    %{
+      lines: 167..622,
+      category: :unimplemented,
+      reason:
+        "collectgarbage is a no-op stub: step/stop/restart pacing, count shrinkage, weak tables and __gc finalizers not implemented",
+      issue: 260
+    }
   ],
   "goto.lua" => [
     %{


### PR DESCRIPTION
## Goal

Narrow `gc.lua`'s whole-file skip to the region that depends on a real garbage collector, so the file's early allocation smoke tests run and report conformance. Triage sub-plan of cluster A22 (issue #260).

## Success criteria

- [x] `gc.lua` is no longer a whole-file `:all` skip; it runs with a narrowed range and passes (`456 lines skipped, 1 ranges`).
- [x] A regression test pins the `collectgarbage` stub behaviour and documents the PUC-Lua divergences: `test/lua/vm/stdlib/collectgarbage_test.exs`.
- [x] `mix test` passes (2044 passed, was 2037).
- [x] `mix test test/lua53_suite_test.exs --only lua53` passes (15 passed / 14 skipped, was 14 / 15).

## Changes

- `test/lua53_skips.exs`: narrow `gc.lua` from `lines: :all` to `lines: 167..622`, category `:unimplemented`, with a precise reason and `issue: 260`.
- `test/lua/vm/stdlib/collectgarbage_test.exs`: new regression test pinning the no-op `collectgarbage` stub and enumerating the divergences a future real collector must satisfy.
- `.agents/plans/A22a-gc-collectgarbage-stub.md`: sub-plan.

### Why

The parent cluster A22 hypothesised a leaked Elixir `MatchError` in the executor for `gc.lua`. That no longer reproduces — intervening VM work resolved it. The current first failure is a Lua-level assertion: `collectgarbage` is a no-op stub (`lib/lua/vm/stdlib.ex`) where `isrunning` always returns `true`, `count` returns `0.0`, and other modes return `0`. So `collectgarbage("stop")` cannot be honoured, and `gc.lua:168` (`assert(not collectgarbage("isrunning"))`) fails via `dosteps` at line 186.

From the `dosteps` helper (line 167) onward the file is pervasively GC-dependent: step pacing returning a boolean cycle flag, `gcinfo()` shrinking after collection, weak tables, `__gc` finalizers, threads, and emergency collections. Lines 1-165 (basic allocation) and the trailing `print('OK')` do not depend on a real collector, so they now run.

## Verification

```
mix format
mix compile --warnings-as-errors
mix test
# Result: 2044 passed (56 doctests, 51 properties, 1937 tests), 21 skipped
mix test test/lua53_suite_test.exs --only lua53
# Result: 15 passed, 14 skipped  (gc.lua flipped into the passing set)
```

`gc.lua` flips from `(pending initial triage)` (whole-file skip) to `(456 lines skipped, 1 ranges)` and passes.

## Out of scope

- Implementing a real garbage collector (step/stop/restart pacing, `count` shrinkage, weak tables, `__gc` finalizers). Deferred well past 1.0; the narrowed skip and the regression test track the gap.
- `attrib.lua` — permanently deferred (filesystem/package I/O).

Plan: A22a

Closes #260
