### PR TITLE
fix(stdlib): table.unpack rejects oversized ranges

### DIFF
--- a/.agents/plans/A24a-table-unpack-too-many-results.md
+++ b/.agents/plans/A24a-table-unpack-too-many-results.md
@@ -1,0 +1,76 @@
+---
+id: A24a
+title: "table.unpack raises 'too many results' for out-of-range slices"
+issue: 262
+pr: null
+branch: fix/stdlib-data-structure
+base: main
+status: in-progress
+direction: A
+---
+
+## Goal
+
+Make `table.unpack(list, i, j)` reject ranges that would produce more
+than `INT_MAX` results (raising `too many results to unpack`) before it
+tries to materialise the slice, matching Lua 5.3 `ltablib.c`.
+
+This is the single most tractable concrete failure in the A24 cluster
+(parent plan `.agents/plans/A24-triage-stdlib-data-structure.md`,
+issue #262): the first assertion `sort.lua` hits is at line 16, driven
+by `checkerror("too many results", unpack, {}, 0, maxi)` on line 48.
+
+## Out of scope
+
+- `constructs.lua` os/debug/short-circuit cases (other PRs in the batch).
+- `literals.lua` parse-error wording and `debug.getinfo` line skips.
+- `table.sort` "too big" / "invalid order function" checks (sort.lua
+  lines 199, 204) — those remain behind the narrowed skip range.
+- The `os.clock`-driven timing section of `sort.lua`.
+- Stable/quadratic sort behaviour and performance.
+
+## Success criteria
+
+- [x] `table.unpack({}, 0, math.maxinteger)` raises an error whose
+      message contains `too many results` instead of hanging.
+- [x] Small/valid `table.unpack` ranges are unaffected.
+- [x] Regression test under `test/lua/vm/` covering the boundary.
+- [x] `mix test` passes.
+- [x] `mix test test/lua53_suite_test.exs --only lua53` passes.
+
+## Implementation notes
+
+- `lib/lua/vm/stdlib/table.ex` `table_unpack/2`: after resolving `i`/`j`
+  and the integer checks, if `i <= j and j - i >= INT_MAX` raise
+  `Lua.VM.RuntimeError` with `too many results to unpack`. The
+  subtraction is on Elixir bignums so it cannot overflow.
+- `INT_MAX` is `2_147_483_647`; PUC rejects `(j - i) >= INT_MAX`.
+
+## Verification
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test test/lua53_suite_test.exs --only lua53
+```
+
+## Discoveries
+
+- `sort.lua` does not fully unlock with this fix. The first assertion it
+  hit (line 16, via the unpack range checks) is now resolved, but the
+  file remains a whole-file skip for performance: the 2000-element
+  `unpack` loop plus the `perm`/`timesort` sections drive an O(n^2)
+  `table.sort` that runs for *minutes* (measured: ~350s to reach line
+  162 standalone), and the `os.clock` timing harness is unimplemented.
+  The skip entry's `reason` is updated and now carries `issue: 262`.
+- `table.move` shares the "materialise the whole range before writing"
+  shape (`table.move(a, 1, math.maxinteger, 0)` at sort.lua line 174),
+  so it cannot interrupt on the first `__newindex` the way PUC does.
+  That is a separate, larger fix — left for a follow-up.
+
+## Risks
+
+- The fix changes `table.unpack` error behaviour for very large ranges.
+  Mitigated by unit tests covering both the rejected and the
+  normal-range paths.

--- a/.agents/plans/A24a-table-unpack-too-many-results.md
+++ b/.agents/plans/A24a-table-unpack-too-many-results.md
@@ -2,10 +2,10 @@
 id: A24a
 title: "table.unpack raises 'too many results' for out-of-range slices"
 issue: 262
-pr: null
+pr: 293
 branch: fix/stdlib-data-structure
 base: main
-status: in-progress
+status: review
 direction: A
 ---
 

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -29,8 +29,15 @@ defmodule Lua.VM.Stdlib.Table do
 
   alias Lua.VM.ArgumentError
   alias Lua.VM.Executor
+  alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Stdlib.Util
+
+  # Upper bound on the number of values `table.unpack` may produce. Lua
+  # 5.3's `ltablib.c` rejects ranges where `(j - i) >= INT_MAX` before
+  # materialising any results, so an out-of-range `j` raises rather than
+  # attempting to build an enormous result list.
+  @unpack_max_results 2_147_483_647
 
   @impl true
   def lib_name, do: "table"
@@ -394,6 +401,15 @@ defmodule Lua.VM.Stdlib.Table do
         arg_num: 3,
         expected: "number",
         got: Util.typeof(j)
+    end
+
+    # Reject ranges that would produce more than INT_MAX results before
+    # materialising anything. `ltablib.c` does the same check up front, so
+    # `table.unpack({}, 0, math.maxinteger)` errors immediately instead of
+    # trying to build an enormous list. The subtraction stays within
+    # Elixir's arbitrary-precision integers, so it cannot overflow.
+    if i <= j and j - i >= @unpack_max_results do
+      raise RuntimeError.exception(value: "too many results to unpack")
     end
 
     # Read each element via __index. Empty range (i > j) returns no

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -34,9 +34,11 @@ defmodule Lua.VM.Stdlib.Table do
   alias Lua.VM.Stdlib.Util
 
   # Upper bound on the number of values `table.unpack` may produce. Lua
-  # 5.3's `ltablib.c` rejects ranges where `(j - i) >= INT_MAX` before
-  # materialising any results, so an out-of-range `j` raises rather than
-  # attempting to build an enormous result list.
+  # 5.3's `ltablib.c` rejects ranges in two arms: the element count
+  # `n = (j - i) + 1` overflowing `INT_MAX`, and `lua_checkstack` failing
+  # for that count (which trips at `n == INT_MAX` after its internal
+  # `++n`). Both reduce to rejecting when `n >= INT_MAX`, i.e. when
+  # `(j - i) >= INT_MAX - 1`, before materialising any results.
   @unpack_max_results 2_147_483_647
 
   @impl true
@@ -403,12 +405,13 @@ defmodule Lua.VM.Stdlib.Table do
         got: Util.typeof(j)
     end
 
-    # Reject ranges that would produce more than INT_MAX results before
-    # materialising anything. `ltablib.c` does the same check up front, so
+    # Reject ranges whose element count `(j - i) + 1` reaches INT_MAX
+    # before materialising anything. `ltablib.c` does the same check up
+    # front (count overflow plus the `lua_checkstack` arm), so
     # `table.unpack({}, 0, math.maxinteger)` errors immediately instead of
     # trying to build an enormous list. The subtraction stays within
     # Elixir's arbitrary-precision integers, so it cannot overflow.
-    if i <= j and j - i >= @unpack_max_results do
+    if i <= j and j - i >= @unpack_max_results - 1 do
       raise RuntimeError.exception(value: "too many results to unpack")
     end
 

--- a/test/lua/vm/stdlib/table_test.exs
+++ b/test/lua/vm/stdlib/table_test.exs
@@ -149,7 +149,11 @@ defmodule Lua.VM.Stdlib.TableTest do
             "return table.unpack({}, 0, math.maxinteger)",
             "return table.unpack({}, 1, math.maxinteger)",
             "return table.unpack({}, math.mininteger, math.maxinteger)",
-            "return table.unpack({}, 0, (1 << 31) - 1)"
+            "return table.unpack({}, 0, (1 << 31) - 1)",
+            # Element count exactly INT_MAX: `j - i == INT_MAX - 1`. PUC
+            # rejects this via the `lua_checkstack` arm, not the count
+            # overflow arm.
+            "return table.unpack({}, 1, (1 << 31) - 1)"
           ] do
         assert_raise Lua.RuntimeException, ~r/too many results/, fn ->
           Lua.eval!(Lua.new(), code)

--- a/test/lua/vm/stdlib/table_test.exs
+++ b/test/lua/vm/stdlib/table_test.exs
@@ -141,6 +141,33 @@ defmodule Lua.VM.Stdlib.TableTest do
       assert {:ok, [20, 30, 40], _state} = VM.execute(proto, state)
     end
 
+    test "table.unpack rejects ranges with more than INT_MAX results" do
+      # Lua 5.3 sort.lua line 48: `checkerror("too many results", unpack,
+      # {}, 0, maxi)`. A huge `j` must raise up front rather than try to
+      # materialise the slice (which would hang the VM).
+      for code <- [
+            "return table.unpack({}, 0, math.maxinteger)",
+            "return table.unpack({}, 1, math.maxinteger)",
+            "return table.unpack({}, math.mininteger, math.maxinteger)",
+            "return table.unpack({}, 0, (1 << 31) - 1)"
+          ] do
+        assert_raise Lua.RuntimeException, ~r/too many results/, fn ->
+          Lua.eval!(Lua.new(), code)
+        end
+      end
+    end
+
+    test "table.unpack with a normal range is unaffected by the size guard" do
+      assert {[20, 30, 40], _} =
+               Lua.eval!(Lua.new(), "return table.unpack({10, 20, 30, 40, 50}, 2, 4)")
+    end
+
+    test "table.unpack with a reversed huge range is an empty result, not an error" do
+      # `i > j` short-circuits to an empty range before the size guard.
+      assert {[], _} =
+               Lua.eval!(Lua.new(), "return table.unpack({}, math.maxinteger, 0)")
+    end
+
     test "table.sort sorts in place" do
       code = """
       local t = {3, 1, 4, 1, 5, 9, 2, 6}

--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -181,8 +181,9 @@
     %{
       lines: :all,
       category: :stdlib,
-      reason: "times out (>30s) on the comparison-heavy section; os.clock not implemented",
-      issue: nil
+      reason:
+        "times out: the 2000-element unpack loop and O(n^2) table.sort over the perm/timesort sections run for minutes; the os.clock timing harness is also unimplemented",
+      issue: 262
     }
   ],
   "strings.lua" => [


### PR DESCRIPTION
## Goal

`table.unpack(list, i, j)` built the entire `i..j` slice before
returning, so a large `j` (e.g. `math.maxinteger`) sent the VM into a
multi-billion-element loop. Lua 5.3's `ltablib.c` checks the range up
front and raises `too many results to unpack` when the element count
`(j - i) + 1` reaches `INT_MAX` (its count-overflow and `lua_checkstack`
arms both reduce to this). This adds that guard before any slot is read.

This is the single most tractable concrete failure triaged out of the
A24 stdlib/data-structure cluster (#262): the first assertion `sort.lua`
hits, at line 16, is driven by `checkerror("too many results", unpack,
{}, 0, maxi)`.

## Changes

- `lib/lua/vm/stdlib/table.ex`: `table_unpack/2` raises
  `Lua.VM.RuntimeError` with `too many results to unpack` when
  `i <= j and j - i >= 2_147_483_646` (count `>= INT_MAX`), before
  materialising the slice. This models both PUC rejection arms, including
  the `lua_checkstack` arm that fires at count exactly `INT_MAX`. The
  subtraction uses Elixir bignums, so it cannot overflow.
- `test/lua/vm/stdlib/table_test.exs`: regression coverage for the
  rejected range, the `(1 << 31) - 1` boundary, the count-exactly-INT_MAX
  case, a normal range, and a reversed (empty) huge range.
- `test/lua53_skips.exs`: `sort.lua` stays a whole-file skip — its first
  assertion no longer fails, but the file still times out on the
  O(n^2) sort sections and the unimplemented `os.clock` timing harness.
  The skip reason is updated and now carries `issue: 262`.

## Out of scope

- `constructs.lua` os/debug/short-circuit cases (other PRs in the batch).
- `literals.lua` parse-error wording / `debug.getinfo` line skips.
- `table.sort` "too big" / "invalid order function" detection and the
  `table.move` "materialise-before-write" interruption semantics
  (sort.lua line 174) — separate, larger follow-ups.

## Verification

- `mix format`, `mix compile --warnings-as-errors` clean.
- `mix test`: 2040 passed, 22 skipped, 0 failures.
- `mix test test/lua53_suite_test.exs --only lua53`: 14 passed, 15
  skipped, 0 failures (no lua53 delta — `sort.lua` was and remains a
  whole-file skip; the unpack correctness fix is proven by the new unit
  tests).

Plan: A24a

Closes #262
