### PR TITLE
test(vm): pin short-circuit depth-4 semantics; correct constructs skip

### DIFF
--- a/.agents/plans/A45-short-circuit-level4.md
+++ b/.agents/plans/A45-short-circuit-level4.md
@@ -2,10 +2,10 @@
 id: A45
 title: "Bisect constructs.lua short-circuit harness at level=4; pin green, narrow skip"
 issue: 281
-pr: null
+pr: 294
 branch: fix/short-circuit-level4
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - constructs.lua

--- a/.agents/plans/A45-short-circuit-level4.md
+++ b/.agents/plans/A45-short-circuit-level4.md
@@ -1,0 +1,85 @@
+---
+id: A45
+title: "Bisect constructs.lua short-circuit harness at level=4; pin green, narrow skip"
+issue: 281
+pr: null
+branch: fix/short-circuit-level4
+base: main
+status: in-progress
+direction: A
+unlocks:
+  - constructs.lua
+---
+
+# Goal
+
+Bisect the dynamic short-circuit harness at `constructs.lua:287-298` at
+`level=4`, find the smallest failing `((((a op b) op c) op d) op e)`
+composition of `and`/`or`, reduce to a one-line repro, and classify the
+suspected executor short-circuit edge case (register aliasing under
+conditional-jump bytecode, or a `not` precedence wrinkle). Fix the
+executor bug if tractable and land green; otherwise narrow the
+`constructs.lua` skip range with a precise reason + issue and document
+the reduced repro.
+
+# Out of scope
+
+- Implementing the `os` library (`os.time`).
+- `debug.getinfo(..., "n").name` call-stack name introspection.
+- Any feature beyond the short-circuit executor path.
+
+# Findings
+
+The suspected executor short-circuit bug does **not** reproduce. A faithful
+replica of the harness — `createcases` up to `level=4`, the
+`if %s then IX = true end; return %s` program template, run through the
+suite-runner `load` — passes **all 204105 cases** for both `_ENV.GLOB1 = 0`
+and `_ENV.GLOB1 = 1`. The `and`/`or` `test_and`/`test_or` CPS path in the
+executor evaluates deep compositions correctly, including the
+`not(<expr>)` wrapping the harness applies.
+
+The real blockers gating lines 225-313 are upstream of the harness and
+unrelated to short-circuiting:
+
+1. **Line 226** `assert(debug.getinfo(1, "n").name == 'F')` — the VM's
+   `debug.getinfo` always returns `name = nil`; call-stack name
+   introspection is unimplemented.
+2. **Line 237** `_ENV.GLOB1 = math.floor(os.time()) % 2` — `os.time` is
+   nil (the `os` library is essentially unimplemented). `GLOB1` then
+   feeds line 248's `print(... .. _ENV.GLOB1 .. ...)` and the harness
+   leaf `(0==_ENV.GLOB1)`, so line 237 cannot simply be blanked.
+
+Both gate the harness from ever executing inside the suite, which is why
+the range was previously (incorrectly) attributed to a "load()-driven
+short-circuit harness" edge case.
+
+# Success criteria
+
+- A regression test under `test/lua/vm/` pins the level-4 short-circuit
+  harness as green, so a future executor regression at depth 4 is caught.
+- The `constructs.lua` skip entry carries a precise, blocker-by-blocker
+  reason and references issue #281, replacing the stale
+  "load()-driven short-circuit harness" wording.
+- `mix test` and `mix test test/lua53_suite_test.exs --only lua53` pass.
+
+# Implementation notes
+
+- Regression test drives `createcases` up to level 4 against the
+  in-process VM via `Lua.eval!` with `load` available, asserting both the
+  return value and the `IX` side-effect for every case.
+- Skip-range reason rewritten to name the two upstream blockers
+  (`debug.getinfo name`, `os.time`) and to record that the short-circuit
+  harness itself is verified green by the regression test.
+
+# Verification
+
+- `mix format`
+- `mix compile --warnings-as-errors`
+- `mix test`
+- `mix test test/lua53_suite_test.exs --only lua53`
+
+# Risks
+
+- Low. No executor code changes; the change is a regression test plus a
+  documentation-accurate skip reason. The harness behaviour is already
+  correct, so the test should stay green.

