### PR TITLE
docs(readme): rewrite for 1.0 positioning, quickstart, and tour

### DIFF
--- a/.agents/plans/A31-readme-rewrite.md
+++ b/.agents/plans/A31-readme-rewrite.md
@@ -2,10 +2,10 @@
 id: A31
 title: README rewrite for 1.0 positioning, quickstart, and tour
 issue: 265
-pr: null
+pr: 298
 branch: docs/readme-rewrite
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - "first-impression" of the library on Hex/GitHub
@@ -222,3 +222,28 @@ listed above.
 - Version is `1.0.0-rc.0` and suite coverage is 6/29 (ROADMAP,
   2026-05-21). Coverage section links ROADMAP for the live count
   rather than hardcoding it.
+- The public runtime exception is `Lua.RuntimeException` (fields
+  `:line`, `:source`, `:message`, `:call_stack`, `:state`,
+  `:original`), not the internal `Lua.VM.RuntimeError`. The Tour's
+  error snippets use the public type.
+- Specific sandboxed ops are allowed via the `:exclude` option, e.g.
+  `Lua.new(exclude: [[:os, :getenv]])`.
+- `{:userdata, term}` round-trips directly through `Lua.set!/3`; no
+  explicit `Lua.encode!/2` is required for the Tour snippet.
+
+## What changed
+
+- `README.md` — full rewrite. New structure: badges + `<!-- MDOC !-->`
+  marker (preserved) + one-line pitch and positioning paragraph;
+  Installation; Quickstart (doctested); Tour (errors with source/line +
+  `pcall`, calling Elixir from Lua, userdata, sandboxing, metatables);
+  Coverage and status (supported subsystems + named non-goals, links
+  `ROADMAP.md`); Examples (six A30 paths + index, absolute `blob/main`
+  links); Documentation; Compatibility and credits (vs Luerl); License.
+  201 lines, under the ~250 target.
+- `.agents/plans/A31-readme-rewrite.md` — plan lifecycle: stub →
+  in-progress → review.
+- No suite delta (docs-only change). `mix test`: 2096 passed, 0 failed.
+  `mix docs` builds with no warnings.
+- Cross-PR link dependency: the `examples/` links resolve once sibling
+  PR A30 (`docs/examples`) merges to `main`.

--- a/.agents/plans/A31-readme-rewrite.md
+++ b/.agents/plans/A31-readme-rewrite.md
@@ -1,70 +1,138 @@
 ---
 id: A31
 title: README rewrite for 1.0 positioning, quickstart, and tour
-issue: null
+issue: 265
 pr: null
 branch: docs/readme-rewrite
 base: main
-status: blocked
+status: in-progress
 direction: A
 unlocks:
   - "first-impression" of the library on Hex/GitHub
 ---
-
-## Blocked on
-
-- A30 — README links to examples; those need to exist first.
 
 ## Goal
 
 Rewrite the README for the 1.0 audience. The current README is
 serviceable but reads like internal docs. The 1.0 README should:
 
-1. **Position** in one paragraph: native Elixir Lua 5.3, no NIFs, for
-   sandboxed embedding.
+1. **Position** in one paragraph: native Elixir Lua 5.3, no NIFs / no C
+   / no Erlang runtime dependency, for sandboxed embedding.
 2. **Quickstart** that compiles and runs in 30 seconds.
 3. **Tour** of the killer features: error messages with source/line,
-   metamethods, userdata, sandboxing.
+   calling Elixir from Lua, userdata, sandboxing, metatables.
 4. **Status & coverage** honestly: which parts of Lua 5.3 are
    supported, which suite files pass, what's deliberately not
-   supported (e.g. `os.execute`).
+   supported (e.g. `os.execute`, file I/O).
 5. **Links** to examples, guides, and the changelog.
 
 ## Out of scope
 
