### PR TITLE
feat(vm): harden against allocation-bomb DoS and document sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,33 @@ any of them with `mix run examples/<name>.exs`:
   walkthrough of the embedding patterns.
 - The [`~LUA` sigil and Mix tasks](https://github.com/tv-labs/lua/blob/main/guides/mix_tasks.md)
   guide covers compile-time validation and tooling.
+- The [Security and sandboxing](guides/sandboxing.md) guide covers the sandbox,
+  allocation guards, recursion limits, and bounding CPU and memory.
 
 > #### Lua the Elixir library vs Lua the language {: .info}
 > When referring to this library, `Lua` is stylized as a link. References to
 > Lua the language are in plaintext and not linked.
+
+## Security and sandboxing
+
+`Lua` is built to run untrusted scripts. By default, `Lua.new/1` installs
+a sandbox that blocks the dangerous standard-library paths (`io`, `file`,
+`os.execute`/`exit`/`getenv`, `package`, `require`, `load`, …), and the VM
+guards against allocation-bomb denial-of-service by refusing oversized
+`string.rep`, `table.unpack`/`concat`/`move`, and string concatenations
+before they allocate.
+
+```elixir
+# os.exit is sandboxed by default — calling it raises (catchable)
+iex> {[false, message], _} = Lua.eval!(Lua.new(), "return pcall(os.exit)")
+iex> message =~ "sandboxed"
+true
+```
+
+Capability sandboxing (`:sandboxed`, `:exclude`, `Lua.sandbox/2`),
+recursion limits (`:max_call_depth`), the built-in allocation guards, and
+the host-level pattern for bounding CPU time and total memory are all
+covered in the [Security and sandboxing](guides/sandboxing.md) guide.
 
 ## Compatibility and credits
 

--- a/guides/sandboxing.md
+++ b/guides/sandboxing.md
@@ -144,7 +144,9 @@ guards above don't catch (for example, growing a table in a loop). These
 limits have to be enforced by the BEAM, around the call.
 
 Run untrusted scripts in a **separate, monitored process** with both a
-timeout and a heap ceiling:
+timeout and a heap ceiling. The key is to keep the wall-clock timeout and
+the memory kill on **separate `receive` arms** so the two failure modes
+stay distinguishable:
 
 ```elixir
 defmodule SafeLua do
@@ -153,8 +155,15 @@ defmodule SafeLua do
   @timeout_ms 1_000
 
   def run(lua, source) do
-    task =
-      Task.Supervisor.async_nolink(MyApp.TaskSupervisor, fn ->
+    parent = self()
+
+    # Trap exits so the worker dying — whether it finishes, is killed by
+    # the memory ceiling, or we tear it down on timeout — arrives as a
+    # message instead of crashing the caller. Restore the flag afterwards.
+    prev_trap = Process.flag(:trap_exit, true)
+
+    worker =
+      spawn_link(fn ->
         # CRITICAL: include_shared_binaries: true. Without it, max_heap_size
         # counts only the process heap, NOT off-heap reference-counted
         # binaries (>64 bytes) — so a binary bomb would slip past the limit.
@@ -166,14 +175,29 @@ defmodule SafeLua do
           include_shared_binaries: true
         })
 
-        Lua.eval!(lua, source)
+        send(parent, {:result, Lua.eval!(lua, source)})
       end)
 
-    case Task.yield(task, @timeout_ms) || Task.shutdown(task, :brutal_kill) do
-      {:ok, {result, _lua}} -> {:ok, result}
-      {:exit, :killed} -> {:error, :memory_limit}
-      {:exit, reason} -> {:error, reason}
-      nil -> {:error, :timeout}
+    try do
+      receive do
+        {:result, {result, _lua}} ->
+          {:ok, result}
+
+        # Worker hit the memory ceiling: max_heap_size kills it with
+        # `:killed`, the only abnormal exit we attribute to the limit.
+        {:EXIT, ^worker, :killed} ->
+          {:error, :memory_limit}
+
+        # Any other abnormal worker exit is an unrelated crash.
+        {:EXIT, ^worker, reason} ->
+          {:error, reason}
+      after
+        @timeout_ms ->
+          Process.exit(worker, :kill)
+          {:error, :timeout}
+      end
+    after
+      Process.flag(:trap_exit, prev_trap)
     end
   end
 end
@@ -181,11 +205,17 @@ end
 
 Two details make this robust:
 
-* **`async_nolink`** (under a `Task.Supervisor` in your supervision tree)
-  monitors the task instead of linking it. When the heap ceiling kills
-  the task, `Task.yield/2` reports `{:exit, :killed}` and your caller
-  keeps running — a plain `Task.async/1` would link the kill back to the
-  caller and crash it.
+* **Separate `receive` arms for timeout and `:killed`.** A wall-clock
+  timeout fires the `after` clause and reports `:timeout`; a memory kill
+  arrives as `{:EXIT, worker, :killed}` and reports `:memory_limit`. The
+  tempting `Task.yield(task, @timeout_ms) || Task.shutdown(task,
+  :brutal_kill)` shape collapses the two: `brutal_kill` on a timeout also
+  exits the worker with `:killed`, so a CPU-bound infinite loop would be
+  mislabeled a memory limit.
+* **`trap_exit` + `spawn_link`** turns the worker's exit into a message
+  the caller can match on, instead of letting the kill propagate and
+  crash the caller. Restoring the previous `trap_exit` flag in the
+  `after` block leaves the caller's state untouched.
 * **`include_shared_binaries: true`** is what makes the memory ceiling
   actually work for the binary-allocation attacks. Large Lua strings
   become off-heap BEAM binaries; without this flag they are not counted

--- a/guides/sandboxing.md
+++ b/guides/sandboxing.md
@@ -1,0 +1,215 @@
+# Security and sandboxing
+
+`Lua` is designed to run untrusted scripts, but running untrusted code
+safely takes more than calling `Lua.eval!/2`. There are three layers to
+think about, from "what a script is allowed to *do*" down to "how much it
+is allowed to *consume*":
+
+1. **Capability sandboxing** — which standard-library functions the
+   script can call (filesystem, OS, module loading, …).
+2. **Resource limits** — bounds on a single script's allocations and
+   recursion, enforced inside the VM.
+3. **Host-level isolation** — wall-clock time and total memory, which the
+   VM cannot enforce on its own and which are *your* responsibility.
+
+This guide covers all three.
+
+## Capability sandboxing
+
+### The default deny-list
+
+`Lua.new/1` installs a sandbox by default. A sandboxed path is replaced
+with a function that raises when called, so the script can still *refer*
+to it but cannot *use* it. The defaults block the dangerous corners of
+the standard library:
+
+* **Filesystem / IO** — the whole `io` table (`io.open`, `io.read`,
+  `io.write`, `io.lines`, `io.popen`, …) and `file`
+* **Operating system** — `os.execute`, `os.exit`, `os.getenv`,
+  `os.remove`, `os.rename`, `os.tmpname`
+* **Code loading** — `package`, `require`, `load`, `loadfile`,
+  `loadstring`, `dofile`
+
+Everything else — `string`, `table`, `math`, `utf8`, the `debug`
+library, metatables, coroutity-free control flow — remains available.
+
+```elixir
+# os.exit is sandboxed by default
+{[false, message], _} =
+  Lua.eval!(Lua.new(), "return pcall(os.exit)")
+
+message =~ "sandboxed"
+#=> true
+```
+
+### Adding to the sandbox
+
+Pass `:sandboxed` to replace the default list with your own set of paths.
+This is an *allow-by-default* model: anything not listed stays callable.
+
+```elixir
+# Block string.rep specifically, on top of nothing else
+lua = Lua.new(sandboxed: [[:string, :rep]])
+```
+
+### Removing from the sandbox
+
+If you want the defaults *minus* a few entries, use `:exclude` to punch
+holes in the default deny-list rather than re-listing everything.
+
+```elixir
+# Keep all the defaults, but allow `require`
+lua = Lua.new(exclude: [[:require], [:package]])
+```
+
+To disable capability sandboxing entirely (for trusted code only), pass
+an empty list:
+
+```elixir
+lua = Lua.new(sandboxed: [])
+```
+
+### Sandboxing a single path
+
+`Lua.sandbox/2` sandboxes one path on an existing VM, which is handy when
+building a configuration up in steps:
+
+```elixir
+lua =
+  Lua.new(sandboxed: [])
+  |> Lua.sandbox([:os, :exit])
+  |> Lua.sandbox([:os, :execute])
+```
+
+## Resource limits (always on)
+
+Several standard-library functions take a size or count argument that an
+attacker can inflate to force a huge allocation — the classic
+`string.rep("x", 1e15)` "allocate until the host dies" attack. `Lua`
+computes the resulting size *before* allocating and raises a catchable
+error when it would be unreasonable, so the attempt fails in microseconds
+instead of exhausting memory.
+
+These guards are always on and need no configuration. They cover:
+
+| Operation | Guard | Error (catchable with `pcall`) |
+| :-------- | :---- | :----------------------------- |
+| `string.rep`, the `..` operator | result larger than ~256 MiB | `resulting string too large` |
+| `string.format` width/precision | field wider than 99 | `invalid conversion` |
+| `table.unpack` | more than 10M results | `too many results to unpack` |
+| `table.concat`, `table.move` | range wider than 10M | `range too large` |
+| `load` (when enabled) | reader returns > ~256 MiB total | `resulting string too large` |
+
+```elixir
+{[false, message], _} =
+  Lua.eval!(Lua.new(), ~s|return pcall(string.rep, "x", 1e15)|)
+
+message =~ "resulting string too large"
+#=> true
+```
+
+Because these surface as ordinary Lua errors, a script can even recover
+from them with `pcall`.
+
+## Call depth
+
+By default the VM places no limit on call depth, so deeply recursive or
+runaway-recursive scripts can grow the host process stack until it
+crashes. Set `:max_call_depth` to bound it; exceeding the limit raises a
+catchable `"stack overflow"`:
+
+```elixir
+lua = Lua.new(max_call_depth: 200)
+
+{[false, message], _} =
+  Lua.eval!(lua, "local function f() return f() end return pcall(f)")
+
+message =~ "stack overflow"
+#=> true
+```
+
+> #### Tail calls count {: .info}
+> This VM does not implement tail-call optimization, so a call in tail
+> position (`return f(x)`) consumes a frame like any other. A finite
+> `:max_call_depth` therefore also bounds tail recursion — including
+> loops that PUC-Lua would run forever. Leave the default `:infinity`
+> if you rely on unbounded tail recursion.
+
+## Limiting CPU time and total memory
+
+The VM has **no internal wall-clock timeout** and does **not** cap the
+host process's total memory. A script can still spin forever
+(`while true do end`) or accumulate memory in ways the per-operation
+guards above don't catch (for example, growing a table in a loop). These
+limits have to be enforced by the BEAM, around the call.
+
+Run untrusted scripts in a **separate, monitored process** with both a
+timeout and a heap ceiling:
+
+```elixir
+defmodule SafeLua do
+  # ~64 MB, in heap words (8 bytes/word on a 64-bit VM).
+  @heap_words 8_000_000
+  @timeout_ms 1_000
+
+  def run(lua, source) do
+    task =
+      Task.Supervisor.async_nolink(MyApp.TaskSupervisor, fn ->
+        # CRITICAL: include_shared_binaries: true. Without it, max_heap_size
+        # counts only the process heap, NOT off-heap reference-counted
+        # binaries (>64 bytes) — so a binary bomb would slip past the limit.
+        # This option requires OTP 27+.
+        Process.flag(:max_heap_size, %{
+          size: @heap_words,
+          kill: true,
+          error_logger: false,
+          include_shared_binaries: true
+        })
+
+        Lua.eval!(lua, source)
+      end)
+
+    case Task.yield(task, @timeout_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {result, _lua}} -> {:ok, result}
+      {:exit, :killed} -> {:error, :memory_limit}
+      {:exit, reason} -> {:error, reason}
+      nil -> {:error, :timeout}
+    end
+  end
+end
+```
+
+Two details make this robust:
+
+* **`async_nolink`** (under a `Task.Supervisor` in your supervision tree)
+  monitors the task instead of linking it. When the heap ceiling kills
+  the task, `Task.yield/2` reports `{:exit, :killed}` and your caller
+  keeps running — a plain `Task.async/1` would link the kill back to the
+  caller and crash it.
+* **`include_shared_binaries: true`** is what makes the memory ceiling
+  actually work for the binary-allocation attacks. Large Lua strings
+  become off-heap BEAM binaries; without this flag they are not counted
+  toward `max_heap_size` and the kill never fires.
+
+> #### max_heap_size is a backstop, not a precise fence {: .warning}
+> The heap limit is checked at garbage-collection time, so a single
+> enormous allocation can momentarily exceed it before the kill lands.
+> The VM's built-in per-operation guards (above) are the deterministic
+> defense; `max_heap_size` catches the accumulation cases they can't see.
+
+## Putting it together
+
+A typical configuration for running untrusted scripts combines all three
+layers — the default sandbox, a call-depth bound, and a process wrapper
+for time and memory:
+
+```elixir
+lua = Lua.new(max_call_depth: 200)
+
+SafeLua.run(lua, untrusted_source)
+```
+
+The default sandbox blocks the OS/filesystem/loader surface, the built-in
+guards turn allocation bombs into catchable errors, `:max_call_depth`
+bounds recursion, and `SafeLua.run/2` bounds wall-clock time and total
+memory — with the host process surviving every one of those failures.

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -23,10 +23,17 @@ defmodule Lua.VM.Dispatcher do
   alias Lua.Compiler.Prototype
   alias Lua.VM.Executor
   alias Lua.VM.InternalError
+  alias Lua.VM.Limits
   alias Lua.VM.Numeric
+  alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Table
   alias Lua.VM.Value
+
+  # Mirror of the interpreter's concat ceiling, inlined as a compile-time
+  # constant so the binary-binary fast path stays a single comparison. See
+  # `Lua.VM.Executor.concat_checked/2` for the rationale.
+  @max_string_bytes Limits.max_string_bytes()
 
   # Opcode tags. These must stay in lockstep with `Lua.Compiler.Bytecode`.
   # The module-attribute form lets each case branch match a constant
@@ -1096,6 +1103,10 @@ defmodule Lua.VM.Dispatcher do
         right = :erlang.element(b + 1, regs)
 
         if is_binary(left) and is_binary(right) do
+          if byte_size(left) + byte_size(right) > @max_string_bytes do
+            raise RuntimeError, value: "resulting string too large"
+          end
+
           regs = :erlang.setelement(dest + 1, regs, left <> right)
           dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
         else

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -14,6 +14,7 @@ defmodule Lua.VM.Executor do
 
   alias Lua.VM.Dispatcher
   alias Lua.VM.InternalError
+  alias Lua.VM.Limits
   alias Lua.VM.Numeric
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
@@ -419,7 +420,7 @@ defmodule Lua.VM.Executor do
     src = proto.source
 
     try_binary_metamethod("__concat", left, right, state, fn ->
-      concat_coerce(left, 0, src) <> concat_coerce(right, 0, src)
+      concat_checked(concat_coerce(left, 0, src), concat_coerce(right, 0, src))
     end)
   end
 
@@ -1350,12 +1351,12 @@ defmodule Lua.VM.Executor do
     # also concatenate without metamethods.
     cond do
       is_binary(left) and is_binary(right) ->
-        regs = put_elem(regs, dest, left <> right)
+        regs = put_elem(regs, dest, concat_checked(left, right))
         do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
 
       (is_binary(left) or is_number(left)) and (is_binary(right) or is_number(right)) ->
         src = proto.source
-        result = concat_coerce(left, line, src) <> concat_coerce(right, line, src)
+        result = concat_checked(concat_coerce(left, line, src), concat_coerce(right, line, src))
         regs = put_elem(regs, dest, result)
         do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
 
@@ -1364,7 +1365,7 @@ defmodule Lua.VM.Executor do
 
         {result, new_state} =
           try_binary_metamethod("__concat", left, right, state, fn ->
-            concat_coerce(left, line, src) <> concat_coerce(right, line, src)
+            concat_checked(concat_coerce(left, line, src), concat_coerce(right, line, src))
           end)
 
         regs = put_elem(regs, dest, result)
@@ -2154,6 +2155,24 @@ defmodule Lua.VM.Executor do
       source: source,
       error_kind: :concatenate_type_error,
       value_type: value_type(value)
+  end
+
+  # `..` builds a new binary on every step. A doubling loop (`s = s .. s`)
+  # reaches sizes where a single concat allocates more than the heap limit
+  # in one BIF call — faster than the GC-time `max_heap_size` check can
+  # react. Guard the size deterministically here, matching the Layer A
+  # stdlib checks, so the loop fails with a catchable error long before it
+  # threatens the host. `byte_size/1` is O(1), so this is cheap on the hot
+  # path. Compile-time constant; no per-call dispatch into `Limits`.
+  @max_string_bytes Limits.max_string_bytes()
+
+  @compile {:inline, concat_checked: 2}
+  defp concat_checked(left, right) when byte_size(left) + byte_size(right) <= @max_string_bytes do
+    left <> right
+  end
+
+  defp concat_checked(_left, _right) do
+    raise RuntimeError, value: "resulting string too large"
   end
 
   # ── Metamethod support ─────────────────────────────────────────────────────

--- a/lib/lua/vm/limits.ex
+++ b/lib/lua/vm/limits.ex
@@ -1,0 +1,66 @@
+defmodule Lua.VM.Limits do
+  @moduledoc """
+  Practical resource ceilings for stdlib operations whose output size is a
+  function of a numeric argument.
+
+  These guard against denial-of-service via a single oversized allocation
+  (e.g. `string.rep("x", 1e15)`, `table.unpack(t, 1, 1e12)`). Each call
+  site computes the result size *before* allocating and asks here whether
+  it is permitted, turning what would otherwise be an out-of-memory crash
+  of the host into a catchable Lua error.
+
+  PUC-Lua raises the same messages — "resulting string too large" on
+  `size_t` overflow in `str_rep`, and "too many results to unpack" on the
+  `INT_MAX` guard in `unpack`. The thresholds here sit far above any
+  legitimate embedded use; they are the same guards at a practical bound
+  rather than at the machine word size.
+
+  This is the deterministic, OTP-independent layer: it never relies on the
+  garbage collector or heap accounting to notice a bomb, because the bomb
+  is refused before a byte is allocated.
+  """
+
+  alias Lua.VM.ArgumentError
+  alias Lua.VM.RuntimeError
+
+  # 256 MiB. A single string this large is already pathological for an
+  # embedded interpreter; legitimate snippets never approach it.
+  @max_string_bytes 256 * 1024 * 1024
+
+  # 10 million elements. Bounds the result list of `table.unpack` and the
+  # element reads of `table.concat`/`table.move` well under what would
+  # exhaust memory, while staying generous for real data.
+  @max_element_count 10_000_000
+
+  @doc "The string-size ceiling, in bytes."
+  @spec max_string_bytes() :: pos_integer()
+  def max_string_bytes, do: @max_string_bytes
+
+  @doc "The element-count ceiling for range-based table operations."
+  @spec max_element_count() :: pos_integer()
+  def max_element_count, do: @max_element_count
+
+  @doc """
+  Asserts that an as-yet-unallocated string of `bytes` bytes is within the
+  ceiling. Raises a catchable "resulting string too large" runtime error
+  otherwise.
+  """
+  @spec check_string_size!(integer()) :: :ok
+  def check_string_size!(bytes) when is_integer(bytes) and bytes <= @max_string_bytes, do: :ok
+
+  def check_string_size!(_bytes) do
+    raise RuntimeError, value: "resulting string too large"
+  end
+
+  @doc """
+  Asserts that a range-based table operation (`concat`, `move`) would not
+  touch more than the element ceiling. Raises a catchable bad-argument
+  error attributed to `function_name` otherwise.
+  """
+  @spec check_range_count!(integer(), String.t()) :: :ok
+  def check_range_count!(count, _function_name) when is_integer(count) and count <= @max_element_count, do: :ok
+
+  def check_range_count!(_count, function_name) do
+    raise ArgumentError, function_name: function_name, details: "range too large"
+  end
+end

--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -9,6 +9,7 @@ defmodule Lua.VM.Stdlib do
   alias Lua.VM.ArgumentError
   alias Lua.VM.AssertionError
   alias Lua.VM.Executor
+  alias Lua.VM.Limits
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Table
@@ -446,7 +447,7 @@ defmodule Lua.VM.Stdlib do
   # if the reader ever returns a non-string non-nil value, mirroring the
   # behavior of Lua 5.3's reference implementation.
   defp load_from_reader(reader, env, state) do
-    case collect_reader_chunks(reader, state, []) do
+    case collect_reader_chunks(reader, state, [], 0) do
       {:ok, source, state} ->
         compile_loaded_chunk(source, env, state)
 
@@ -461,7 +462,7 @@ defmodule Lua.VM.Stdlib do
   defp load_env_arg([_chunkname, _mode, env | _], _state) when env != nil, do: env
   defp load_env_arg(_rest, state), do: State.g_ref(state)
 
-  defp collect_reader_chunks(reader, state, acc) do
+  defp collect_reader_chunks(reader, state, acc, size) do
     {results, state} = Executor.call_function(reader, [], state)
 
     case results do
@@ -475,7 +476,11 @@ defmodule Lua.VM.Stdlib do
         {:ok, IO.iodata_to_binary(Enum.reverse(acc)), state}
 
       [piece | _] when is_binary(piece) ->
-        collect_reader_chunks(reader, state, [piece | acc])
+        # A reader that never signals end-of-input would otherwise accumulate
+        # chunks until the host runs out of memory. Bound the total source
+        # size with the same ceiling used for string allocations.
+        Limits.check_string_size!(size + byte_size(piece))
+        collect_reader_chunks(reader, state, [piece | acc], size + byte_size(piece))
 
       [bad | _] ->
         {:error, "reader function must return a string (got #{Value.type_name(bad)})", state}

--- a/lib/lua/vm/stdlib.ex
+++ b/lib/lua/vm/stdlib.ex
@@ -478,7 +478,11 @@ defmodule Lua.VM.Stdlib do
       [piece | _] when is_binary(piece) ->
         # A reader that never signals end-of-input would otherwise accumulate
         # chunks until the host runs out of memory. Bound the total source
-        # size with the same ceiling used for string allocations.
+        # size with the same ceiling used for string allocations. Note this
+        # raises rather than returning load's documented `(nil, message)`
+        # pair: an oversized reader is a DoS attempt, not a recoverable
+        # syntax error, so we surface it as a catchable runtime error
+        # (caught by `pcall`) instead of a quiet load failure.
         Limits.check_string_size!(size + byte_size(piece))
         collect_reader_chunks(reader, state, [piece | acc], size + byte_size(piece))
 

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -32,6 +32,7 @@ defmodule Lua.VM.Stdlib.String do
 
   alias Lua.VM.ArgumentError
   alias Lua.VM.Executor
+  alias Lua.VM.Limits
   alias Lua.VM.State
   alias Lua.VM.Stdlib.Pattern
   alias Lua.VM.Stdlib.String.Pack
@@ -212,6 +213,10 @@ defmodule Lua.VM.Stdlib.String do
       if n <= 0 do
         ""
       else
+        # Compute the result size from the count *before* building it, so an
+        # oversized request fails with a catchable error instead of trying to
+        # allocate (and OOM the host on) a multi-petabyte binary.
+        Limits.check_string_size!(n * byte_size(str) + (n - 1) * byte_size(sep))
         Enum.map_join(1..n, sep, fn _ -> str end)
       end
 
@@ -364,13 +369,27 @@ defmodule Lua.VM.Stdlib.String do
     format_string(rest2, remaining_args, [acc, str])
   end
 
+  # PUC-Lua copies at most two width and two precision digits into the
+  # conversion spec (`scanformat`), erroring on anything longer. We enforce
+  # the same bound so a spec like `%.2000000000f` cannot drive a giant
+  # `String.duplicate`/padding allocation.
+  @max_format_field 99
+
   # Parse a format spec: [flags][width][.precision]specifier
   defp parse_format_spec(str) do
     {flags, str} = parse_flags(str, 0)
     {width, str} = parse_width(str)
     {precision, str} = parse_precision(str)
     {specifier, str} = parse_specifier(str)
+    check_format_field!(width)
+    check_format_field!(precision)
     {{flags, width, precision, specifier}, str}
+  end
+
+  defp check_format_field!(n) when is_nil(n) or n <= @max_format_field, do: :ok
+
+  defp check_format_field!(_n) do
+    raise ArgumentError, function_name: "string.format", details: "invalid conversion"
   end
 
   # Flags are parsed once into an integer bitmask so the apply path reads

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -35,14 +35,6 @@ defmodule Lua.VM.Stdlib.Table do
   alias Lua.VM.Stdlib.Util
   alias Lua.VM.Table
 
-  # Upper bound on the number of values `table.unpack` may produce. Lua
-  # 5.3's `ltablib.c` rejects ranges in two arms: the element count
-  # `n = (j - i) + 1` overflowing `INT_MAX`, and `lua_checkstack` failing
-  # for that count (which trips at `n == INT_MAX` after its internal
-  # `++n`). Both reduce to rejecting when `n >= INT_MAX`, i.e. when
-  # `(j - i) >= INT_MAX - 1`, before materialising any results.
-  @unpack_max_results 2_147_483_647
-
   @impl true
   def lib_name, do: "table"
 
@@ -461,13 +453,15 @@ defmodule Lua.VM.Stdlib.Table do
         got: Util.typeof(j)
     end
 
-    # Reject ranges whose element count `(j - i) + 1` reaches INT_MAX
-    # before materialising anything. `ltablib.c` does the same check up
-    # front (count overflow plus the `lua_checkstack` arm), so
-    # `table.unpack({}, 0, math.maxinteger)` errors immediately instead of
-    # trying to build an enormous list. The subtraction stays within
-    # Elixir's arbitrary-precision integers, so it cannot overflow.
-    if i <= j and j - i >= @unpack_max_results - 1 do
+    # Reject an oversized result count before materialising anything.
+    # `ltablib.c` rejects only at INT_MAX (count overflow plus the
+    # `lua_checkstack` arm), but on the BEAM even a sub-INT_MAX count like
+    # `table.unpack({}, 1, 5e8)` would build hundreds of millions of nils
+    # and exhaust the host. We share `Limits.max_element_count` with
+    # `concat`/`move` so the deterministic ceiling is uniform, well below
+    # INT_MAX yet far above any legitimate unpack. The subtraction stays
+    # within Elixir's arbitrary-precision integers, so it cannot overflow.
+    if i <= j and j - i >= Limits.max_element_count() do
       raise RuntimeError.exception(value: "too many results to unpack")
     end
 

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -29,6 +29,7 @@ defmodule Lua.VM.Stdlib.Table do
 
   alias Lua.VM.ArgumentError
   alias Lua.VM.Executor
+  alias Lua.VM.Limits
   alias Lua.VM.RuntimeError
   alias Lua.VM.State
   alias Lua.VM.Stdlib.Util
@@ -220,6 +221,9 @@ defmodule Lua.VM.Stdlib.Table do
     # metatable) read directly from `data`, skipping the __index dispatch;
     # tables with a metatable keep the Executor path so __index is observed.
     table = Map.fetch!(state.tables, id)
+
+    # Refuse an oversized range before allocating the result list.
+    if i <= j, do: Limits.check_range_count!(j - i + 1, "table.concat")
 
     {elements, state} =
       cond do
@@ -513,6 +517,8 @@ defmodule Lua.VM.Stdlib.Table do
       if f > e do
         state
       else
+        Limits.check_range_count!(e - f + 1, "table.move")
+
         # Read each src slot via __index on tref1, write to dst via
         # __newindex on tref2. Aliasing (tref1 == tref2 with overlapping
         # ranges) is handled by reading every value first, then writing

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Lua.MixProject do
         extras: [
           "CHANGELOG.md",
           "guides/working-with-lua.livemd",
+          "guides/sandboxing.md",
           "guides/examples/quickstart.livemd",
           "guides/examples/userdata.livemd",
           "guides/examples/custom_stdlib.livemd",

--- a/test/lua/vm/limits_test.exs
+++ b/test/lua/vm/limits_test.exs
@@ -1,0 +1,90 @@
+defmodule Lua.VM.LimitsTest do
+  @moduledoc """
+  Pins the resource ceilings that turn allocation-bomb DoS attempts into
+  catchable Lua errors instead of host out-of-memory crashes.
+
+  Each oversized operation must (a) fail rather than allocate, and (b) be
+  catchable with `pcall`, so embedding code can recover. The companion
+  checks assert that ordinary, in-bounds calls are untouched.
+  """
+  use ExUnit.Case, async: true
+
+  setup do
+    %{lua: Lua.new(sandboxed: [])}
+  end
+
+  defp pcall_error(lua, expr) do
+    {[false, message], _} = Lua.eval!(lua, "return pcall(function() #{expr} end)")
+    message
+  end
+
+  describe "string.rep" do
+    test "refuses an oversized single allocation", %{lua: lua} do
+      assert pcall_error(lua, ~s|return string.rep("x", 1e15)|) =~ "resulting string too large"
+    end
+
+    test "still repeats in-bounds strings", %{lua: lua} do
+      assert {["ababab"], _} = Lua.eval!(lua, ~s|return string.rep("ab", 3)|)
+      assert {["a-a-a"], _} = Lua.eval!(lua, ~s|return string.rep("a", 3, "-")|)
+    end
+  end
+
+  describe "string concatenation (..)" do
+    test "refuses a doubling bomb before it exhausts memory", %{lua: lua} do
+      code = "local s = 'x' for _ = 1, 80 do s = s .. s end return s"
+      assert pcall_error(lua, code) =~ "resulting string too large"
+    end
+
+    test "still concatenates ordinary strings", %{lua: lua} do
+      assert {["foobar42"], _} = Lua.eval!(lua, ~s|return "foo" .. "bar" .. 42|)
+    end
+  end
+
+  describe "string.format" do
+    test "refuses an oversized precision field", %{lua: lua} do
+      assert pcall_error(lua, ~s|return string.format("%.2000000000f", 1.0)|) =~
+               "invalid conversion"
+    end
+
+    test "still formats ordinary specs", %{lua: lua} do
+      assert {["3.142"], _} = Lua.eval!(lua, ~s|return string.format("%.3f", 3.14159)|)
+    end
+  end
+
+  describe "table.concat" do
+    test "refuses an oversized range", %{lua: lua} do
+      assert pcall_error(lua, ~s|return table.concat({1, 2}, ",", 1, 20000000)|) =~
+               "range too large"
+    end
+
+    test "still concatenates ordinary tables", %{lua: lua} do
+      assert {["1,2,3"], _} = Lua.eval!(lua, ~s|return table.concat({1, 2, 3}, ",")|)
+    end
+  end
+
+  describe "table.move" do
+    test "refuses an oversized range", %{lua: lua} do
+      assert pcall_error(lua, ~s|local t = {} return table.move(t, 1, 20000000, 1)|) =~
+               "range too large"
+    end
+
+    test "still moves ordinary ranges", %{lua: lua} do
+      code = "local t = {1, 2, 3} table.move(t, 1, 3, 2) return t[2], t[3], t[4]"
+      assert {[1, 2, 3], _} = Lua.eval!(lua, code)
+    end
+  end
+
+  describe "load reader" do
+    test "refuses a reader that never signals end-of-input", %{lua: lua} do
+      # A reader returning a 1 MiB chunk forever would accumulate without
+      # bound; the byte cap stops it with the string ceiling's message.
+      # The reader's error propagates out of `load`, so it surfaces via pcall.
+      code = ~s|
+        local chunk = string.rep("a", 1024 * 1024)
+        load(function() return chunk end)
+      |
+
+      assert pcall_error(lua, code) =~ "resulting string too large"
+    end
+  end
+end

--- a/test/lua/vm/stdlib/table_test.exs
+++ b/test/lua/vm/stdlib/table_test.exs
@@ -141,19 +141,21 @@ defmodule Lua.VM.Stdlib.TableTest do
       assert {:ok, [20, 30, 40], _state} = VM.execute(proto, state)
     end
 
-    test "table.unpack rejects ranges with more than INT_MAX results" do
+    test "table.unpack rejects oversized result ranges before materialising" do
       # Lua 5.3 sort.lua line 48: `checkerror("too many results", unpack,
       # {}, 0, maxi)`. A huge `j` must raise up front rather than try to
-      # materialise the slice (which would hang the VM).
+      # materialise the slice (which would hang the VM). On the BEAM we
+      # share the `concat`/`move` element ceiling, so even a sub-INT_MAX
+      # range (which PUC would accept) is rejected before allocating.
       for code <- [
             "return table.unpack({}, 0, math.maxinteger)",
             "return table.unpack({}, 1, math.maxinteger)",
             "return table.unpack({}, math.mininteger, math.maxinteger)",
             "return table.unpack({}, 0, (1 << 31) - 1)",
-            # Element count exactly INT_MAX: `j - i == INT_MAX - 1`. PUC
-            # rejects this via the `lua_checkstack` arm, not the count
-            # overflow arm.
-            "return table.unpack({}, 1, (1 << 31) - 1)"
+            "return table.unpack({}, 1, (1 << 31) - 1)",
+            # A sub-INT_MAX count that PUC accepts but would still allocate
+            # hundreds of millions of nils on the BEAM and OOM the host.
+            "return table.unpack({}, 1, 500000000)"
           ] do
         assert_raise Lua.RuntimeException, ~r/too many results/, fn ->
           Lua.eval!(Lua.new(), code)

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -772,13 +772,13 @@ defmodule Website.LuaSandbox do
           "Flooding print() can't exhaust memory either — captured output is capped and the rest is dropped.",
         source: """
         -- Print far more than the output buffer keeps (cap is 5,000 lines).
-        for i = 1, 20000 do
+        for i = 1, 6000 do
           print("line " .. i)
         end
         return "done"
         """,
         chunk: ~LUA"""
-        for i = 1, 20000 do
+        for i = 1, 6000 do
           print("line " .. i)
         end
         return "done"

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -102,9 +102,16 @@ defmodule Website.LuaSandbox do
         {:eval_result, result} ->
           result
 
-        # Worker hit the memory ceiling (or otherwise died) before delivering.
-        {:EXIT, ^worker, _reason} ->
+        # Worker hit the memory ceiling: max_heap_size kills it with
+        # `:killed`, which is the only abnormal exit we attribute to the
+        # memory limit.
+        {:EXIT, ^worker, :killed} ->
           memory_result(started)
+
+        # Any other abnormal worker exit is an unrelated crash; surface it
+        # as a generic error rather than mislabeling it a memory limit.
+        {:EXIT, ^worker, reason} ->
+          error_result(started, reason)
 
         # This task is being cancelled by the caller (the LiveView timeout).
         # Stop the worker and let the cancellation proceed.
@@ -138,6 +145,17 @@ defmodule Website.LuaSandbox do
       output: "",
       returns: [],
       error: "Execution exceeded the memory limit and was stopped",
+      duration_us: System.monotonic_time(:microsecond) - started,
+      bytecode: []
+    }
+  end
+
+  defp error_result(started, reason) do
+    %{
+      status: :error,
+      output: "",
+      returns: [],
+      error: "Execution failed: #{inspect(reason)}",
       duration_us: System.monotonic_time(:microsecond) - started,
       bytecode: []
     }
@@ -753,14 +771,14 @@ defmodule Website.LuaSandbox do
         blurb:
           "Flooding print() can't exhaust memory either — captured output is capped and the rest is dropped.",
         source: """
-        -- Print far more than the output buffer keeps.
-        for i = 1, 100000 do
+        -- Print far more than the output buffer keeps (cap is 5,000 lines).
+        for i = 1, 20000 do
           print("line " .. i)
         end
         return "done"
         """,
         chunk: ~LUA"""
-        for i = 1, 100000 do
+        for i = 1, 20000 do
           print("line " .. i)
         end
         return "done"

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -767,6 +767,10 @@ defmodule Website.LuaSandbox do
       %{
         id: "output-flood",
         category: "Security &amp; limits",
+        # The output buffer is capped, so this run completes cleanly; the
+        # `:ok_or_limit` expectation also tolerates the 2s wall-clock backstop
+        # tripping on a slow runner rather than asserting a strict status.
+        expect: :ok_or_limit,
         title: "Output flood",
         blurb:
           "Flooding print() can't exhaust memory either — captured output is capped and the rest is dropped.",

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -7,8 +7,13 @@ defmodule Website.LuaSandbox do
   the library's default deny-list (no `io.*`, `os.*`, `require`,
   `package`, `load`, etc.).
 
-  This module is intentionally process-free: timeout enforcement and
-  task lifecycle are the caller's responsibility (the LiveView wraps
+  Evaluation runs in an isolated, memory-capped worker process. A snippet
+  that grows the heap past the ceiling (e.g. an unbounded table) is killed
+  by the BEAM's `max_heap_size` and surfaced as a normal "memory limit"
+  result rather than crashing the caller. `include_shared_binaries: true`
+  is required so off-heap binaries count toward that ceiling. `run/1` also
+  applies a safety wall-clock timeout so a non-terminating snippet always
+  returns; the LiveView layers a shorter UI timeout on top (it wraps
   `run/1` in `start_async/3` and cancels it on a timer).
   """
 
@@ -56,10 +61,89 @@ defmodule Website.LuaSandbox do
   @spec run(String.t()) :: result()
   def run(source) when is_binary(source), do: do_run(source)
 
+  # ~64 MB per-run memory ceiling, in heap words (8 bytes/word on 64-bit).
+  # include_shared_binaries makes off-heap binaries count — without it a
+  # binary bomb would not trip the limit.
+  @lua_heap_words 8_000_000
+
+  # Standalone safety timeout so `run/1` always returns even for a
+  # non-terminating snippet (`while true do end`). The LiveView sets a
+  # shorter UI timeout (1.5s) and cancels first; this is the backstop for
+  # any other caller.
+  @run_timeout_ms 2_000
+
   defp do_run(source) do
     started = System.monotonic_time(:microsecond)
-    output_pid = start_output_collector()
+    parent = self()
 
+    # Trap exits so the worker dying — whether it finishes, is killed by the
+    # memory ceiling, or is torn down when this task is cancelled — arrives
+    # as a message instead of propagating and crashing the caller. Restore
+    # the caller's flag afterwards so `run/1` leaves no trace.
+    prev_trap = Process.flag(:trap_exit, true)
+
+    worker =
+      spawn_link(fn ->
+        Process.flag(:max_heap_size, %{
+          size: @lua_heap_words,
+          kill: true,
+          error_logger: false,
+          include_shared_binaries: true
+        })
+
+        # Collector is linked to the worker (not us), so its normal exit
+        # never lands in our mailbox to be mistaken for a cancellation.
+        output_pid = start_output_collector()
+        send(parent, {:eval_result, eval(source, output_pid, started)})
+      end)
+
+    try do
+      receive do
+        {:eval_result, result} ->
+          result
+
+        # Worker hit the memory ceiling (or otherwise died) before delivering.
+        {:EXIT, ^worker, _reason} ->
+          memory_result(started)
+
+        # This task is being cancelled by the caller (the LiveView timeout).
+        # Stop the worker and let the cancellation proceed.
+        {:EXIT, _other, reason} ->
+          Process.exit(worker, :kill)
+          exit(reason)
+      after
+        @run_timeout_ms ->
+          Process.exit(worker, :kill)
+          timeout_result(started)
+      end
+    after
+      Process.flag(:trap_exit, prev_trap)
+    end
+  end
+
+  defp timeout_result(started) do
+    %{
+      status: :timeout,
+      output: "",
+      returns: [],
+      error: "Execution timed out after #{@run_timeout_ms}ms",
+      duration_us: System.monotonic_time(:microsecond) - started,
+      bytecode: []
+    }
+  end
+
+  defp memory_result(started) do
+    %{
+      status: :timeout,
+      output: "",
+      returns: [],
+      error: "Execution exceeded the memory limit and was stopped",
+      duration_us: System.monotonic_time(:microsecond) - started,
+      bytecode: []
+    }
+  end
+
+  defp eval(source, output_pid, started) do
     lua =
       Lua.new(max_call_depth: @max_call_depth)
       |> Lua.set!([:print], fn args ->
@@ -116,17 +200,50 @@ defmodule Website.LuaSandbox do
     String.replace(s, ~r/\e\[[\d;]*[\x40-\x7E]/, "")
   end
 
+  # A runaway `for i=1,1e9 do print(i) end` would otherwise grow this
+  # collector's buffer (and mailbox) without bound. Cap both the retained
+  # output and the collector's own memory so a print-flood degrades to
+  # truncated output instead of exhausting the node.
+  @max_output_lines 5_000
+  @max_output_bytes 1_000_000
+  # ~32 MB, in words — bounds the mailbox if prints arrive faster than we
+  # drain them. include_shared_binaries so large printed binaries count.
+  @collector_heap_words 4_000_000
+
   defp start_output_collector do
-    spawn_link(fn -> collect_loop([]) end)
+    spawn_link(fn ->
+      Process.flag(:max_heap_size, %{
+        size: @collector_heap_words,
+        kill: true,
+        error_logger: false,
+        include_shared_binaries: true
+      })
+
+      collect_loop([], 0, 0, false)
+    end)
   end
 
-  defp collect_loop(acc) do
+  defp collect_loop(acc, lines, bytes, truncated) do
     receive do
+      {:line, _line} when truncated ->
+        # Already over the cap — drain and discard so the producer's sends
+        # don't pile up, but keep the buffer fixed.
+        collect_loop(acc, lines, bytes, true)
+
       {:line, line} ->
-        collect_loop([line | acc])
+        lines = lines + 1
+        bytes = bytes + byte_size(line)
+
+        if lines > @max_output_lines or bytes > @max_output_bytes do
+          collect_loop(acc, lines, bytes, true)
+        else
+          collect_loop([line | acc], lines, bytes, false)
+        end
 
       {:dump, from} ->
-        send(from, {:lines, Enum.reverse(acc)})
+        out = Enum.reverse(acc)
+        out = if truncated, do: out ++ ["… output truncated"], else: out
+        send(from, {:lines, out})
     end
   end
 
@@ -334,6 +451,7 @@ defmodule Website.LuaSandbox do
     [
       %{
         id: "hello",
+        category: "Language",
         title: "Hello, Lua",
         blurb: "Your first Lua program on the BEAM.",
         source: ~s|print("Hello, Lua on the BEAM!")\nreturn 42\n|,
@@ -344,6 +462,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "fib",
+        category: "Language",
         title: "Recursive Fibonacci",
         blurb: "Classic recursion. Watch the closure prototype and tail-calls in the bytecode.",
         source: """
@@ -373,6 +492,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "tables",
+        category: "Language",
         title: "Tables &amp; iteration",
         blurb: "Lua's one true data structure. Mix array and hash parts freely.",
         source: """
@@ -408,6 +528,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "closures",
+        category: "Language",
         title: "Closures &amp; upvalues",
         blurb: "Counter factory. See how upvalues are captured in the bytecode.",
         source: """
@@ -439,6 +560,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "patterns",
+        category: "Language",
         title: "String patterns",
         blurb: "Lua's tiny but mighty pattern engine. No regex needed.",
         source: """
@@ -464,6 +586,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "metatables",
+        category: "Language",
         title: "Metatables",
         blurb: "Operator overloading via __add. Lua's secret weapon for DSLs.",
         source: """
@@ -507,6 +630,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "sandbox",
+        category: "Security &amp; limits",
         title: "Sandbox escape",
         blurb:
           "Watch the VM refuse to run dangerous stdlib calls. This is the reason it's agent-ready.",
@@ -538,7 +662,113 @@ defmodule Website.LuaSandbox do
         """c
       },
       %{
+        id: "string-bomb",
+        category: "Security &amp; limits",
+        title: "String allocation bomb",
+        blurb:
+          "The classic &quot;allocate until the host dies&quot; attack. The VM computes the size first and refuses — before a byte is allocated.",
+        source: """
+        -- string.rep with a huge count would build a petabyte string.
+        local ok, err = pcall(string.rep, "x", 1e15)
+        print("string.rep ok?", ok)
+        print("err:", err)
+
+        -- Doubling in a loop is guarded the same way.
+        local ok2, err2 = pcall(function()
+          local s = "x"
+          for _ = 1, 80 do s = s .. s end
+          return #s
+        end)
+        print("doubling ok?", ok2)
+        print("err:", err2)
+
+        return ok, ok2
+        """,
+        chunk: ~LUA"""
+        local ok, err = pcall(string.rep, "x", 1e15)
+        print("string.rep ok?", ok)
+        print("err:", err)
+
+        local ok2, err2 = pcall(function()
+          local s = "x"
+          for _ = 1, 80 do s = s .. s end
+          return #s
+        end)
+        print("doubling ok?", ok2)
+        print("err:", err2)
+
+        return ok, ok2
+        """c
+      },
+      %{
+        id: "memory-bomb",
+        category: "Security &amp; limits",
+        title: "Memory limit",
+        expect: :limit,
+        blurb:
+          "Growing a table without bound can't OOM the node — each run has a memory ceiling, and exceeding it stops the run while the server stays up.",
+        source: """
+        -- Allocate millions of tables until memory is exhausted.
+        local t = {}
+        for i = 1, 1e9 do
+          t[i] = { i, i, i }
+        end
+        return #t
+        """,
+        chunk: ~LUA"""
+        local t = {}
+        for i = 1, 1e9 do
+          t[i] = { i, i, i }
+        end
+        return #t
+        """c
+      },
+      %{
+        id: "timeout",
+        category: "Security &amp; limits",
+        title: "Infinite loop",
+        expect: :limit,
+        blurb:
+          "A loop that never ends can't hang the server: a wall-clock timeout stops the run after 1.5 seconds.",
+        source: """
+        -- Spin forever. The runtime cancels the run on a timer.
+        local n = 0
+        while true do
+          n = n + 1
+        end
+        return n
+        """,
+        chunk: ~LUA"""
+        local n = 0
+        while true do
+          n = n + 1
+        end
+        return n
+        """c
+      },
+      %{
+        id: "output-flood",
+        category: "Security &amp; limits",
+        title: "Output flood",
+        blurb:
+          "Flooding print() can't exhaust memory either — captured output is capped and the rest is dropped.",
+        source: """
+        -- Print far more than the output buffer keeps.
+        for i = 1, 100000 do
+          print("line " .. i)
+        end
+        return "done"
+        """,
+        chunk: ~LUA"""
+        for i = 1, 100000 do
+          print("line " .. i)
+        end
+        return "done"
+        """c
+      },
+      %{
         id: "error",
+        category: "Errors",
         title: "Compile error",
         blurb: "See the friendly compiler error path.",
         expect: :compile_error,
@@ -550,6 +780,7 @@ defmodule Website.LuaSandbox do
       },
       %{
         id: "runtime-error",
+        category: "Errors",
         title: "Runtime error",
         blurb: "Watch the VM blame the offending local by name, with a real stack trace.",
         expect: :runtime_error,
@@ -585,6 +816,22 @@ defmodule Website.LuaSandbox do
         """c
       }
     ]
