### PR TITLE
docs(stdlib): add @spec and type defs across the public API

### DIFF
--- a/.agents/plans/A32-docstring-audit.md
+++ b/.agents/plans/A32-docstring-audit.md
@@ -2,10 +2,10 @@
 id: A32
 title: Public API docstring audit — every public function carries its weight
 issue: 266
-pr: null
+pr: 301
 branch: docs/docstring-audit
 base: main
-status: in-progress
+status: review
 direction: A
 unlocks:
   - "world-class docs" promise
@@ -115,4 +115,31 @@ experience should be coherent.
 
 ## Discoveries
 
-(populated during implementation)
+- The A27 display structs ship as `Lua.VM.Display.{Closure,Userdata,NativeFunc,Table}`
+  (internal VM namespace), not the top-level `Lua.Closure` / `Lua.Userdata` /
+  `Lua.NativeFunc` names the plan anticipated. They are not on the public surface
+  and were left out of scope.
+- The named in-scope modules already carried strong prose docstrings with examples.
+  The real gap on this surface was missing `@spec`/`@type` and a CI guard, not
+  missing prose.
+- `mix.exs` docs config already renders cleanly (`mix docs --warnings-as-errors`
+  exits 0 before any changes), so no config tightening was needed.
+
+## What changed
+
+- `lib/lua.ex` — added `@spec` to every public function (`new/1`, `sandbox/2`,
+  `set_lua_paths/2`, `set!/3`, `get!/3`, `eval!`, `parse_chunk/1`, `load_chunk!/2`,
+  `call_function/3`, `call_function!/3`, `encode!/2`, `encode_list!/2`, `decode!/2`,
+  `decode_list!/2`, `load_file!/2`, `load_api/3`, `put_private/3`, `get_private/2`,
+  `get_private!/2`, `delete_private/2`).
+- `lib/lua/table.ex` — added `@spec` to `as_list/2`, `as_map/1`, `as_string/2`,
+  `deep_cast/1` plus `## Options`/`## Returns` prose where missing.
+- `lib/lua/runtime_exception.ex`, `lib/lua/vm/type_error.ex`,
+  `lib/lua/vm/runtime_error.ex`, `lib/lua/vm/assertion_error.ex`,
+  `lib/lua/vm/argument_error.ex` — added `@type t` and `@spec` on public helpers
+  (`to_map/2`, `value_expected/2`, `type_error/4`, `wrong_number_of_arguments/1`).
+- `.github/workflows/ci.yml` — added a `mix docs --warnings-as-errors` step to the
+  build job so future PRs can't regress doc warnings.
+- Verification: `mix test` 2092 passed (56 doctests), 19 skipped;
+  `mix docs --warnings-as-errors` exit 0; `mix dialyzer` 0 errors.
+- PR: #301.

--- a/.agents/plans/A32-docstring-audit.md
+++ b/.agents/plans/A32-docstring-audit.md
@@ -1,11 +1,11 @@
 ---
 id: A32
 title: Public API docstring audit — every public function carries its weight
-issue: null
+issue: 266
 pr: null
 branch: docs/docstring-audit
 base: main
-status: ready
+status: in-progress
 direction: A
 unlocks:
   - "world-class docs" promise

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Format
         run: mix format --check-formatted
 
+      - name: Docs
+        run: mix docs --warnings-as-errors
+
   website:
     name: Website tests
     runs-on: ubuntu-latest

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -101,6 +101,7 @@ defmodule Lua do
       iex> message =~ "stack overflow"
       true
   """
+  @spec new(keyword()) :: t()
   def new(opts \\ []) do
     opts = Keyword.validate!(opts, sandboxed: @default_sandbox, exclude: [], debug: false, max_call_depth: :infinity)
     exclude = Keyword.fetch!(opts, :exclude)
@@ -169,6 +170,7 @@ defmodule Lua do
       iex> Lua.sandbox(lua, [:os, :exit])
 
   """