-- Long-form tutorials (those go in `guides/`).
-- API reference content (that's `mix docs`).
+- Long-form tutorials (those live in `guides/`).
+- API reference content (that's `mix docs` / hexdocs).
 - Marketing copy or testimonials.
+- Creating the `examples/` files themselves — that is plan A30,
+  shipping in a sibling PR. This plan only *links* to those paths.
+- Splitting coverage into `guides/coverage.md` (deferred; only do it
+  if the inline list becomes unwieldy, and note in Discoveries).
 
 ## Success criteria
 
 - [ ] README opens with a one-sentence pitch and a one-paragraph
       "what is this".
+- [ ] The `<!-- MDOC !-->` marker is preserved in its current position
+      so `Lua`'s `@moduledoc` (sourced from this file in `lib/lua.ex`)
+      still resolves to the content after the marker.
 - [ ] Quickstart section: install snippet for `mix.exs`, then a 5-10
-      line "your first Lua eval" block that demonstrably works.
+      line "your first Lua eval" block. The eval snippet is a working
+      doctest (`iex>` form) so `mix test` exercises it.
 - [ ] Tour section: 4-6 short subsections with code snippets:
       - [ ] Error messages with source/line.
-      - [ ] Calling Elixir functions from Lua.
-      - [ ] Userdata.
-      - [ ] Sandboxing (default and customization).
+      - [ ] Calling Elixir functions from Lua (`Lua.set!/3` +
+            `deflua`).
+      - [ ] Userdata (`{:userdata, term}` round-trip).
+      - [ ] Sandboxing (default sandbox + how to allow specific
+            `os.*` ops explicitly).
       - [ ] (optional) Metatables and metamethods.
 - [ ] "Coverage and status" section: lists supported subsystems and
-      explicitly names what's not in scope (`os.execute`, etc.). If
-      the suite gate from A20 lands first, link to that decision.
-- [ ] "Examples" section: links every file in `examples/` with a
-      one-line description.
-- [ ] "Compatibility" or "vs Luerl" subsection: brief honest
-      comparison. Errors are better; perf is comparable
-      (post-perf-track); pure-Elixir; no shared mutable state.
-- [ ] All snippets in the README run as-is (or are doctested in
-      `lib/lua.ex` and the README references them).
-- [ ] Project status badge / Hex badge present.
+      explicitly names what's not in scope (`os.execute`, file I/O,
+      coroutines, GC/weak tables). States coverage qualitatively and
+      links the suite-status decision rather than hardcoding a brittle
+      pass count.
+- [ ] "Examples" section: links the six canonical A30 example files
+      with a one-line description each (see Implementation notes for
+      exact paths). Links resolve once A30 merges.
+- [ ] "Compatibility" / "vs Luerl" subsection: brief honest
+      comparison — pure-Elixir, no shared mutable state, better error
+      messages, perf comparable (post-perf-track). Reuse the Credits
+      framing already in the README.
+- [ ] Every doctested snippet in the README still passes `mix test`.
+- [ ] Hex / Hexdocs / CI / license badges present near the top.
 - [ ] `mix docs` still builds clean.
 
 ## Implementation notes
 
 Keep the README under ~250 lines. Push depth to `guides/` and
 `examples/`. The README is the trailer, not the movie.
+
+### CRITICAL: README is the source of `Lua`'s `@moduledoc`
+
+`lib/lua.ex` (lines 1-7) does:
+
+```elixir
+external_resource = "README.md"
+
+defmodule Lua do
+  @moduledoc external_resource
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
+```
+
+Consequences the rewrite MUST respect:
+
+- The literal marker `<!-- MDOC !-->` must remain exactly once, after
+  the `# Lua` title/badges and before the body. Everything after it
+  becomes the module doc shown on hexdocs. If the marker is removed or
+  duplicated, `mix docs` and compilation of `lib/lua.ex` break.
+- The indented `iex>` blocks (e.g. `iex> {[4], _} = Lua.eval!("return
+  2 + 2")`) are real doctests executed by `mix test`. Any snippet
+  written in `iex>` form must be valid and pass. Snippets that are not
+  meant to be doctested should stay in fenced ```` ```elixir ```` blocks
+  (the current README already mixes both deliberately).
+
+### Decoupling from A30 (the former blocker)
+
+A30 (`docs/examples`, sibling PR) creates the `examples/` directory.
+Those files are NOT in this worktree. Link to the exact paths A30's
+plan defines — they resolve once both PRs merge to `main`. Link only
+the six **non-optional** files so there are no dangling links if A30
+drops the optional bonus examples:
+
+- `examples/01_quickstart.exs` — eval some Lua, get the result.
+- `examples/02_userdata.exs` — pass an Elixir struct as userdata, call
+  methods on it from Lua.
+- `examples/03_custom_stdlib.exs` — add an Elixir-defined function to
+  the state, call it from Lua.
+- `examples/04_sandboxing.exs` — default sandbox + allowing specific
+  `os.*` ops explicitly.
+- `examples/05_chunks.exs` — compile once, eval many times.
+- `examples/06_error_handling.exs` — `pcall`, structured exception
+  fields, source/line attribution.
+- `examples/README.md` — index of the above.
+
+Do not link `07_metatables.exs` / `08_repl.exs` (A30 marks them
+optional). Link the `examples/README.md` index as the umbrella entry.
+
+### Coverage section
+
+Per `ROADMAP.md` (2026-05-21): 6/29 official Lua 5.3 suite files pass,
+version is `1.0.0-rc.0`. State this qualitatively (supported
+subsystems + named non-goals) and link `ROADMAP.md` for the live
+count rather than baking `6/29` into the README, where it will rot.
+Named non-goals to call out: standalone interpreter / `os.execute`,
+file I/O (`io.*` is a stub by design), filesystem `require`,
+coroutines, GC / weak tables, full `debug` library.
 
 ### Suggested structure
 
@@ -73,46 +141,30 @@ Keep the README under ~250 lines. Push depth to `guides/` and
 
 [badges]
 
-One-sentence pitch.
+<!-- MDOC !-->
 
+One-sentence pitch.
 One-paragraph "what is this".
 
-## Installation
-
-mix.exs snippet.
-
-## Quickstart
-
-5-10 line "first Lua eval" example.
-
+## Installation        (mix.exs snippet)
+## Quickstart          (5-10 line first eval, doctested)
 ## Tour
-
-### Error messages with source and line
-### Calling Elixir from Lua
-### Userdata
-### Sandboxing
-### Compatibility with Lua 5.3
-
-## Coverage
-
-What's supported, what's not, link to suite status.
-
-## Examples
-
-Links to `examples/*.exs`.
-
-## Documentation
-
-Link to `mix docs` output / hexdocs.
-
+  ### Error messages with source and line
+  ### Calling Elixir from Lua
+  ### Userdata
+  ### Sandboxing
+  ### Metatables (optional)
+## Coverage            (supported / not supported, link ROADMAP)
+## Examples            (links to examples/*.exs from A30)
+## Documentation       (hexdocs, guides/working-with-lua.livemd)
+## Compatibility / Credits (vs Luerl)
 ## License
 ```
 
 ### Files
 
-- `README.md` — full rewrite.
-- `guides/coverage.md` (new, optional) — long-form coverage doc if
-  the README list gets unwieldy.
+- `README.md` — full rewrite. Preserve the `<!-- MDOC !-->` marker and
+  keep all `iex>` doctests valid.
 
 ## Verification
 
@@ -123,19 +175,50 @@ mix test
 mix docs
 ```
 
+`mix test` must pass because the README's `iex>` snippets are
+doctests for `Lua`. `mix docs` must build clean because `Lua`'s
+`@moduledoc` is sourced from `README.md` after the `<!-- MDOC !-->`
+marker.
+
 Manual: read the README top-to-bottom from a "first time looking at
-this library" mindset. Does the path from "should I use this?" to
-"my first eval" take more than 60 seconds? If yes, tighten.
+this library" mindset. Does the path from "should I use this?" to "my
+first eval" take more than 60 seconds? If yes, tighten. Spot-check
+that every `examples/...` link points at one of the six A30 paths
+listed above.
 
 ## Risks
 
-- Drift between snippets in README and actual API. Mitigation: the
-  snippets in the Tour should mirror examples in `examples/` 1:1, so
-  there's only one place to update.
-- "Coverage" section can become a moving target. Defer the precise
-  numbers until A20-A24 triage clusters land. State the gate
-  qualitatively until then.
+- **README is load-bearing for `@moduledoc` and doctests.** Removing or
+  duplicating the `<!-- MDOC !-->` marker, or breaking an `iex>`
+  snippet, fails `mix test` / `mix docs`. Mitigation: the Verification
+  step runs both; preserve the marker and validate every doctest.
+- **Cross-PR link dependency.** The `examples/` links are dead until
+  A30 merges. Mitigation: link the exact stable paths from A30's plan;
+  link only the six non-optional files; reviewers merge both PRs in
+  this batch.
+- Drift between snippets in README and actual API. Mitigation: Tour
+  snippets mirror the `examples/` files 1:1 so there's a single place
+  to update.
+- "Coverage" section can become a moving target. Mitigation: state the
+  status qualitatively and link `ROADMAP.md` for the live suite count
+  instead of hardcoding numbers.
 
 ## Discoveries
 
-(populated during implementation)
+- **README.md is the source of `Lua`'s `@moduledoc`.** `lib/lua.ex`
+  reads `README.md`, splits on `<!-- MDOC !-->`, and uses everything
+  after the marker as the module doc. The indented `iex>` blocks are
+  doctests run by `mix test`. The rewrite must preserve the marker and
+  keep the doctests valid; `mix test` + `mix docs` are part of
+  Verification for this reason.
+- **Cross-PR link dependency (former blocker, now resolved).** This
+  plan was `blocked` on A30 because the README links to `examples/`.
+  A30 ships as a sibling PR in this batch, so its files are absent from
+  this worktree. Decoupled by linking the exact stable paths A30's plan
+  defines (`examples/01_quickstart.exs` … `examples/06_error_handling.exs`,
+  `examples/README.md`); the links resolve once both PRs land on
+  `main`. Optional A30 examples (`07_metatables.exs`, `08_repl.exs`)
+  are intentionally not linked to avoid dangling links.
+- Version is `1.0.0-rc.0` and suite coverage is 6/29 (ROADMAP,
+  2026-05-21). Coverage section links ROADMAP for the live count
+  rather than hardcoding it.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ try do
   """)
 rescue
   e in Lua.RuntimeException ->
-    e.line   # => 2
-    e.source # => "something went wrong"
+    e.line    # => 2
+    e.source  # => "<eval>" (chunk name)
+    e.message # => "Lua runtime error: ...something went wrong..."
 end
 ```
 
@@ -109,7 +110,7 @@ but cannot inspect or dereference it:
 
 ```elixir
 Lua.eval!(~S[os.execute("rm -rf /")])
-# ** (Lua.RuntimeException) os.execute(_) is sandboxed
+# ** (Lua.RuntimeException) Lua runtime error: os.execute(_) is sandboxed
 ```
 
 To allow a specific operation, exclude it from the sandbox explicitly:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Embed a sandboxed Lua 5.3 scripting runtime in your Elixir application — no NI
 `Lua` is a Lua 5.3 virtual machine implemented entirely in Elixir. The lexer,
 parser, register-based VM, and standard library all run directly on the BEAM,
 so there is nothing to compile and no foreign code in your release. It exists
-to let you safely run untrusted scripts — game logic, user-defined rules,
-configuration, plugins — with a small, idiomatic Elixir API for passing data
-and functions across the boundary. Scripts are sandboxed by default, errors
-carry source and line information, and each `Lua` value is plain immutable
-Elixir state with no shared mutable globals.
+to let you safely run untrusted scripts — AI-agent–authored code, game logic,
+user-defined rules, configuration, plugins — with a small, idiomatic Elixir API
+for passing data and functions across the boundary. Giving an AI agent a
+sandboxed runtime where it can only call the Elixir functions you expose is a
+primary use case. Scripts are sandboxed by default, errors carry source and
+line information, and each `Lua` value is plain immutable Elixir state with no
+shared mutable globals.
 
 ## Installation
 
@@ -144,12 +146,14 @@ encoding/decoding, varargs, multiple returns, `_G`/`_ENV`, metatables, the
 string-pattern engine (`find`/`match`/`gmatch`/`gsub`), and the `string`,
 `table`, `math`, `os`, and `debug` standard libraries are implemented.
 
-As a sandboxed *embedded* VM, several capabilities are deliberate non-goals
-rather than missing features:
+As a sandboxed *embedded* VM, some standalone-interpreter behavior is a
+deliberate non-goal rather than a missing feature:
 
-- **Standalone interpreter / `os.execute`** — there is no shell-out.
-- **File I/O** — `io.*` is a stub by design.
-- **Filesystem `require`** — modules are not loaded from disk.
+- **Standalone interpreter / `os.execute`** — there is no shell-out to the host.
+- **Host filesystem access** — `Lua` does not read your host filesystem. The
+  `io.*` library and `require`/`dofile` do not touch disk; file-backed scripts
+  and modules are resolved through `Lua`'s own controlled layer rather than the
+  host OS.
 - **Coroutines**, **garbage collection / weak tables**, and the **full
   `debug` library**.
 

--- a/README.md
+++ b/README.md
@@ -1,217 +1,201 @@
 # Lua
 
+[![Hex.pm](https://img.shields.io/hexpm/v/lua.svg)](https://hex.pm/packages/lua)
+[![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/lua)
+[![CI](https://github.com/tv-labs/lua/actions/workflows/ci.yml/badge.svg)](https://github.com/tv-labs/lua/actions/workflows/ci.yml)
+[![License](https://img.shields.io/hexpm/l/lua.svg)](https://github.com/tv-labs/lua/blob/main/LICENSE)
+
 <!-- MDOC !-->
 
-`Lua` is an Elixir-native Lua 5.3 virtual machine. It runs Lua code on the BEAM
-with no Erlang or C dependencies, and exposes an ergonomic Elixir API for
-embedding Lua scripting in your application.
+Embed a sandboxed Lua 5.3 scripting runtime in your Elixir application — no NIFs, no C, no Erlang runtime dependency.
 
-## Features
+`Lua` is a Lua 5.3 virtual machine implemented entirely in Elixir. The lexer,
+parser, register-based VM, and standard library all run directly on the BEAM,
+so there is nothing to compile and no foreign code in your release. It exists
+to let you safely run untrusted scripts — game logic, user-defined rules,
+configuration, plugins — with a small, idiomatic Elixir API for passing data
+and functions across the boundary. Scripts are sandboxed by default, errors
+carry source and line information, and each `Lua` value is plain immutable
+Elixir state with no shared mutable globals.
 
-* Pure-Elixir implementation of Lua 5.3 — lexer, parser, register-based VM,
-  and standard library — running directly on the BEAM
-* `~LUA` sigil for validating (and optionally pre-compiling) Lua code at
-  compile time
-* `deflua` macro for exposing Elixir functions to Lua
-* Beautiful error messages and stack traces
-* Sandboxing of stdlib paths
-* Deep setting/getting of variables and state from Elixir
-* Pattern-matching, metatables, varargs, multiple returns, `_G`/`_ENV`,
-  `string`/`table`/`math`/`debug` libraries, and the `string.find`/`match`/
-  `gmatch`/`gsub` pattern engine
+## Installation
 
-> #### Lua the Elixir library vs Lua the language {: .info}
-> When referring to this library, `Lua` will be stylized as a link.
->
-> References to Lua the language will be in plaintext and not linked.
+Add `lua` to your dependencies in `mix.exs`:
 
-## Executing Lua
-
-`Lua` can be run using the `eval!/2` function
-
-    iex> {[4], _} = Lua.eval!("return 2 + 2")
-
-## Compile-time validation
-
-Use the `~LUA` sigil to parse and validate your Lua code at compile time
-
-    iex> import Lua, only: [sigil_LUA: 2]
-
-    #iex> {[4], _} = Lua.eval!(~LUA[return 2 +])
-    ** (Lua.CompilerException) Failed to compile Lua!
-
-Using the `c` modifier transforms your Lua code into a `t:Lua.Chunk.t/0` at compile-time,
-which will speed up execution at runtime since the Lua no longer needs to be parsed
-
-    iex> import Lua, only: [sigil_LUA: 2]
-    iex> {[4], _} = Lua.eval!(~LUA[return 2 + 2]c)
-
-## Exposing Elixir functions to Lua
-
-The simplest way to expose an Elixir function to Lua is using the `Lua.set!/3` function
-
-``` elixir
-import Lua, only: [sigil_LUA: 2]
-
-lua = 
-  Lua.set!(Lua.new(), [:sum], fn args ->
-    [Enum.sum(args)]
-  end)
-
-{[10], _} = Lua.eval!(lua, ~LUA[return sum(1, 2, 3, 4)]c)
+```elixir
+def deps do
+  [
+    {:lua, "~> 1.0"}
+  ]
+end
 ```
 
-For easily expressing APIs, `Lua` provides the `deflua` macro for exposing Elixir functions to Lua
+## Quickstart
 
-``` elixir
+Evaluate Lua with `Lua.eval!/2`. It returns `{results, lua}` where `results`
+is the list of returned values and `lua` is the updated state:
+
+    iex> {[4], _lua} = Lua.eval!("return 2 + 2")
+
+You can thread state across multiple evaluations, set globals from Elixir, and
+read them back:
+
+    iex> lua = Lua.set!(Lua.new(), [:name], "world")
+    iex> {[greeting], _lua} = Lua.eval!(lua, ~S[return "hello, " .. name])
+    iex> greeting
+    "hello, world"
+
+## Tour
+
+### Error messages with source and line
+
+Runtime errors raise `Lua.RuntimeException`, which carries the failing
+`:source` and `:line` so you can report exactly where a script broke:
+
+```elixir
+try do
+  Lua.eval!(~LUA"""
+  local x = 1
+  error("something went wrong")
+  """)
+rescue
+  e in Lua.RuntimeException ->
+    e.line   # => 2
+    e.source # => "something went wrong"
+end
+```
+
+Lua-level error handling works too — `pcall` catches the error and returns it
+as a value:
+
+    iex> {[false, "nope"], _lua} = Lua.eval!(~S[return pcall(function() error("nope") end)])
+
+### Calling Elixir functions from Lua
+
+The quickest way to expose an Elixir function is `Lua.set!/3`:
+
+    iex> lua = Lua.set!(Lua.new(), [:sum], fn args -> [Enum.sum(args)] end)
+    iex> {[10], _lua} = Lua.eval!(lua, "return sum(1, 2, 3, 4)")
+
+For richer APIs, define a module with `use Lua.API` and the `deflua` macro,
+then load it with `Lua.load_api/2`:
+
+```elixir
 defmodule MyAPI do
   use Lua.API
-      
+
   deflua double(v), do: 2 * v
 end
 
-import Lua, only: [sigil_LUA: 2]
-    
 lua = Lua.new() |> Lua.load_api(MyAPI)
 
-{[10], _} = Lua.eval!(lua, ~LUA[return double(5)])
+{[10], _lua} = Lua.eval!(lua, "return double(5)")
 ```
 
-## Calling Lua functions from Elixir
+### Userdata
 
-`Lua` can be used to expose complex functions written in Elixir. In some cases, you may want to call Lua functions from Elixir. This can
-be achieved with the `Lua.call_function!/3` function
+Pass an arbitrary Elixir term across the boundary as a `{:userdata, term}`
+tuple. It round-trips opaquely — Lua can hold the reference and hand it back,
+but cannot inspect or dereference it:
 
-``` elixir
-defmodule MyAPI do
-  use Lua.API, scope: "example"
+    iex> lua = Lua.set!(Lua.new(), [:thing], {:userdata, %{secret: 42}})
+    iex> {[{:userdata, %{secret: 42}}], _lua} = Lua.eval!(lua, "return thing")
 
-  deflua foo(value), state do
-    Lua.call_function!(state, [:string, :lower], [value])
-  end
-end
+### Sandboxing
 
-import Lua, only: [sigil_LUA: 2]
+`Lua.new/1` sandboxes dangerous stdlib paths by default, including
+`os.execute`, `os.exit`, `os.getenv`, file I/O (`io.*`), `require`, `load`, and
+`dofile`. Calling a sandboxed function raises rather than touching the host:
 
-lua = Lua.new() |> Lua.load_api(MyAPI)
-
-{["wow"], _} = Lua.eval!(lua, ~LUA[return example.foo("WOW")])
+```elixir
+Lua.eval!(~S[os.execute("rm -rf /")])
+# ** (Lua.RuntimeException) os.execute(_) is sandboxed
 ```
 
-## Modify Lua state from Elixir
+To allow a specific operation, exclude it from the sandbox explicitly:
 
-You can also use `Lua` to modify the state of the lua environment inside your Elixir code. Imagine you have a queue module that you
-want to implement in Elixir, with the queue stored in a global variable
+    iex> lua = Lua.new(exclude: [[:os, :getenv]])
+    iex> {[value], _lua} = Lua.eval!(lua, ~S[return os.getenv("HOME")])
+    iex> is_binary(value)
+    true
 
-``` elixir
-defmodule Queue do
-  use Lua.API, scope: "q"
-  
-  deflua push(v), state do
-    # Pull out the global variable "my_queue" from lua
-    queue = Lua.get!(state, [:my_queue])
-    
-    # Call the Lua function table.insert(table, value)
-    {[], state} = Lua.call_function!(state, [:table, :insert], [queue, v])
-    
-    # Return the modified lua state with no return values
-    {[], state}
-  end
-end
+### Metatables and metamethods
 
-import Lua, only: [sigil_LUA: 2]
+Full metamethod dispatch is supported (`__index`, `__newindex`, `__call`,
+arithmetic, comparison, length, concatenation, and `__tostring`), so idiomatic
+Lua object patterns work as written:
 
-lua = Lua.new() |> Lua.load_api(Queue)
+    iex> {[result], _lua} = Lua.eval!(~LUA"""
+    ...> local Vec = {}
+    ...> Vec.__index = Vec
+    ...> Vec.__add = function(a, b) return setmetatable({x = a.x + b.x}, Vec) end
+    ...> local a = setmetatable({x = 1}, Vec)
+    ...> local b = setmetatable({x = 2}, Vec)
+    ...> return (a + b).x
+    ...> """)
+    iex> result
+    3
 
-{[queue], _} =
-  Lua.eval!(lua, """
-  my_queue = {}
+## Coverage and status
 
-  q.push("first")
-  q.push("second")
+`Lua` targets Lua 5.3. The lexer, parser, register-based VM, value
+encoding/decoding, varargs, multiple returns, `_G`/`_ENV`, metatables, the
+string-pattern engine (`find`/`match`/`gmatch`/`gsub`), and the `string`,
+`table`, `math`, `os`, and `debug` standard libraries are implemented.
 
-  return my_queue
-  """)
-  
-["first", "second"] = Lua.Table.as_list(queue)
-```
+As a sandboxed *embedded* VM, several capabilities are deliberate non-goals
+rather than missing features:
 
-## Accessing private state from Elixir
+- **Standalone interpreter / `os.execute`** — there is no shell-out.
+- **File I/O** — `io.*` is a stub by design.
+- **Filesystem `require`** — modules are not loaded from disk.
+- **Coroutines**, **garbage collection / weak tables**, and the **full
+  `debug` library**.
 
-When building applications with `Lua`, you may find yourself in need of propagating extra context for use in your APIs. For instance, you may want to access information about the current user who executed the Lua script, an API key, or something else that is private and should not be available to the Lua code. For this, we have the `Lua.put_private/3`, `Lua.get_private/2`, and `Lua.delete_private/2` functions.
+For the live Lua 5.3 official test-suite pass count and the rationale behind
+each deferral, see the
+[`ROADMAP.md`](https://github.com/tv-labs/lua/blob/main/ROADMAP.md). This
+release is `1.0.0-rc.0`.
 
-For example, imagine you wanted to allow the user to access information about themselves
+## Examples
 
-``` elixir
-defmodule User do
-  defstruct [:name]
-end
+Runnable, end-to-end scripts live in
+[`examples/`](https://github.com/tv-labs/lua/blob/main/examples/README.md). Run
+any of them with `mix run examples/<name>.exs`:
 
-defmodule UserAPI do
-  use Lua.API, scope: "user"
-  
-  deflua name(), state do
-    user = Lua.get_private!(state, :user) 
-    
-    {[user.name], state}
-  end
-end
+- [`examples/01_quickstart.exs`](https://github.com/tv-labs/lua/blob/main/examples/01_quickstart.exs) — eval some Lua and get the result.
+- [`examples/02_userdata.exs`](https://github.com/tv-labs/lua/blob/main/examples/02_userdata.exs) — pass an Elixir struct as userdata and call methods on it from Lua.
+- [`examples/03_custom_stdlib.exs`](https://github.com/tv-labs/lua/blob/main/examples/03_custom_stdlib.exs) — add an Elixir-defined function to the state and call it from Lua.
+- [`examples/04_sandboxing.exs`](https://github.com/tv-labs/lua/blob/main/examples/04_sandboxing.exs) — the default sandbox plus allowing specific `os.*` ops explicitly.
+- [`examples/05_chunks.exs`](https://github.com/tv-labs/lua/blob/main/examples/05_chunks.exs) — compile once, eval many times.
+- [`examples/06_error_handling.exs`](https://github.com/tv-labs/lua/blob/main/examples/06_error_handling.exs) — `pcall`, structured exception fields, source/line attribution.
 
-user = %User{name: "Robert Virding"}
+## Documentation
 
-lua = Lua.new() |> Lua.put_private(:user, user) |> Lua.load_api(UserAPI)
+- Full API reference on [HexDocs](https://hexdocs.pm/lua).
+- The [Working with Lua](guides/working-with-lua.livemd) guide is a Livebook
+  walkthrough of the embedding patterns.
+- The [`~LUA` sigil and Mix tasks](https://github.com/tv-labs/lua/blob/main/guides/mix_tasks.md)
+  guide covers compile-time validation and tooling.
 
-{["Hello Robert Virding"], _lua} = Lua.eval!(lua, ~LUA"""
-  return "Hello " .. user.name()
-""")
-```
+> #### Lua the Elixir library vs Lua the language {: .info}
+> When referring to this library, `Lua` is stylized as a link. References to
+> Lua the language are in plaintext and not linked.
 
-This allows you to have simple, expressive APIs that access context that is unavailable to the Lua code.
-
-## Encoding and Decoding data
-
-When working with `Lua`, you may want to inject data of various types into the runtime. Some values, such as integers, have the same representation inside the VM as they do in Elixir and do not require encoding. Other values, such as maps, are represented inside the VM as tables and must be encoded first. Arbitrary Elixir terms can be passed across the boundary using a `{:userdata, any()}` tuple.
-
-Values may be encoded with `Lua.encode!/2`.
-
-  Elixir type                 | Internal VM type            | Requires encoding?
-  :-------------------------- | :-------------------------- | :---------------------
-  `nil`                       | `nil`                       | no
-  `boolean()`                 | `boolean()`                 | no
-  `number()`                  | `number()`                  | no
-  `binary()`                  | `binary()`                  | no
-  `atom()`                    | `binary()`                  | yes
-  `map()`                     | `{:tref, integer()}`        | yes
-  `{:userdata, any()}`        | `{:udref, integer()}`       | yes
-  `(any()) -> any()`          | `{:native_func, fun}`       | yes
-  `(any(), Lua.t()) -> any()` | `{:native_func, fun}`       | yes
-  `list(any())`               | `list(VM type)`             | maybe (if any of its values require encoding)
-  
-
-## Userdata
-
-There are situations where you want to pass around a reference to some Elixir datastructure, such as a struct. In these situations, you can use a `{:userdata, any()}` tuple.
-
-``` elixir
-defmodule Thing do
-  defstruct [:value]
-end
-
-{encoded, lua} = Lua.encode!(Lua.new(), {:userdata, %Thing{value: "1234"}})
-
-lua = Lua.set!(lua, [:foo], encoded)
-
-{[{:userdata, %Thing{value: "1234"}}], _} = Lua.eval!(lua, "return foo")
-```
-
-Trying to deference userdata inside a Lua program will result in an exception.
-  
-  
-## Credits
+## Compatibility and credits
 
 `Lua` started as an ergonomic Elixir wrapper around Robert Virding's
-[Luerl](https://github.com/rvirding/luerl) project. As of `1.0.0` this library
-is a full Elixir-native reimplementation of the Lua 5.3 lexer, parser, and
-virtual machine, with a public API designed to feel idiomatic from Elixir.
+[Luerl](https://github.com/rvirding/luerl) project. As of `1.0.0` it is a full
+Elixir-native reimplementation of the Lua 5.3 lexer, parser, and virtual
+machine, with a public API designed to feel idiomatic from Elixir.
+
+Compared to Luerl: `Lua` is pure Elixir with no shared mutable state (each
+`Lua` value is plain immutable state you thread explicitly), ships richer error
+messages with source and line attribution, and benchmarks competitively.
 Luerl deserves credit as the prior art that made this possible — its design
-informed many of the decisions in the new VM, and we benchmark against it.
+informed many decisions in the new VM, and we benchmark against it.
+
+## License
+
+Released under the Apache-2.0 license. See
+[`LICENSE`](https://github.com/tv-labs/lua/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add `lua` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:lua, "~> 1.0"}
+    {:lua, "~> 1.0.0-rc"}
   ]
 end
 ```
@@ -64,7 +64,15 @@ rescue
   e in Lua.RuntimeException ->
     e.line    # => 2
     e.source  # => "<eval>" (chunk name)
-    e.message # => "Lua runtime error: ...something went wrong..."
+
+    # e.message is a formatted, colorized frame (ANSI codes elided here):
+    #
+    #   Lua runtime error: Runtime Error
+    #
+    #     at <eval>:2:
+    #
+    #     runtime error: something went wrong
+    e.message
 end
 ```
 
@@ -151,9 +159,8 @@ deliberate non-goal rather than a missing feature:
 
 - **Standalone interpreter / `os.execute`** — there is no shell-out to the host.
 - **Host filesystem access** — `Lua` does not read your host filesystem. The
-  `io.*` library and `require`/`dofile` do not touch disk; file-backed scripts
-  and modules are resolved through `Lua`'s own controlled layer rather than the
-  host OS.
+  `io.*` library and `require`/`dofile` are sandboxed by default and raise
+  rather than touching disk; there is no host-OS file or module resolution.
 - **Coroutines**, **garbage collection / weak tables**, and the **full
   `debug` library**.
 


### PR DESCRIPTION
## README rewrite for 1.0 positioning, quickstart, and tour

Plan: [`.agents/plans/A31-readme-rewrite.md`](https://github.com/tv-labs/lua/blob/docs/readme-rewrite/.agents/plans/A31-readme-rewrite.md)
Closes #265

### Goal

Rewrite the README for the 1.0 audience. The current README reads like internal docs. The 1.0 README positions the library in one paragraph (native Elixir Lua 5.3, no NIFs/C/Erlang runtime dependency, for sandboxed embedding), provides a 30-second quickstart, tours the killer features (errors with source/line, calling Elixir from Lua, userdata, sandboxing, metatables), states coverage honestly, and links to examples, guides, and the changelog.

### Success criteria

- [x] One-sentence pitch + one-paragraph "what is this" at the top (after badges + MDOC marker).
- [x] `<!-- MDOC !-->` marker preserved in its current position — `lib/lua.ex` still compiles and `mix docs` resolves the moduledoc (verified: `mix compile --warnings-as-errors` and `mix docs` clean).
- [x] Quickstart: `mix.exs` install snippet + a doctested first-eval block (verified: 60 doctests pass under `mix test`).
- [x] Tour with 6 subsections: error messages (source/line + `pcall`), calling Elixir from Lua (`Lua.set!/3` + `deflua`), userdata round-trip, sandboxing (default + `exclude:` to allow `os.getenv`), metatables/metamethods. The eval snippets are `iex>` doctests.
- [x] Coverage section: lists supported subsystems, names non-goals (`os.execute`, file I/O, filesystem `require`, coroutines, GC/weak tables, full `debug`), links `ROADMAP.md` for the live suite count instead of hardcoding it.
- [x] Examples section: links the six canonical A30 files + the `examples/README.md` index, one line each. Links use stable `blob/main` paths that resolve once A30 merges.
- [x] Compatibility / vs-Luerl subsection: pure Elixir, no shared mutable state, richer errors, benchmarks competitively. Reuses the existing Credits framing.
- [x] Every doctested snippet passes `mix test` (60 doctests, 0 failures).
- [x] Hex / Hexdocs / CI / license badges present near the top.
- [x] `mix docs` builds clean (no broken-link warnings — repo-file links use absolute GitHub URLs).

### Changes

```
 .agents/plans/A31-readme-rewrite.md | 215 ++++++++++++++++++--------
 README.md                           | 298 +++++++++++++++++-------------------
 2 files changed, 290 insertions(+), 223 deletions(-)
```

### Discoveries

- The public runtime exception is `Lua.RuntimeException` (fields `:line`, `:source`, `:message`, `:call_stack`, `:state`, `:original`), not the internal `Lua.VM.RuntimeError`. Tour snippets use the public type.
- Specific sandboxed ops are allowed via `Lua.new(exclude: [[:os, :getenv]])`.
- `{:userdata, term}` round-trips directly through `Lua.set!/3` without an explicit `Lua.encode!/2`.
- Cross-PR link dependency (former blocker): the `examples/` files are created by sibling plan A30 and are absent from this worktree. Decoupled by linking the six non-optional stable paths; links resolve once both PRs land on `main`.

### Verification

```
mix format
mix compile --warnings-as-errors
mix test
mix docs
```

```
Result: 2096 passed (60 doctests, 51 properties, 1985 tests), 19 skipped, 1 excluded
```

`mix docs` builds with no warnings.

### Out of scope (intentional)

- Long-form tutorials (those live in `guides/`).
- API reference content (`mix docs` / hexdocs).
- Marketing copy or testimonials.
- Creating the `examples/` files themselves — that is plan A30, shipping in a sibling PR. This plan only links to those paths.
- Splitting coverage into `guides/coverage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)