### PR TITLE
test(suite): split pm.lua skip into precise sub-ranges

### DIFF
--- a/test/lua53_skips.exs
+++ b/test/lua53_skips.exs
@@ -182,10 +182,45 @@
   ],
   "pm.lua" => [
     %{
-      lines: 233..374,
+      lines: 233..238,
       category: :unimplemented,
-      reason:
-        "gsub capture-index/replacement error validation, 'pattern too complex' depth limit, %b balanced match, %f frontier, and %1-%9 backreferences not yet implemented; position capture passes through line 232",
+      reason: "gsub capture-index/replacement-value error validation not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 250..250,
+      category: :unimplemented,
+      reason: "'pattern too complex' recursion-depth limit not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 277..277,
+      category: :unimplemented,
+      reason: "gsub table replacement keyed on a multi-char capture not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 280..280,
+      category: :unimplemented,
+      reason: "gsub position-capture index into a replacement table not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 283..283,
+      category: :unimplemented,
+      reason: "gsub replacement via a table __index metamethod not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 312..339,
+      category: :unimplemented,
+      reason: "%f frontier pattern not yet implemented",
+      issue: 257
+    },
+    %{
+      lines: 341..358,
+      category: :unimplemented,
+      reason: "malformed-pattern error reporting (unfinished capture, %b, %f, trailing %) not yet implemented",
       issue: 257
     }
   ],


### PR DESCRIPTION
## Land the pm.lua skip refinement stranded by #288's early merge

Follow-up to #257 / #288. PR #288 (position-capture) merged before its
review-feedback pass completed, so this refinement to `test/lua53_skips.exs`
never reached `main` — `main` still carries the broad `pm.lua` skip
`233..374`.

### What this does

Replaces the single broad `233..374` skip with seven precise, empirically
bisected sub-ranges, recovering ~86 lines of genuine `pm.lua` coverage that
the broad range was masking:

- recursive `gsub`
- `gsub` with table replacement
- `gmatch`
- magic-char-after-`\0` tests

Genuine-failure clusters stay skipped honestly as whole blocks (the `%f`
frontier block and the malformed-pattern error-reporting block) rather than
masking only their helper-assert lines — which would let calls like
`malform("%b")` vacuously pass.

### Verification

```
mix test test/lua53_suite_test.exs --only lua53
# Result: 16 passed, 13 skipped, 0 failures
```

Skip-list-only change; no source or behavior change.