### PR TITLE
fix(vm): match PUC-Lua integer divide/modulo by zero semantics

### DIFF
--- a/.agents/plans/A21a-integer-divide-by-zero.md
+++ b/.agents/plans/A21a-integer-divide-by-zero.md
@@ -1,0 +1,70 @@
+---
+id: A21a
+title: "Integer division/modulo by zero: PUC message + float-operand semantics"
+issue: 259
+pr: null
+branch: fix/runtime-type-cluster
+base: main
+status: in-progress
+direction: A
+---
+
+## Goal
+
+Fix `//` and `%` zero-divisor handling in the VM so it matches PUC-Lua
+5.3: integer `//` zero reports "attempt to divide by zero", and a float
+operand follows the float (inf/nan) path instead of raising.
+
+This is a concrete sub-fix carved out of the parent triage cluster
+(A21, issue #259), independent of the deferred `math.huge` finite
+stand-in limitation that keeps `math.lua` skipped overall.
+
+## Out of scope
+
+- The `math.huge` / `:nan` finite-sentinel design (the reason `math.lua`
+  remains skipped). NaN/inf flowing through bitwise ops is unchanged.
+- `os.*` (handled in a separate PR).
+- Unskipping `math.lua` or `errors.lua` wholesale.
+
+## Success criteria
+
+- [ ] `2 // 0` raises with a message containing "divide by zero"
+      (PUC-Lua parity; previously "attempt to perform 'n//0'").
+- [ ] `2.0 // 0` and `2.0 % 0` do NOT raise — a float operand makes the
+      whole expression float `//`/`%`, yielding inf/nan.
+- [ ] `mix test` passes.
+- [ ] `mix test test/lua53_suite_test.exs --only lua53` passes.
+
+## Implementation notes
+
+`lib/lua/vm/executor.ex`:
+
+- `safe_floor_divide/6`: only raise when BOTH operands are integers and
+  the divisor is zero; change the message to "attempt to divide by
+  zero". When either operand is a float, take the inf/nan path.
+- `safe_modulo/6`: same both-operands-integer guard; message `'n%0'`
+  is already correct.
+
+Verified against PUC-Lua: `2 // 0` -> "attempt to divide by zero";
+`2 % 0` -> "attempt to perform 'n%0'"; `2.0 // 0` -> inf; `2.0 % 0`
+-> nan.
+
+Tests updated to the corrected contract: `float_div_zero_test.exs`,
+`arithmetic_test.exs`, `error_format_test.exs`.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test test/lua53_suite_test.exs --only lua53
+```
+
+## Risks
+
+- Other suite files may assert the old `'n//0'` wording. Mitigated:
+  the suite (`errors.lua`, `math.lua`) expects "divide by zero", and
+  our own tests were the only ones pinning the old message.
+</content>
+</invoke>

--- a/.agents/plans/A21a-integer-divide-by-zero.md
+++ b/.agents/plans/A21a-integer-divide-by-zero.md
@@ -2,10 +2,10 @@
 id: A21a
 title: "Integer division/modulo by zero: PUC message + float-operand semantics"
 issue: 259
-pr: null
+pr: 292
 branch: fix/runtime-type-cluster
 base: main
-status: in-progress
+status: review
 direction: A
 ---
 

--- a/.agents/plans/A21a-integer-divide-by-zero.md
+++ b/.agents/plans/A21a-integer-divide-by-zero.md
@@ -66,5 +66,3 @@ mix test test/lua53_suite_test.exs --only lua53
 - Other suite files may assert the old `'n//0'` wording. Mitigated:
   the suite (`errors.lua`, `math.lua`) expects "divide by zero", and
   our own tests were the only ones pinning the old message.
-</content>
-</invoke>

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -2550,28 +2550,30 @@ defmodule Lua.VM.Executor do
     end
   end
 
-  # Lua 5.3 §3.4.1: floor division of floats is `floor(a/b)`. With a float
-  # zero divisor, `a/b` is the inf/nan stand-in produced by `safe_divide`,
-  # and the floor of that flows through to the result:
+  # Lua 5.3 §3.4.1: floor division of floats is `floor(a/b)`. With a zero
+  # divisor where either operand is a float, `a/b` is the inf/nan stand-in
+  # produced by `safe_divide`, and the floor of that flows through to the
+  # result:
   #
-  #   * ` 1.0 // 0.0` → `+math.huge`
-  #   * `-1.0 // 0.0` → `-math.huge`
-  #   * ` 0.0 // 0.0` → `:nan`
+  #   * ` 1.0 // 0` / ` 1.0 // 0.0` → `+math.huge`
+  #   * `-1.0 // 0` / `-1.0 // 0.0` → `-math.huge`
+  #   * ` 0.0 // 0` / ` 0.0 // 0.0` → `:nan`
   #
-  # An integer-zero divisor still raises — that's correct per spec, since
-  # `//` between two integers is integer floor division.
+  # Only an integer `//` integer with a zero divisor raises — that's correct
+  # per spec, since `//` between two integers is integer floor division.
+  # PUC-Lua reports this as "attempt to divide by zero".
   defp safe_floor_divide(a, b, line, source, hint_a, hint_b) do
     na = number_or_arith_raise!(a, line, source, hint_a)
     nb = number_or_arith_raise!(b, line, source, hint_b)
 
     cond do
-      is_integer(nb) and nb == 0 ->
-        raise RuntimeError, value: "attempt to perform 'n//0'", line: line, source: source
+      is_integer(na) and is_integer(nb) and nb == 0 ->
+        raise RuntimeError, value: "attempt to divide by zero", line: line, source: source
 
       is_integer(na) and is_integer(nb) ->
         Numeric.to_signed_int64(lua_idiv(na, nb))
 
-      is_float(nb) and nb == 0.0 ->
+      nb == 0 or nb == 0.0 ->
         cond do
           na == 0 or na == 0.0 -> :nan
           na > 0 -> 1.0e308
@@ -2583,21 +2585,22 @@ defmodule Lua.VM.Executor do
     end
   end
 
-  # Lua 5.3 §3.4.1: `a % b = a - floor(a/b)*b`. With a float zero divisor,
-  # `a/0.0` is inf or nan, and `inf * 0.0 = nan`, so `a % 0.0` is always
-  # `:nan` regardless of `a`. An integer-zero divisor still raises.
+  # Lua 5.3 §3.4.1: `a % b = a - floor(a/b)*b`. With a zero divisor where
+  # either operand is a float, `a/0.0` is inf or nan and `inf * 0.0 = nan`,
+  # so the result is always `:nan` regardless of `a`. Only an integer `%`
+  # integer with a zero divisor raises; PUC-Lua reports it as `'n%0'`.
   defp safe_modulo(a, b, line, source, hint_a, hint_b) do
     na = number_or_arith_raise!(a, line, source, hint_a)
     nb = number_or_arith_raise!(b, line, source, hint_b)
 
     cond do
-      is_integer(nb) and nb == 0 ->
+      is_integer(na) and is_integer(nb) and nb == 0 ->
         raise RuntimeError, value: "attempt to perform 'n%0'", line: line, source: source
 
       is_integer(na) and is_integer(nb) ->
         Numeric.to_signed_int64(na - lua_idiv(na, nb) * nb)
 
-      is_float(nb) and nb == 0.0 ->
+      nb == 0 or nb == 0.0 ->
         :nan
 
       true ->

--- a/test/lua/vm/arithmetic_test.exs
+++ b/test/lua/vm/arithmetic_test.exs
@@ -136,7 +136,7 @@ defmodule Lua.VM.ArithmeticTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       state = State.new()
 
-      assert_raise RuntimeError, ~r/attempt to perform 'n\/\/0'/, fn ->
+      assert_raise RuntimeError, ~r/attempt to divide by zero/, fn ->
         VM.execute(proto, state)
       end
     end
@@ -251,7 +251,7 @@ defmodule Lua.VM.ArithmeticTest do
       state = Stdlib.install(State.new())
       assert {:ok, [false, err], _state} = VM.execute(proto, state)
       assert is_binary(err)
-      assert err =~ "attempt to perform 'n//0'"
+      assert err =~ "attempt to divide by zero"
     end
 
     test "pcall catches comparison TypeError" do

--- a/test/lua/vm/error_format_test.exs
+++ b/test/lua/vm/error_format_test.exs
@@ -58,9 +58,9 @@ defmodule Lua.VM.ErrorFormatTest do
     end
   end
 
-  describe "attempt to perform 'n//0'" do
+  describe "attempt to divide by zero" do
     test "integer floor-divide by zero" do
-      assert_raise LuaRuntimeError, ~r/attempt to perform 'n\/\/0'/, fn ->
+      assert_raise LuaRuntimeError, ~r/attempt to divide by zero/, fn ->
         run("return 1 // 0")
       end
     end

--- a/test/lua/vm/float_div_zero_test.exs
+++ b/test/lua/vm/float_div_zero_test.exs
@@ -10,8 +10,10 @@ defmodule Lua.VM.FloatDivZeroTest do
     * `-1/0` → `-1.0e308`
     * `0/0`  → `:nan` sentinel atom, which compares unequal to itself
 
-  Only `//` and `%` raise on integer-zero divisors (covered elsewhere);
-  this module locks down the `/` contract.
+  `//` and `%` raise only when *both* operands are integers and the
+  divisor is zero; PUC-Lua reports `//` as "attempt to divide by zero"
+  and `%` as `'n%0'`. When either operand is a float the float path
+  applies and no error is raised.
   """
 
   use ExUnit.Case, async: true
@@ -79,8 +81,8 @@ defmodule Lua.VM.FloatDivZeroTest do
   end
 
   describe "floor div and modulo with integer-zero divisor still raise" do
-    test "1 // 0 raises" do
-      assert_raise Lua.RuntimeException, ~r/attempt to perform 'n\/\/0'/, fn ->
+    test "1 // 0 raises with PUC-Lua's 'divide by zero' message" do
+      assert_raise Lua.RuntimeException, ~r/attempt to divide by zero/, fn ->
         Lua.eval!(Lua.new(), "return 1 // 0")
       end
     end
@@ -149,20 +151,20 @@ defmodule Lua.VM.FloatDivZeroTest do
       assert run!("return 0 // 0.0 ~= 0 // 0.0") == [true]
     end
 
-    test "1.0 // 0 still raises — integer divisor" do
-      assert_raise Lua.RuntimeException, ~r/attempt to perform 'n\/\/0'/, fn ->
-        Lua.eval!(Lua.new(), "return 1.0 // 0")
-      end
+    test "1.0 // 0 follows the float path and returns +inf — a float operand never raises" do
+      assert run!("return 1.0 // 0 == math.huge") == [true]
+    end
+
+    test "-1.0 // 0 follows the float path and returns -inf" do
+      assert run!("return -1.0 // 0 == -math.huge") == [true]
     end
 
     test "1 % 0.0 follows the float path and returns NaN" do
       assert run!("return 1 % 0.0 ~= 1 % 0.0") == [true]
     end
 
-    test "1.0 % 0 still raises — integer divisor" do
-      assert_raise Lua.RuntimeException, ~r/attempt to perform 'n%0'/, fn ->
-        Lua.eval!(Lua.new(), "return 1.0 % 0")
-      end
+    test "1.0 % 0 follows the float path and returns NaN — a float operand never raises" do
+      assert run!("return 1.0 % 0 ~= 1.0 % 0") == [true]
     end
   end
 end


### PR DESCRIPTION
## Goal

Fix `//` and `%` zero-divisor handling in the VM to match PUC-Lua 5.3.
This is a concrete sub-fix carved out of the runtime-type triage cluster
(parent plan A21).

## What changed

`lib/lua/vm/executor.ex`:

- `safe_floor_divide/6`: integer `//` zero now raises **"attempt to
  divide by zero"** (the PUC-Lua 5.3 wording the suite checks for),
  not "attempt to perform 'n//0'". The raise now fires only when *both*
  operands are integers.
- `safe_modulo/6`: same both-operands-integer guard; message `'n%0'`
  unchanged (already correct).
- When either operand is a float, a zero divisor takes the float
  (inf/nan) path and never raises: `2.0 // 0` -> +inf, `2.0 % 0` -> nan.

Previously `2.0 // 0` and `2.0 % 0` wrongly raised, diverging from
PUC-Lua. Confirmed against `lua`:

- `2 // 0` -> `attempt to divide by zero`
- `2 % 0` -> `attempt to perform 'n%0'`
- `2.0 // 0` -> `inf`
- `2.0 % 0` -> `nan`

This also satisfies the `checkmessage("a = 24 // 0", "divide by zero")`
idiom in `errors.lua` and `checkcompt("divide by zero", "return 2 // 0")`
in `math.lua`.

## Out of scope

- The `math.huge` / `:nan` finite-sentinel design that keeps `math.lua`
  skipped overall (NaN through bitwise ops is unchanged).
- `os.*` (separate PR #289).

## Success criteria

- [x] `2 // 0` raises with a message containing "divide by zero".
- [x] `2.0 // 0` and `2.0 % 0` do not raise (inf / nan).
- [x] `mix test` passes (2038 passed, 22 skipped).
- [x] `mix test test/lua53_suite_test.exs --only lua53` passes
      (14 passed, 15 skipped — no regressions).

## Verification

```
mix format
mix compile --warnings-as-errors
mix test
mix test test/lua53_suite_test.exs --only lua53
```

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)