--- a/test/lua/vm/short_circuit_test.exs
+++ b/test/lua/vm/short_circuit_test.exs
@@ -1,0 +1,144 @@
+defmodule Lua.VM.ShortCircuitTest do
+  use ExUnit.Case, async: true
+
+  # Pins Lua 5.3 §3.4.5 short-circuit semantics for `and`/`or` under deep
+  # left-associative composition — `((((a op b) op c) op d) op e)` and the
+  # `not(...)` wrapping of each such expression.
+  #
+  # `and` returns its first operand if that operand is falsy, otherwise its
+  # second; `or` returns its first operand if truthy, otherwise its second.
+  # Only `nil` and `false` are falsy. The executor compiles these to
+  # `test_and` / `test_or` conditional-jump bytecode; the cases below guard
+  # against register aliasing across the conditional branch and against a
+  # `not` precedence wrinkle when the depth-4 chains nest.
+
+  defp eval!(code) do
+    {results, _state} = Lua.eval!(Lua.new(sandboxed: []), code)
+    results
+  end
+
+  describe "explicit depth-4 left-associative compositions" do
+    # Each tuple: {expression, expected_value}. Expected values are the Lua
+    # 5.3 results, computed by hand from the short-circuit rules above.
+    cases = [
+      {"(((10 and 20) and 30) and 40) and 50", 50},
+      {"(((nil and 20) and 30) and 40) and 50", nil},
+      {"(((false or nil) or false) or 10) or 20", 10},
+      {"(((nil or false) or nil) or false) or 99", 99},
+      {"(((10 and nil) or 20) and 30) or 40", 30},
+      {"(((false and 1) or (nil and 2)) or 3) and 4", 4},
+      {"(((10 or error()) and 20) or error()) and 30", 30},
+      {"(((nil and error()) or 5) and 6) or error()", 6},
+      {"(((true and false) or true) and false) or true", true},
+      {"(((1 and 2) and 3) and 4) or 5", 4}
+    ]
+
+    for {expr, expected} <- cases do
+      test "#{expr} == #{inspect(expected)}" do
+        assert [unquote(Macro.escape(expected))] = eval!("return #{unquote(expr)}")
+      end
+    end
+  end
+
+  describe "not(...) wrapping a depth-4 chain" do
+    test "not flips the truthiness of the composed result" do
+      assert [true] = eval!("return not((((nil and 2) and 3) and 4) and 5)")
+      assert [false] = eval!("return not((((10 or 2) or 3) or 4) or 5)")
+      assert [false] = eval!("return not((((false or nil) or 0) or 4) or 5)")
+    end
+  end
+
+  describe "if-condition side effect matches the expression value" do
+    # Mirrors the constructs.lua harness shape: a deep `and`/`or` expression
+    # is used both as an `if` condition (a side-effecting branch) and as the
+    # returned value; the branch must fire iff the value is truthy.
+    test "branch fires exactly when the composed value is truthy" do
+      [taken?, value] =
+        eval!("""
+        local taken = false
+        local expr = (((10 and nil) or 20) and 30) or 40
+        if expr then taken = true end
+        return taken, expr
+        """)
+
+      assert value == 30
+      assert taken? == true
+    end
+
+    test "branch is skipped when the composed value is falsy" do
+      [taken?, value] =
+        eval!("""
+        local taken = false
+        local expr = (((10 and nil) and 20) and 30) and 40
+        if expr then taken = true end
+        return taken, expr
+        """)
+
+      assert value == nil
+      assert taken? == false
+    end
+  end
+
+  describe "generative harness (constructs.lua level 3)" do
+    # Faithful in-process replica of the constructs.lua short-circuit
+    # harness, built from the same `createcases` generator. Level 3 builds
+    # every `((a op b) op c)` composition (and its `not` wrapping) over the
+    # five basic cases, then asserts both the returned value and the `IX`
+    # branch side effect against a precomputed truth table. The full level-4
+    # run (204105 cases) passes identically but is too slow for the default
+    # suite; level 3 (4105 cases) pins the generative property here.
+    @harness ~S"""
+    _ENV.GLOB1 = 1
+    local basiccases = {
+      {"nil", nil},
+      {"false", false},
+      {"true", true},
+      {"10", 10},
+      {"(0==_ENV.GLOB1)", 0 == _ENV.GLOB1},
+    }
+    local binops = {
+      {" and ", function (a,b) if not a then return a else return b end end},
+      {" or ", function (a,b) if a then return a else return b end end},
+    }
+    local cases = {}
+    local function createcases (n)
+      local res = {}
+      for i = 1, n - 1 do
+        for _, v1 in ipairs(cases[i]) do
+          for _, v2 in ipairs(cases[n - i]) do
+            for _, op in ipairs(binops) do
+                local t = {
+                  "(" .. v1[1] .. op[1] .. v2[1] .. ")",
+                  op[2](v1[2], v2[2])
+                }
+                res[#res + 1] = t
+                res[#res + 1] = {"not" .. t[1], not t[2]}
+            end
+          end
+        end
+      end
+      return res
+    end
+    local level = 3
+    cases[1] = basiccases
+    for i = 2, level do cases[i] = createcases(i) end
+    local prog = [[if %s then IX = true end; return %s]]
+    local count = 0
+    for n = 1, level do
+      for _, v in pairs(cases[n]) do
+        local s = v[1]
+        local p = load(string.format(prog, s, s), "")
+        IX = false
+        local r = p()
+        assert(r == v[2] and IX == not not v[2], s)
+        count = count + 1
+      end
+    end
+    return count
+    """
+
+    test "every level-3 composition matches its value and branch side effect" do
+      assert [4105] = eval!(@harness)
+    end
+  end
+end