+  @spec sandbox(t(), [atom() | String.t()]) :: t()
   def sandbox(lua, path) do
     set!(lua, path, fn args ->
       raise Lua.RuntimeException,
@@ -193,6 +195,7 @@ defmodule Lua do
   >
   > By default these are sandboxed, see the `:exclude` option in `Lua.new/1` to allow them.
   """
+  @spec set_lua_paths(t(), [String.t()] | String.t()) :: t()
   def set_lua_paths(%__MODULE__{} = lua, paths) when is_list(paths) do
     set_lua_paths(lua, Enum.join(paths, ";"))
   end
@@ -233,6 +236,7 @@ defmodule Lua do
       iex> {[3], _} = Lua.eval!(lua, "set_count(1, 2, 3); return count")
 
   """
+  @spec set!(t(), atom() | String.t() | [atom() | String.t()], term()) :: t()
   def set!(%__MODULE__{}, [], _) do
     raise Lua.RuntimeException, "Lua.set!/3 cannot have empty keys"
   end
@@ -389,6 +393,7 @@ defmodule Lua do
   ### Options
   * `:decode` - (default `true`) - By default, values are decoded
   """
+  @spec get!(t(), [atom() | String.t()], keyword()) :: term()
   def get!(%__MODULE__{state: state}, keys, opts \\ []) when is_list(keys) do
     opts = Keyword.validate!(opts, decode: true)
 
@@ -465,6 +470,10 @@ defmodule Lua do
                 runtime errors as `at <source>:<line>:` and in stack traces. Pick a name that
                 identifies where this script came from (e.g. `"my_script.lua"`).
   """
+  @spec eval!(String.t() | Lua.Chunk.t()) :: {[term()], t()}
+  @spec eval!(t() | String.t() | Lua.Chunk.t(), String.t() | Lua.Chunk.t() | keyword()) ::
+          {[term()], t()}
+  @spec eval!(t(), String.t() | Lua.Chunk.t(), keyword()) :: {[term()], t()}
   def eval!(script) do
     eval!(new(), script, [])
   end
@@ -616,6 +625,7 @@ defmodule Lua do
       true
 
   """
+  @spec parse_chunk(String.t()) :: {:ok, Lua.Chunk.t()} | {:error, [String.t()]}
   def parse_chunk(code) do
     case Lua.Parser.parse(code) do
       {:ok, ast} ->
@@ -646,6 +656,7 @@ defmodule Lua do
 
       iex> {%Lua.Chunk{}, %Lua{}} = Lua.load_chunk!(Lua.new(), ~LUA[return 2 + 2]c)
   """
+  @spec load_chunk!(t(), String.t() | Lua.Chunk.t()) :: {Lua.Chunk.t(), t()}
   def load_chunk!(%__MODULE__{} = lua, code) when is_binary(code) do
     case parse_chunk(code) do
       {:ok, chunk} -> {chunk, lua}
@@ -681,6 +692,8 @@ defmodule Lua do
       42
 
   """
+  @spec call_function(t(), term(), [term()]) ::
+          {:ok, [term()], t()} | {:error, term(), t()}
   def call_function(%__MODULE__{} = lua, %Display.Closure{ref: ref}, args) do
     call_function(lua, ref, args)
   end
@@ -772,6 +785,7 @@ defmodule Lua do
   end
   ```
   """
+  @spec call_function!(t(), term(), [term()]) :: {[term()], t()}
   def call_function!(%__MODULE__{} = lua, func, args) do
     case call_function(lua, func, args) do
       {:ok, ret, lua} -> {ret, lua}
@@ -812,6 +826,7 @@ defmodule Lua do
       iex> match?({:tref, _}, encoded)
       true
   """
+  @spec encode!(t(), term()) :: {term(), t()}
   def encode!(%__MODULE__{} = lua, value) when is_atom(value) and not is_boolean(value) do
     {Atom.to_string(value), lua}
   end
@@ -840,6 +855,7 @@ defmodule Lua do
 
       iex> {[1, {:tref, _}, true], _} = Lua.encode_list!(Lua.new(), [1, %{a: 2}, true])
   """
+  @spec encode_list!(t(), [term()]) :: {[term()], t()}
   def encode_list!(%__MODULE__{} = lua, list) when is_list(list) do
     Enum.map_reduce(list, lua, &encode!(&2, &1))
   end
@@ -852,6 +868,7 @@ defmodule Lua do
       [{"a", 1}]
 
   """
+  @spec decode!(t(), term()) :: term()
   def decode!(%__MODULE__{state: state}, value) do
     value = Display.unwrap(value)
 
@@ -874,6 +891,7 @@ defmodule Lua do
       iex> Lua.decode_list!(lua, encoded)
       [1, [{"a", 2}], true]
   """
+  @spec decode_list!(t(), [term()]) :: [term()]
   def decode_list!(%__MODULE__{} = lua, list) when is_list(list) do
     Enum.map(list, &decode!(lua, &1))
   end
@@ -884,6 +902,7 @@ defmodule Lua do
 
   Mimics the functionality of Lua's [dofile](https://www.lua.org/manual/5.4/manual.html#pdf-dofile)
   """
+  @spec load_file!(t(), String.t()) :: t()
   def load_file!(%__MODULE__{} = lua, path) when is_binary(path) do
     # Add .lua extension if not present
     full_path =
@@ -916,6 +935,7 @@ defmodule Lua do
   * `:data` - (optional) - data to be passed to the Lua.API.install/3 callback
 
   """
+  @spec load_api(t(), module(), keyword()) :: t()
   def load_api(lua, module, opts \\ []) do
     opts = Keyword.validate!(opts, [:scope, :data])
     funcs = :functions |> module.__info__() |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
@@ -945,6 +965,7 @@ defmodule Lua do
 
       iex> Lua.new() |> Lua.put_private(:api_key, "1234")
   """
+  @spec put_private(t(), term(), term()) :: t()
   def put_private(%__MODULE__{state: state} = lua, key, value) do
     %{lua | state: State.put_private(state, key, value)}
   end
@@ -956,6 +977,7 @@ defmodule Lua do
       iex> Lua.get_private(lua, :api_key)
       {:ok, "1234"}
   """
+  @spec get_private(t(), term()) :: {:ok, term()} | :error
   def get_private(%__MODULE__{state: state}, key) do
     {:ok, State.get_private(state, key)}
   rescue
@@ -969,6 +991,7 @@ defmodule Lua do
       iex> Lua.get_private!(lua, :api_key)
       "1234"
   """
+  @spec get_private!(t(), term()) :: term()
   def get_private!(%__MODULE__{} = lua, key) do
     case get_private(lua, key) do
       {:ok, value} -> value
@@ -984,6 +1007,7 @@ defmodule Lua do
       iex> Lua.get_private(lua, :api_key)
       :error
   """
+  @spec delete_private(t(), term()) :: t()
   def delete_private(%__MODULE__{state: state} = lua, key) do
     %{lua | state: State.delete_private(state, key)}
   end

--- a/lib/lua/runtime_exception.ex
+++ b/lib/lua/runtime_exception.ex
@@ -17,6 +17,8 @@ defmodule Lua.RuntimeException do
 
   @runtime_prefix "Lua runtime error: "
 
+  @type t :: %__MODULE__{}
+
   defexception [:message, :original, :state, :line, :source, :call_stack]
 
   @impl true

--- a/lib/lua/table.ex
+++ b/lib/lua/table.ex
@@ -22,7 +22,17 @@ defmodule Lua.Table do
       iex> Lua.Table.as_list([{2, "b"}, {1, "a"}, {3, "c"}], sort: true)
       ["a", "b", "c"]
 
+  ## Options
+
+    * `:sort` - (default `false`) when `true`, sorts entries by their
+      integer key before dropping keys, so the result is index-ordered
+      regardless of the input order.
+
+  ## Returns
+
+  A list of the table's values in key order.
   """
+  @spec as_list([{term(), term()}], keyword()) :: [term()]
   def as_list(values, opts \\ []) do
     opts = Keyword.validate!(opts, sort: false)
 
@@ -44,6 +54,7 @@ defmodule Lua.Table do
       iex> Lua.Table.as_map([{"a", 1}, {"b", 2}])
       %{"a" => 1, "b" => 2}
   """
+  @spec as_map([{term(), term()}]) :: map()
   def as_map(values) do
     Map.new(values)
   end
@@ -73,7 +84,12 @@ defmodule Lua.Table do
   ### Options
   * `:formatter` - A 2-arity function used to format values before serialization. The key and value
   are passed as arguments. If there is no key, it will default to `nil`.
+
+  ## Returns
+
+  A string containing the Lua table literal.
   """
+  @spec as_string(list() | map(), keyword()) :: String.t()
   def as_string(table, opts \\ []) do
     opts = Keyword.validate!(opts, formatter: &default_formatter/2)
 
@@ -157,7 +173,13 @@ defmodule Lua.Table do
 
       iex> Lua.Table.deep_cast([{"a", 1}, {"b", [{1, 3}, {2, 4}]}])
       %{"a" => 1, "b" => [3, 4]}
+
+  ## Returns
+
+  A list when the table looks like a 1-indexed array, otherwise a map.
+  Nested tables are cast recursively.
   """
+  @spec deep_cast([{term(), term()}]) :: list() | map()
   def deep_cast(value) do
     case value do
       [{1, _val} | _rest] = list ->

--- a/lib/lua/vm/argument_error.ex
+++ b/lib/lua/vm/argument_error.ex
@@ -41,6 +41,10 @@ defmodule Lua.VM.ArgumentError do
         details: "value out of range"
   """
 
+  alias Lua.VM.RuntimeError
+
+  @type t :: %__MODULE__{}
+
   defexception [
     :function_name,
     :arg_num,
@@ -116,6 +120,7 @@ defmodule Lua.VM.ArgumentError do
 
       ArgumentError.value_expected("string.lower", 1)
   """
+  @spec value_expected(String.t(), pos_integer()) :: t()
   def value_expected(function_name, arg_num) do
     exception(
       function_name: function_name,
@@ -131,6 +136,7 @@ defmodule Lua.VM.ArgumentError do
 
       ArgumentError.type_error("string.rep", 2, "number", "string")
   """
+  @spec type_error(String.t(), pos_integer(), String.t(), String.t()) :: t()
   def type_error(function_name, arg_num, expected, got) do
     exception(
       function_name: function_name,
@@ -151,7 +157,8 @@ defmodule Lua.VM.ArgumentError do
 
       raise ArgumentError.wrong_number_of_arguments("insert")
   """
+  @spec wrong_number_of_arguments(String.t()) :: RuntimeError.t()
   def wrong_number_of_arguments(function_name) do
-    Lua.VM.RuntimeError.exception(value: "wrong number of arguments to '#{function_name}'")
+    RuntimeError.exception(value: "wrong number of arguments to '#{function_name}'")
   end
 end

--- a/lib/lua/vm/assertion_error.ex
+++ b/lib/lua/vm/assertion_error.ex
@@ -9,6 +9,8 @@ defmodule Lua.VM.AssertionError do
 
   alias Lua.VM.ErrorFormatter
 
+  @type t :: %__MODULE__{}
+
   defexception [:value, :source, :message, :call_stack, :line]
 
   @impl true
@@ -36,6 +38,7 @@ defmodule Lua.VM.AssertionError do
 
   Pass `:source_code` to populate `source_context`.
   """
+  @spec to_map(t(), keyword()) :: map()
   def to_map(%__MODULE__{} = error, opts \\ []) do
     ErrorFormatter.to_map(:assertion_error, raw_message(error.value),
       source: error.source,

--- a/lib/lua/vm/runtime_error.ex
+++ b/lib/lua/vm/runtime_error.ex
@@ -15,6 +15,8 @@ defmodule Lua.VM.RuntimeError do
 
   alias Lua.VM.ErrorFormatter
 
+  @type t :: %__MODULE__{}
+
   defexception [:value, :source, :message, :call_stack, :line]
 
   @impl true
@@ -42,6 +44,7 @@ defmodule Lua.VM.RuntimeError do
 
   Pass `:source_code` to populate `source_context`.
   """
+  @spec to_map(t(), keyword()) :: map()
   def to_map(%__MODULE__{} = error, opts \\ []) do
     ErrorFormatter.to_map(:runtime_error, raw_message(error.value),
       source: error.source,

--- a/lib/lua/vm/type_error.ex
+++ b/lib/lua/vm/type_error.ex
@@ -14,6 +14,8 @@ defmodule Lua.VM.TypeError do
 
   alias Lua.VM.ErrorFormatter
 
+  @type t :: %__MODULE__{}
+
   defexception [:value, :source, :message, :call_stack, :line, :error_kind, :value_type]
 
   @impl true
@@ -48,6 +50,7 @@ defmodule Lua.VM.TypeError do
 
   Pass `:source_code` to populate `source_context`.
   """
+  @spec to_map(t(), keyword()) :: map()
   def to_map(%__MODULE__{} = error, opts \\ []) do
     ErrorFormatter.to_map(:type_error, raw_message(error.value),
       source: error.source,


### PR DESCRIPTION
## Public API docstring audit — every public function carries its weight

Plan: [`.agents/plans/A32-docstring-audit.md`](https://github.com/tv-labs/lua/blob/docs/docstring-audit/.agents/plans/A32-docstring-audit.md)
Closes #266

### Goal

Every public function and module on the library's surface has a docstring that says what it does, documents arguments and return values, has at least one example block, and cross-links related functions. `mix docs --warnings-as-errors` exits 0, and every public function carries a `@spec`.

### Success criteria

- [x] Every public module has a meaningful `@moduledoc` — `Lua`, `Lua.Chunk`, `Lua.API`, `Lua.RuntimeException`, `Lua.VM.TypeError`, `Lua.VM.RuntimeError`, `Lua.VM.AssertionError`, `Lua.VM.ArgumentError` all already carried prose moduledocs; audited and confirmed.
- [x] Every public function has `@doc` with a one-sentence summary, argument/return prose, and at least one example block (verified by reading each `def` in the in-scope modules; gaps in arguments/returns prose filled in `Lua.Table`).
- [x] At least 10 example blocks run as doctests — `mix test` reports **56 doctests**.
- [x] `mix docs --warnings-as-errors` exits 0 (verified locally; now enforced in CI).
- [x] `@spec` present on every public function — added to `Lua`, `Lua.Table`, and the public exception helper functions; `@type t` added to the exception structs so the specs resolve.
- [x] `@deprecated` annotations — nothing is being removed in 1.0 on this surface, so none required.
- [x] `mix test` passes (2092 passed, 19 skipped, no regressions).

### Changes

```
 .github/workflows/ci.yml      |  3 +++
 lib/lua.ex                    | 24 ++++++++++++++++++++++++
 lib/lua/runtime_exception.ex  |  2 ++
 lib/lua/table.ex              | 22 ++++++++++++++++++++++
 lib/lua/vm/argument_error.ex  |  9 ++++++++-
 lib/lua/vm/assertion_error.ex |  3 +++
 lib/lua/vm/runtime_error.ex   |  3 +++
 lib/lua/vm/type_error.ex      |  3 +++
 8 files changed, 68 insertions(+), 1 deletion(-)
```

### Discoveries

- The A27 display structs ship as `Lua.VM.Display.{Closure,Userdata,NativeFunc,Table}` (internal VM namespace), not the top-level `Lua.Closure` / `Lua.Userdata` / `Lua.NativeFunc` names the plan anticipated. They are not on the public surface and were left out of scope.
- The named modules already carried strong prose docstrings and examples; the real gap on this surface was missing `@spec`/`@type` and a CI guard, which is what this PR closes.
- `mix.exs` docs config already renders cleanly (`mix docs --warnings-as-errors` exits 0), so no config tightening was needed.

### Verification

```
mix format
mix compile --warnings-as-errors
mix docs --warnings-as-errors   # EXIT: 0
mix test                        # 2092 passed (56 doctests), 19 skipped
mix dialyzer                    # Total errors: 0, passed successfully
```

### Out of scope (intentional)

- Internal modules (`Lua.VM.Executor`, `Lua.Compiler.*`, `Lua.Lexer`).
- Long-form guides (those live in `guides/`).
- Hex publish itself (release plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)