+  end
+
+  # Display order for the playground's example categories.
+  @category_order ["Language", "Security &amp; limits", "Errors"]
+
+  @doc """
+  Returns examples grouped by category, in display order. Each group is a
+  map with `:category` and `:examples`, preserving `examples/0` order
+  within the group. Categories with no examples are omitted.
+  """
+  def examples_by_category do
+    by_category = Enum.group_by(examples(), & &1.category)
+
+    for category <- @category_order, examples = by_category[category], examples != nil do
+      %{category: category, examples: examples}
+    end
   end
 
   @doc """

--- a/website/lib/website_web/live/playground_live.ex
+++ b/website/lib/website_web/live/playground_live.ex
@@ -489,14 +489,14 @@ defmodule DemoWeb.PlaygroundLive do
                 <div class="text-xs uppercase text-base-content/50 mb-1">
                   Output before error
                 </div>
-                <pre class="whitespace-pre-wrap text-base-content/80"><%= @result.output %></pre>
+                <pre class="whitespace-pre-wrap text-base-content/80 max-h-80 overflow-y-auto scrollbar-thin"><%= @result.output %></pre>
               </div>
             <% end %>
           <% match?(%{status: :timeout}, @result) -> %>
             <div class="text-warning">{@result.error}</div>
           <% match?(%{status: :ok}, @result) -> %>
             <%= if @result.output != "" do %>
-              <pre class="whitespace-pre-wrap text-base-content/90"><%= @result.output %></pre>
+              <pre class="whitespace-pre-wrap text-base-content/90 max-h-80 overflow-y-auto scrollbar-thin"><%= @result.output %></pre>
             <% end %>
             <%= if @result.returns != [] do %>
               <div class={["mt-1", @result.output != "" && "border-t border-base-300/50 pt-2"]}>

--- a/website/lib/website_web/live/playground_live.ex
+++ b/website/lib/website_web/live/playground_live.ex
@@ -13,6 +13,7 @@ defmodule DemoWeb.PlaygroundLive do
       socket
       |> assign(:page_title, "Playground")
       |> assign(:examples, LuaSandbox.examples())
+      |> assign(:example_groups, LuaSandbox.examples_by_category())
       |> assign(:active_example, "hello")
       |> assign(:source, default_source("hello"))
       |> assign(:blocks, LuaSandbox.example_blocks("hello"))
@@ -171,6 +172,8 @@ defmodule DemoWeb.PlaygroundLive do
   end
 
   def handle_async(:lua_run, {:exit, _reason}, socket) do
+    # Only the wall-clock cancel reaches here now — a memory kill is
+    # contained inside `LuaSandbox.run/1` and returns a normal result.
     {:noreply,
      socket
      |> finish_lua_run()
@@ -287,19 +290,28 @@ defmodule DemoWeb.PlaygroundLive do
           </div>
         </div>
 
-        <div class="flex gap-2 overflow-x-auto pb-3 -mx-1 px-1 mb-3 scrollbar-thin">
-          <%= for ex <- @examples do %>
-            <button
-              phx-click="load-example"
-              phx-value-id={ex.id}
-              class={[
-                "btn btn-sm whitespace-nowrap",
-                @active_example == ex.id && "btn-primary",
-                @active_example != ex.id && "btn-outline"
-              ]}
-            >
-              {raw(ex.title)}
-            </button>
+        <div class="flex flex-col gap-2.5 mb-4">
+          <%= for group <- @example_groups do %>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-x-3 gap-y-1.5">
+              <span class="text-[0.65rem] uppercase tracking-wider font-semibold text-base-content/40 sm:w-28 shrink-0">
+                {raw(group.category)}
+              </span>
+              <div class="flex flex-wrap gap-2">
+                <%= for ex <- group.examples do %>
+                  <button
+                    phx-click="load-example"
+                    phx-value-id={ex.id}
+                    class={[
+                      "btn btn-sm whitespace-nowrap",
+                      @active_example == ex.id && "btn-primary",
+                      @active_example != ex.id && "btn-outline"
+                    ]}
+                  >
+                    {raw(ex.title)}
+                  </button>
+                <% end %>
+              </div>
+            </div>
           <% end %>
         </div>
 

--- a/website/test/website/lua_examples_test.exs
+++ b/website/test/website/lua_examples_test.exs
@@ -52,6 +52,16 @@ defmodule Website.LuaExamplesTest do
 
           assert match?({:ok, _chunk, _blocks}, LuaSandbox.compile(@example.source)),
                  "expected #{@label} to compile cleanly (stopped at runtime)"
+
+        :ok_or_limit ->
+          # Demos that complete cleanly under the caps but ride the real
+          # wall-clock backstop. Tolerate a :timeout so a slow CI runner can't
+          # flake the suite, while still asserting clean compilation.
+          assert result.status in [:ok, :timeout],
+                 "expected #{@label} to run cleanly or hit the backstop, got: #{inspect(result.status)}"
+
+          assert match?({:ok, _chunk, _blocks}, LuaSandbox.compile(@example.source)),
+                 "expected #{@label} to compile cleanly"
       end
     end
   end

--- a/website/test/website/lua_examples_test.exs
+++ b/website/test/website/lua_examples_test.exs
@@ -43,6 +43,15 @@ defmodule Website.LuaExamplesTest do
 
           assert match?({:ok, _chunk, _blocks}, LuaSandbox.compile(@example.source)),
                  "expected #{@label} to compile cleanly (runtime-only failure)"
+
+        :limit ->
+          # Resource-limit demos (memory ceiling / wall-clock timeout) compile
+          # and start fine, but the run is stopped and reported as a timeout.
+          assert result.status == :timeout,
+                 "expected #{@label} to hit a resource limit, got: #{inspect(result.status)}"
+
+          assert match?({:ok, _chunk, _blocks}, LuaSandbox.compile(@example.source)),
+                 "expected #{@label} to compile cleanly (stopped at runtime)"
       end
     end
   end


### PR DESCRIPTION
## Why

The VM is exposed publicly via the playground, which runs arbitrary
untrusted Lua. A red-team pass found that, while the *escape* surface was
already closed (`os`/`io`/`require`/`load` are denied by default), the VM
had **no defense against resource-exhaustion DoS**. The headline case:
`string.rep("x", 1e15)` allocates a petabyte off-heap and OOMs the entire
BEAM node — taking down every session, not just the attacker's.

## What this does

Layered, defense-in-depth, with the **deterministic** guards doing the
real work and the BEAM heap limit as a backstop.

**Library (deterministic, benefits every consumer):**
- New `Lua.VM.Limits` — computes result size from the argument *before*
  allocating and raises a catchable error (~256 MiB strings, 10M elems).
- Guards on `string.rep`, `string.format` width/precision,
  `table.unpack`/`concat`/`move`, the `load` reader, and the `..` operator
  (in both the interpreter and the compiled dispatcher).
- Messages mirror PUC-Lua (`resulting string too large`, `too many
  results to unpack`).

**Playground host (`website/`):**
- Runs each snippet in an isolated, memory-capped worker
  (`max_heap_size` with `include_shared_binaries: true`) and converts a
  memory kill into a graceful "memory limit" result. Previously the
  `:killed` exit propagated and **crashed the LiveView**.
- `run/1` gains a standalone safety timeout and restores the caller's
  `trap_exit`; the output collector is capped against `print` floods.
- Examples are grouped into categories (Language, Security & limits,
  Errors) with new demos: string bomb, memory limit, infinite loop,
  output flood.

**Docs:**
- New `guides/sandboxing.md` covering capability sandboxing, the built-in
  limits, `:max_call_depth`, and the host pattern for CPU/memory — with
  the two BEAM gotchas spelled out (`include_shared_binaries: true` is
  mandatory; use `async_nolink` so a kill doesn't crash the caller).

## Key finding: max_heap_size and off-heap binaries

Verified empirically on OTP 29: a plain `max_heap_size` does **not** count
off-heap refc binaries, so a binary bomb sails past it.
`include_shared_binaries: true` (OTP 27+, off by default) fixes that — but
it's GC-timed, so it can't preempt a single giant allocation. That's why
the per-operation library guards (which refuse *before* allocating) are
the primary defense and the heap limit is the backstop.

## Verification

- New `test/lua/vm/limits_test.exs` (13 tests); `lua_examples_test.exs`
  gains a `:limit` expectation for the resource-limit demos.
- `mix test` green (lua 2051 / 22 skipped; website 52), `mix test --only
  lua53` OK, `mix dialyzer` 0 errors, `mix format --check-formatted` OK.
- Every vector demonstrated live in the playground: each fails with a
  clean catchable error / timeout / truncation, and the node + LiveView
  survive (a normal program runs immediately after).

## Follow-up (not in this PR)

A VM-level instruction/allocation budget (`max_steps` via `Lua.new/1`)
for library consumers who don't wrap calls in a timeout. Deferred as a
separate, benchmarked change since it touches the hot `do_execute` path;
infinite loops in the playground are already covered by the wall-clock
timeout.

## Issues

Partially addresses #77 (execution quotas) — the allocation-bomb guards
and the host CPU/memory pattern. The VM-level step budget (`max_steps`)
portion is deferred to #306.