--- a/test/lua/vm/short_circuit_test.exs
+++ b/test/lua/vm/short_circuit_test.exs
@@ -8,9 +8,10 @@ defmodule Lua.VM.ShortCircuitTest do
   # `and` returns its first operand if that operand is falsy, otherwise its
   # second; `or` returns its first operand if truthy, otherwise its second.
   # Only `nil` and `false` are falsy. The executor compiles these to
-  # `test_and` / `test_or` conditional-jump bytecode; the cases below guard
-  # against register aliasing across the conditional branch and against a
-  # `not` precedence wrinkle when the depth-4 chains nest.
+  # `test_and` / `test_or` conditional-jump bytecode. The suspected hazards
+  # were register aliasing across the conditional branch and a `not`
+  # precedence wrinkle when the depth-4 chains nest; the cases below confirm
+  # both are handled correctly.
 
   defp eval!(code) do
     {results, _state} = Lua.eval!(Lua.new(sandboxed: []), code)
@@ -79,66 +80,75 @@ defmodule Lua.VM.ShortCircuitTest do
     end
   end
 
-  describe "generative harness (constructs.lua level 3)" do
+  describe "generative harness (constructs.lua)" do
     # Faithful in-process replica of the constructs.lua short-circuit
-    # harness, built from the same `createcases` generator. Level 3 builds
-    # every `((a op b) op c)` composition (and its `not` wrapping) over the
-    # five basic cases, then asserts both the returned value and the `IX`
-    # branch side effect against a precomputed truth table. The full level-4
-    # run (204105 cases) passes identically but is too slow for the default
-    # suite; level 3 (4105 cases) pins the generative property here.
-    @harness ~S"""
-    _ENV.GLOB1 = 1
-    local basiccases = {
-      {"nil", nil},
-      {"false", false},
-      {"true", true},
-      {"10", 10},
-      {"(0==_ENV.GLOB1)", 0 == _ENV.GLOB1},
-    }
-    local binops = {
-      {" and ", function (a,b) if not a then return a else return b end end},
-      {" or ", function (a,b) if a then return a else return b end end},
-    }
-    local cases = {}
-    local function createcases (n)
-      local res = {}
-      for i = 1, n - 1 do
-        for _, v1 in ipairs(cases[i]) do
-          for _, v2 in ipairs(cases[n - i]) do
-            for _, op in ipairs(binops) do
-                local t = {
-                  "(" .. v1[1] .. op[1] .. v2[1] .. ")",
-                  op[2](v1[2], v2[2])
-                }
-                res[#res + 1] = t
-                res[#res + 1] = {"not" .. t[1], not t[2]}
+    # harness, built from the same `createcases` generator. Each level builds
+    # every nested `op` composition (and its `not` wrapping) over the five
+    # basic cases, then asserts both the returned value and the `IX` branch
+    # side effect against a precomputed truth table. Level 3 (4105 cases)
+    # pins the generative property in the default suite. Level 4 (204105
+    # cases) is the exact surface the suite default exercises but is too slow
+    # for every run; it is tagged `:slow` and excluded by default.
+    defp harness(level) do
+      ~s"""
+      _ENV.GLOB1 = 1
+      local basiccases = {
+        {"nil", nil},
+        {"false", false},
+        {"true", true},
+        {"10", 10},
+        {"(0==_ENV.GLOB1)", 0 == _ENV.GLOB1},
+      }
+      local binops = {
+        {" and ", function (a,b) if not a then return a else return b end end},
+        {" or ", function (a,b) if a then return a else return b end end},
+      }
+      local cases = {}
+      local function createcases (n)
+        local res = {}
+        for i = 1, n - 1 do
+          for _, v1 in ipairs(cases[i]) do
+            for _, v2 in ipairs(cases[n - i]) do
+              for _, op in ipairs(binops) do
+                  local t = {
+                    "(" .. v1[1] .. op[1] .. v2[1] .. ")",
+                    op[2](v1[2], v2[2])
+                  }
+                  res[#res + 1] = t
+                  res[#res + 1] = {"not" .. t[1], not t[2]}
+              end
             end
           end
         end
+        return res
       end
-      return res
-    end
-    local level = 3
-    cases[1] = basiccases
-    for i = 2, level do cases[i] = createcases(i) end
-    local prog = [[if %s then IX = true end; return %s]]
-    local count = 0
-    for n = 1, level do
-      for _, v in pairs(cases[n]) do
-        local s = v[1]
-        local p = load(string.format(prog, s, s), "")
-        IX = false
-        local r = p()
-        assert(r == v[2] and IX == not not v[2], s)
-        count = count + 1
+      local level = #{level}
+      cases[1] = basiccases
+      for i = 2, level do cases[i] = createcases(i) end
+      local prog = [[if %s then IX = true end; return %s]]
+      local count = 0
+      for n = 1, level do
+        for _, v in pairs(cases[n]) do
+          local s = v[1]
+          local p = load(string.format(prog, s, s), "")
+          IX = false
+          local r = p()
+          assert(r == v[2] and IX == not not v[2], s)
+          count = count + 1
+        end
       end
+      return count
+      """
     end
-    return count
-    """
 
     test "every level-3 composition matches its value and branch side effect" do
-      assert [4105] = eval!(@harness)
+      assert [4105] = eval!(harness(3))
+    end
+
+    @tag :slow
+    @tag timeout: :infinity
+    test "every level-4 composition matches its value and branch side effect" do
+      assert [204_105] = eval!(harness(4))
     end
   end
 end

--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -88,8 +88,8 @@
       lines: 225..313,
       category: :unimplemented,
       reason:
-        "debug.getinfo(...).name / os.time / load()-driven short-circuit harness exercised below line 225; pending separate triage",
-      issue: nil
+        "two upstream blockers gate this block: debug.getinfo(1,\"n\").name returns nil (call-stack name introspection unimplemented) at line 226, and os.time is nil at line 237 (feeds _ENV.GLOB1, used by line 248 and the short-circuit harness leaf). The short-circuit harness itself (287-298) is verified green up to level 4 by test/lua/vm/short_circuit_test.exs",
+      issue: 281
     }
   ],
   "coroutine.lua" => [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:slow])


### PR DESCRIPTION
## Summary

Bisected the `constructs.lua` short-circuit harness (lines 287-298) at
`level=4`, as flagged in #281. The suspected executor short-circuit bug
(register aliasing under conditional-jump bytecode, or a `not` precedence
wrinkle) **does not reproduce**.

A faithful in-process replica of the harness — `createcases` up to
`level=4`, the `if %s then IX = true end; return %s` program template, run
through `load` — passes **all 204105 cases** for both `_ENV.GLOB1 = 0` and
`_ENV.GLOB1 = 1`. The `test_and`/`test_or` CPS path in the executor
evaluates deep `((((a op b) op c) op d) op e)` compositions and their
`not(...)` wrappings correctly.

## Reduced findings

The real blockers gating `constructs.lua` lines 225-313 are upstream of the
harness and unrelated to short-circuiting:

1. **Line 226** `assert(debug.getinfo(1, "n").name == 'F')` — `debug.getinfo`
   always returns `name = nil`; call-stack name introspection is
   unimplemented.
2. **Line 237** `_ENV.GLOB1 = math.floor(os.time()) % 2` — `os.time` is nil
   (the `os` library is essentially unimplemented). `GLOB1` then feeds line
   248's concat and the harness leaf `(0==_ENV.GLOB1)`, so line 237 cannot
   simply be blanked.

Both are out of scope for this issue, which targeted the short-circuit
executor path. This is therefore the "otherwise" branch of #281: no
tractable executor fix, so the skip reason is corrected and the harness is
pinned green by a regression test.

## Changes

- `test/lua/vm/short_circuit_test.exs` — new regression test pinning the
  short-circuit semantics: explicit depth-4 `and`/`or` chains, `not`
  wrapping, the if-condition side-effect shape, and the level-3 generative
  harness (4105 cases). The full level-4 run (204105 cases) passes
  identically but is too slow for the default suite.
- `test/lua53_skips.exs` — `constructs.lua` skip reason rewritten to name
  the two upstream blockers and reference the issue; previously it wrongly
  implicated a "load()-driven short-circuit harness" edge case.

## Why draft

Per #281, the directive was to fix the executor bug if tractable, otherwise
narrow the skip with a precise reason and open a draft documenting the
reduced repro. The executor is correct, so there is no fix to land; this PR
documents that and pins it. Opened as draft for review of the
classification before the skip-reason correction merges.

## Validation

- `mix format`
- `mix compile --warnings-as-errors`
- `mix test` — 2051 passed, 22 skipped
- `mix test test/lua53_suite_test.exs --only lua53` — 14 passed, 15 skipped (no delta; constructs.lua stays skipped with an accurate reason)

Plan: A45

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)