### PR TITLE
chore(workflow): add PR-feedback-stabilize and ship-issue-batch orchestration scripts

### DIFF
--- a/.agents/workflows/pr-feedback-stabilize.mjs
+++ b/.agents/workflows/pr-feedback-stabilize.mjs
@@ -1,0 +1,281 @@
+export const meta = {
+  name: 'pr-feedback-stabilize',
+  description: 'For each open PR: address current review feedback (pr-feedback-handler method) and push, then run an independent review round, looping address→review until the PR stabilizes (no actionable findings) or a round cap is hit. Posts each review to the PR. Never merges.',
+  phases: [
+    { title: 'Round 1', detail: 'address existing PR feedback + push, then independent review' },
+    { title: 'Round 2', detail: 'address round-1 review findings + push, then re-review' },
+    { title: 'Round 3', detail: 'address round-2 review findings + push, then final review' },
+  ],
+}
+
+const MAX_ROUNDS = 3
+
+// ---------------------------------------------------------------------------
+// PRs to stabilize (branch names from `gh pr list`).
+// ---------------------------------------------------------------------------
+const PRS = [
+  { num: 305, branch: 'vm-dos-resource-limits',      label: 'vm-dos',          title: 'Harden the VM against allocation-bomb DoS; document sandboxing' },
+  { num: 304, branch: 'errors/quality-pass',         label: 'error-render',    title: 'feat(error): lead rendered errors with location and gate ANSI on TTY' },
+  { num: 302, branch: 'feat/vfs-sandbox',            label: 'vfs',             title: 'feat(stdlib): route os/require file IO through a virtual filesystem' },
+  { num: 300, branch: 'docs/examples',               label: 'examples',        title: 'docs(examples): add runnable embedding examples' },
+  { num: 298, branch: 'docs/readme-rewrite',         label: 'readme',          title: 'docs(readme): rewrite for 1.0 positioning, quickstart, and tour' },
+  { num: 282, branch: 'chore/constructs-triage-narrow', label: 'constructs-narrow', title: 'chore(suite): narrow constructs.lua skip with per-failure tracking' },
+]
+
+// ---------------------------------------------------------------------------
+// Shared repo conventions every agent must honor (from .agents/skills/* and
+// the sibling triage-implement-review workflow).
+// ---------------------------------------------------------------------------
+const CONV = `
+REPO: tv-labs/lua — an embedded Lua 5.3 VM written in Elixir. The canonical
+checkout is /Users/dave/code/tvlabs/lua. Use the gh CLI (authenticated as
+davydog187) for all GitHub operations.
+
+NON-NEGOTIABLE CONVENTIONS:
+- Commit subject and PR title scope = the affected SUBSYSTEM, never a plan id.
+  e.g. 'fix(vm): ...', 'feat(stdlib): ...', 'docs(readme): ...', 'chore(suite): ...'.
+  Allowed scopes: lexer, parser, compiler, vm, stdlib, pattern, string, table,
+  coroutine, error, suite, plan, docs, bench.
+- NO plan-id references in source files, test moduledocs, @doc, or comments.
+  Plan ids live only in the commit body ('Plan: <id>') and the PR body.
+- NO "Co-Authored-By" trailers for AI agents. Plain authorship.
+- Conventional-commit types: feat, fix, perf, chore, docs, test, refactor.
+- NEVER push red tests to a ready PR. NEVER force-push. NEVER merge — the PR
+  stays open for human review.
+
+GIT PUSH PROTOCOL (you run in a fresh worktree off 'main'; the PR's local
+branch may already be checked out in another worktree, so do NOT check it out
+by name — work in DETACHED HEAD off the remote tip):
+  git fetch origin <branch>
+  git checkout --detach origin/<branch>
+  mix deps.get            # only if deps/_build are missing in this worktree
+  ...make changes, commit...
+  git push origin HEAD:<branch>
+
+VALIDATION (run from the worktree root; deps/_build are per-worktree):
+  mix format
+  mix compile --warnings-as-errors
+  mix test
+  mix test test/lua53_suite_test.exs --only lua53
+All must pass before you push. (Docs-only PRs: the suite still runs fast.)
+`
+
+const ADDRESS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['prNumber', 'round', 'noFeedback', 'addressed', 'skipped', 'pushed', 'testsGreen', 'summary'],
+  properties: {
+    prNumber: { type: 'number' },
+    round: { type: 'number' },
+    noFeedback: { type: 'boolean', description: 'true if there was nothing actionable to address this round' },
+    addressed: { type: 'array', items: { type: 'string' }, description: 'one line per finding/comment addressed' },
+    skipped: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['finding', 'reason'],
+        properties: { finding: { type: 'string' }, reason: { type: 'string' } },
+      },
+    },
+    pushed: { type: 'boolean', description: 'true if a fix-commit was pushed to the PR branch' },
+    testsGreen: { type: 'boolean', description: 'true if mix test AND the lua53 suite passed after changes' },
+    summary: { type: 'string', description: '2-5 sentences on what changed and why' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['prNumber', 'round', 'overallVerdict', 'findings'],
+  properties: {
+    prNumber: { type: 'number' },
+    round: { type: 'number' },
+    overallVerdict: { type: 'string', description: 'one-paragraph overall assessment' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['severity', 'file', 'title', 'detail'],
+        properties: {
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor', 'nit'] },
+          file: { type: 'string' },
+          line: { type: 'string' },
+          title: { type: 'string' },
+          detail: { type: 'string' },
+          suggestedFix: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const ACTIONABLE = new Set(['blocker', 'major', 'minor'])
+const fmtFindings = (findings) =>
+  (findings || [])
+    .map((f, i) => `${i + 1}. [${f.severity}] ${f.file}${f.line ? ':' + f.line : ''} — ${f.title}\n   ${f.detail}${f.suggestedFix ? '\n   Suggested: ' + f.suggestedFix : ''}`)
+    .join('\n')
+
+// ---------------------------------------------------------------------------
+// Address step — pr-feedback-handler method, headless. Round 1 pulls the PR's
+// existing unresolved feedback; later rounds address the prior review findings.
+// Runs in an isolated worktree because it mutates the branch and pushes.
+// ---------------------------------------------------------------------------
+function addressAgent(pr, round, priorFindings) {
+  const feedbackSection =
+    round === 1
+      ? `FETCH CURRENT FEEDBACK (round 1). Get every UNRESOLVED review thread plus
+top-level PR review/comment bodies. Thread resolution is NOT in 'gh pr view --json';
+use the GraphQL API:
+  gh api graphql -f query='query($o:String!,$r:String!,$p:Int!){repository(owner:$o,name:$r){pullRequest(number:$p){reviewThreads(first:100){nodes{isResolved isOutdated path line comments(first:20){nodes{author{login} body}}}}}}}' -f o=tv-labs -f r=lua -F p=${pr.num}
+  gh pr view ${pr.num} --repo tv-labs/lua --json reviews,comments
+Act ONLY on threads where isResolved is false, plus substantive review/comment
+bodies. Ignore bot chatter and already-resolved threads. If there is NO actionable
+feedback, make no changes: set noFeedback true, pushed false, and return.`
+      : `ADDRESS PRIOR-ROUND REVIEW FINDINGS (round ${round}). These came from the
+workflow's own review of the PR after the last push:
+${fmtFindings(priorFindings)}
+If none of these are actually actionable, set noFeedback true, pushed false, return.`
+
+  return agent(
+    `${CONV}
+
+You are addressing review feedback on an open PR using the pr-feedback-handler
+method (classify → propose → implement → validate → push), running headless.
+
+PR #${pr.num} "${pr.title}" — branch ${pr.branch}. Round ${round} of up to ${MAX_ROUNDS}.
+
+Set up your worktree per the GIT PUSH PROTOCOL (detached HEAD off origin/${pr.branch}).
+
+${feedbackSection}
+
+For each actionable item:
+- Classify it: simple change / discussion-needed / pushback-worthy.
+- Address every BLOCKER and MAJOR item, and any MINOR item whose fix is clear and
+  low-risk. Honor Elixir philosophy: locality, immutability, small focused changes.
+- SKIP an item only if it is wrong, out of scope for this PR, or a pure nit —
+  record each skip in 'skipped' with a concrete reason. A pushback-worthy item
+  (e.g. reviewer asks for global state where a pure solution exists) counts as a
+  skip with the reason being your pushback rationale. Do NOT expand PR scope to
+  chase unrelated improvements.
+- Update or add tests whenever you change behavior.
+
+Then VALIDATE (all must pass) and push the fix-commit to the PR branch with a
+conventional-commit subject scoped to the subsystem (no plan id, no Co-Authored-By):
+  git push origin HEAD:${pr.branch}
+
+If a review thread was fully resolved by your change you may resolve it via the
+GraphQL resolveReviewThread mutation. DO NOT MERGE. DO NOT force-push.
+
+Return the structured result for round ${round}. testsGreen reflects whether BOTH
+mix test and the lua53 suite passed.`,
+    { label: `address:${pr.label}#r${round}`, phase: `Round ${round}`, isolation: 'worktree', schema: ADDRESS_SCHEMA },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Review step — independent /review-equivalent on the freshly pushed PR. Reads
+// via gh, posts a comment, returns structured findings. No worktree needed.
+// ---------------------------------------------------------------------------
+function reviewAgent(pr, round) {
+  return agent(
+    `${CONV}
+
+You are an independent reviewer running the equivalent of the /review command on
+an open PR. Be rigorous and skeptical — assume the author may have missed something.
+The address step just pushed to this branch, so review the CURRENT remote state.
+
+PR #${pr.num} "${pr.title}" — branch ${pr.branch}. Review round ${round}.
+Read the latest diff and metadata:
+  gh pr view ${pr.num} --repo tv-labs/lua
+  gh pr diff ${pr.num} --repo tv-labs/lua
+You may read full files under /Users/dave/code/tvlabs/lua for surrounding context,
+but the pushed branch may be AHEAD of that working copy — trust 'gh pr diff'.
+
+Review for:
+- CORRECTNESS: real bugs, wrong Lua 5.3 §semantics (consult the 5.3 reference
+  manual when unsure), missed edge cases, off-by-one, integer/float subtleties,
+  error-message mismatches.
+- TESTS: do the tests actually pin the behavior? Would they fail before the fix?
+  Are edge cases covered? For suite PRs, did the lua53 skip range narrow correctly
+  (smallest range, precise reason, no plan-id in the reason)?
+- REPO CONVENTIONS (blockers if violated): commit/PR scope is the subsystem not a
+  plan id; no plan-id in source/test/comments; no Co-Authored-By trailers; PR body
+  references the issue it closes where applicable.
+- SIMPLIFICATION / reuse: dead code, needless complexity, duplication.
+- DOCS PRs specifically: do the example snippets actually run as written? Broken
+  links, stale version claims, copy-paste errors, mismatched output.
+
+Post a concise review to the PR (clearly mark it as an automated round-${round}
+review):
+  gh pr comment ${pr.num} --repo tv-labs/lua --body "<your review markdown>"
+
+Then return the structured findings. Include ONLY real, actionable findings. If the
+PR is clean, return an empty findings array with a positive overallVerdict — that
+is how the loop detects stabilization.`,
+    { label: `review:${pr.label}#r${round}`, phase: `Round ${round}`, schema: REVIEW_SCHEMA },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Per-PR loop: address → review, repeated until stabilized or MAX_ROUNDS.
+// Rounds are inherently sequential (must push before re-review).
+// ---------------------------------------------------------------------------
+async function stabilizePr(pr) {
+  const rounds = []
+  let priorFindings = []
+  let stabilized = false
+
+  for (let round = 1; round <= MAX_ROUNDS; round++) {
+    const address = await addressAgent(pr, round, priorFindings)
+
+    // Round 1 with genuinely no feedback and nothing pushed: still review once to
+    // confirm the PR is clean, then we can stabilize on a clean review.
+    const review = await reviewAgent(pr, round)
+    rounds.push({ round, address, review })
+
+    if (!review) {
+      log(`#${pr.num} ${pr.label}: review round ${round} produced no result — stopping.`)
+      break
+    }
+
+    const actionable = (review.findings || []).filter((f) => ACTIONABLE.has(f.severity))
+    log(`#${pr.num} ${pr.label}: round ${round} — ${actionable.length} actionable finding(s), ${(review.findings || []).length} total.`)
+
+    if (actionable.length === 0) {
+      stabilized = true
+      log(`#${pr.num} ${pr.label}: STABILIZED after round ${round}.`)
+      break
+    }
+    priorFindings = review.findings
+    if (round === MAX_ROUNDS) {
+      log(`#${pr.num} ${pr.label}: hit round cap (${MAX_ROUNDS}) with ${actionable.length} finding(s) still open.`)
+    }
+  }
+
+  return {
+    prNumber: pr.num,
+    label: pr.label,
+    branch: pr.branch,
+    title: pr.title,
+    stabilized,
+    roundsRun: rounds.length,
+    rounds,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Drive all PRs concurrently; each runs its own sequential address→review loop.
+// ---------------------------------------------------------------------------
+log(`Stabilizing ${PRS.length} PRs (cap ${MAX_ROUNDS} rounds each): ${PRS.map((p) => '#' + p.num).join(', ')}`)
+
+const results = await parallel(PRS.map((pr) => () => stabilizePr(pr)))
+
+const report = PRS.map((pr, i) => results[i] || { prNumber: pr.num, label: pr.label, error: 'no result' })
+
+const stable = report.filter((r) => r.stabilized).map((r) => '#' + r.prNumber)
+const unstable = report.filter((r) => r && !r.stabilized && !r.error).map((r) => '#' + r.prNumber)
+log(`Done. Stabilized: ${stable.join(', ') || 'none'}. Hit cap / unresolved: ${unstable.join(', ') || 'none'}.`)
+
+return report

--- a/.agents/workflows/ship-issue-batch.mjs
+++ b/.agents/workflows/ship-issue-batch.mjs
@@ -1,0 +1,258 @@
+export const meta = {
+  name: 'ship-issue-batch',
+  description: 'Plan, implement, PR, and loop-review 7 tv-labs/lua issues following ship-a-plan',
+  phases: [
+    { title: 'Preflight', detail: 'verify main is clean, compiles, tests green' },
+    { title: 'Plan', detail: 'per issue: read/author a ship-a-plan-conformant plan' },
+    { title: 'Implement', detail: 'per issue: branch + implement + green tests + PR (worktree-isolated)' },
+    { title: 'Review', detail: 'per PR: adversarial review -> fix, loop until clean (max 3)' },
+  ],
+}
+
+// ---- The 7 issues, with everything an agent needs to act autonomously ----
+const ITEMS = [
+  {
+    issue: 264, id: 'A30', slug: 'examples-directory', branch: 'docs/examples',
+    type: 'docs', scope: 'examples', planState: 'ready',
+    planFile: '.agents/plans/A30-examples-directory.md',
+    guidance: 'Plan is already status: ready. Read it and implement EXACTLY what it specifies (an examples/ directory of runnable scripts). Do not expand scope.',
+  },
+  {
+    issue: 266, id: 'A32', slug: 'docstring-audit', branch: 'docs/docstring-audit',
+    type: 'docs', scope: 'stdlib', planState: 'ready',
+    planFile: '.agents/plans/A32-docstring-audit.md',
+    guidance: 'Plan is already status: ready. Read it and implement EXACTLY (audit + fill @doc/@moduledoc on public API). Pure docstring/doc work; no behavior changes.',
+  },
+  {
+    issue: 273, id: 'B9', slug: 'stdlib-hot-paths', branch: 'perf/stdlib-hot-paths',
+    type: 'perf', scope: 'stdlib', planState: 'missing',
+    planFile: '.agents/plans/B9-stdlib-hot-paths.md',
+    guidance: 'No plan file exists yet — AUTHOR .agents/plans/B9-stdlib-hot-paths.md from issue #273. Scope (from the issue): (1) string.format iolist accumulation + single IO.iodata_to_binary at end in lib/lua/vm/stdlib/string.ex (~333-350), replacing per-char binary concat; (2) table.sort/table.concat fast path that skips Executor.table_index/3 + table_newindex/3 when table.metatable == nil, in lib/lua/vm/stdlib/table.ex (~249-288); (3) apply_width_flags use byte_size not String.length for single-byte %d/%f output. OUT OF SCOPE: the O(n^2) comparator insertion sort, and Table.put order_tail allocation. Behavior must be identical — these are perf-only. mix test must stay green.',
+  },
+  {
+    issue: 276, id: 'A47', slug: 'open-upvalue-block-close', branch: 'fix/open-upvalue-block-close',
+    type: 'fix', scope: 'vm', planState: 'missing',
+    planFile: '.agents/plans/A47-open-upvalue-block-close.md',
+    guidance: 'No plan file exists — AUTHOR .agents/plans/A47-open-upvalue-block-close.md from issue #276 (a real VM bug). Root cause: state.open_upvalues is keyed by register and never closed at block (do/if/while/for/repeat) end; a later block reusing the same register reuses a stale cell ref (lib/lua/vm/executor.ex:707). Preferred fix (option 1 in the issue): emit a :close_open_upvalues instruction at block-scope end, parametrised by the registers that opened cells in that block; the executor removes ONLY those entries from state.open_upvalues, never touching state.upvalue_cells (existing closures hold valid cell refs and resolve through it). CRITICAL: loops re-enter the block body across iterations — cells must persist across iterations and close only on loop exit. ACCEPTANCE: the two-sibling-do-block repro in the issue passes; remove calls.lua:65-69 from test/lua53_skips.exs and narrow that file range; add a regression test to test/lua/vm/upvalue_test.exs (two sibling do blocks declaring captured locals on the same register). Run `mix test` AND `mix test --only lua53`; no regressions in upvalue/closure tests or the suite.',
+  },
+  {
+    issue: 263, id: 'A26', slug: 'error-message-quality', branch: 'errors/quality-pass',
+    type: 'feat', scope: 'error', planState: 'blocked',
+    planFile: '.agents/plans/A26-error-message-quality.md',
+    guidance: 'Plan is status: blocked on A19 (error line-info), which is now status: review — the :line/:source/:call_stack data is wired in. UNBLOCK it: set frontmatter status: ready, then execute. Audit every user-visible error message against PUC-Lua and fix rough edges per the plan: prominent `at <source>:<line>:` line, category-specific suggestions (no generic filler), readable on TTY and non-TTY. Add the fixture/gallery tests the plan lists. If some raise sites still lack line info (because A19 is not merged to main), note exactly which in ## Discoveries and audit what is present rather than expanding scope.',
+  },
+  {
+    issue: 265, id: 'A31', slug: 'readme-rewrite', branch: 'docs/readme-rewrite',
+    type: 'docs', scope: 'readme', planState: 'blocked', dep: 'A30',
+    planFile: '.agents/plans/A31-readme-rewrite.md',
+    guidance: 'Plan is status: blocked on A30 (README links to examples). A30 ships in a SIBLING PR in this same batch — its example files will NOT be in your worktree. UNBLOCK by decoupling: read .agents/plans/A30-examples-directory.md to learn the exact example filenames/paths A30 creates, and have the README link to those paths (they resolve once both PRs merge). Set frontmatter status: ready and execute the rewrite (1.0 positioning, quickstart, tour). Note the cross-PR link dependency in ## Discoveries.',
+  },
+  {
+    issue: 297, id: 'A48', slug: 'vfs-sandbox', branch: 'feat/vfs-sandbox',
+    type: 'feat', scope: 'stdlib', planState: 'missing',
+    planFile: '.agents/plans/A48-vfs-sandbox.md',
+    guidance: 'No plan file and no labels — this is a NEW FEATURE. First AUTHOR .agents/plans/A48-vfs-sandbox.md. Goal (issue #297): make os/filesystem operations safe by default by running the VM inside a virtual filesystem instead of sandboxing. Integrate github.com/ivarvong/vfs (a VFS.Mountable protocol with pluggable backends). Default backend = in-memory FS. Provide an API for users to populate the FS with files and mount other backends. Use a special dir (e.g. /lua/deps) as the mechanism for pulling Lua dependencies via require. Rewire lib/lua/vm/stdlib/os.ex (and any file IO) to operate through the VFS. THIS IS LARGE: research the vfs library API first (its README/hexdocs), design the integration in the plan, add the dep to mix.exs, then implement incrementally. If you cannot reach green tests with a complete feature, DO NOT open a PR with red tests — instead implement the smallest coherent slice that is green (e.g. dep + in-memory VFS + os ops rerouted, deferring deps-dir require), document the deferral in ## Discoveries, and open the PR for that slice. Keep mix test green.',
+  },
+]
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['id', 'issue', 'branch', 'ready', 'planMarkdown', 'filesToTouch', 'commitType', 'commitScope', 'title'],
+  properties: {
+    id: { type: 'string' },
+    issue: { type: 'number' },
+    branch: { type: 'string' },
+    title: { type: 'string', description: 'one-line plan title for the commit/PR subject (NO plan id)' },
+    commitType: { type: 'string', enum: ['feat', 'fix', 'perf', 'docs', 'chore', 'refactor', 'test'] },
+    commitScope: { type: 'string', description: 'affected subsystem, NEVER the plan id' },
+    ready: { type: 'boolean', description: 'true if the plan is complete, in-scope, and safe to implement' },
+    planMarkdown: { type: 'string', description: 'the FULL plan file contents incl YAML frontmatter with status: ready and all required sections (Goal, Out of scope, Success criteria, Implementation notes, Verification, Risks)' },
+    filesToTouch: { type: 'array', items: { type: 'string' } },
+    notes: { type: 'string' },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  required: ['opened', 'testsGreen', 'summary'],
+  properties: {
+    opened: { type: 'boolean', description: 'true only if a PR was actually opened' },
+    prNumber: { type: ['number', 'null'] },
+    prUrl: { type: ['string', 'null'] },
+    branch: { type: ['string', 'null'] },
+    testsGreen: { type: 'boolean' },
+    blockedReason: { type: ['string', 'null'], description: 'if no PR opened, why (e.g. red tests, scope too large)' },
+    summary: { type: 'string' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['clean', 'findings', 'summary'],
+  properties: {
+    clean: { type: 'boolean', description: 'true if no real blocker/major findings remain' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'severity', 'real'],
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor', 'nit'] },
+          real: { type: 'boolean' },
+          rationale: { type: 'string' },
+        },
+      },
+    },
+    summary: { type: 'string' },
+  },
+}
+
+const FIX_SCHEMA = {
+  type: 'object',
+  required: ['pushed', 'summary'],
+  properties: {
+    pushed: { type: 'boolean' },
+    addressed: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+}
+
+const SHIP_RULES = `
+SHIP-A-PLAN CONTRACT (.agents/skills/ship-a-plan/SKILL.md) — follow exactly:
+- Branch off main inside this worktree: git checkout -b <branch>.
+- First commit: create/update the plan file with status: in-progress, commit "chore(<id>): start plan" (this commit touches ONLY the plan file).
+- Implement ONLY what is in the plan's scope. Touch only the files named. If something out of scope appears, record it in the plan's "## Discoveries" section, do NOT expand scope.
+- Run: mix format; mix compile --warnings-as-errors; mix test  (plus "mix test --only lua53" if the plan's success criteria mention the suite). NEVER push or PR with red tests — if you cannot get green, stop and report opened:false with blockedReason.
+- Implementation commit subject is "<type>(<scope>): <title>" where <scope> is the SUBSYSTEM (vm, stdlib, parser, error, examples, readme, ...), NEVER the plan id. Body includes a short why + "Plan: <id>" + "Closes #<issue>".
+- ABSOLUTELY NO "Co-Authored-By" trailer for AI. Plain authorship.
+- Before pushing, run: git log --format="%h %s" main..HEAD and confirm no subject scope is a plan id (A30, B9, etc.) except plan-only "chore(<id>): ..." commits.
+- git push -u origin <branch>; then gh pr create with title "<type>(<scope>): <title>" and a body from the ship-a-plan template (## title, Plan: link, Closes #<issue>, Goal, Success criteria as checked boxes with how-verified, Changes from git diff --stat, Verification output tail, Out of scope).
+- After PR opens: set plan frontmatter status: review and pr: <number>, append a "## What changed" section, commit "chore(<id>): mark plan as review", push.
+- DO NOT run gh pr merge. Stop at PR creation.
+`
+
+function planPrompt(item) {
+  return `You are preparing a ship-a-plan plan file for issue #${item.issue} in the tv-labs/lua repo (an Elixir implementation of Lua 5.3).
+
+Run \`gh issue view ${item.issue}\` for full context. Read ROADMAP.md and the ship-a-plan skill at .agents/skills/ship-a-plan/SKILL.md for conventions. Plan state: ${item.planState}. Target plan file: ${item.planFile}. Branch: ${item.branch}.
+
+${item.guidance}
+
+Produce a COMPLETE, ship-a-plan-conformant plan as structured output. The planMarkdown field must be the full file contents: YAML frontmatter (id: ${item.id}, title, issue: ${item.issue}, pr: null, branch: ${item.branch}, base: main, status: ready, direction) followed by the required sections — Goal, Out of scope, Success criteria (checkbox list), Implementation notes (name the exact files), Verification (exact commands), Risks. ${item.planState === 'ready' ? 'A ready plan already exists at the target path — read it and return its content essentially as-is (confirm it is complete; keep status: ready).' : item.planState === 'blocked' ? 'A blocked plan exists — read it, resolve the blocker per the guidance, and return an UNBLOCKED version with status: ready.' : 'Author the plan from scratch based on the issue.'}
+
+This is a READ/THINK step only — do NOT modify any files, branch, or push. Set ready:true only if the plan is complete and safe to implement now. Pick commitType/commitScope per ship-a-plan (scope = subsystem, never the plan id).`
+}
+
+function implPrompt(item, plan) {
+  return `You are implementing plan ${item.id} for issue #${item.issue} in tv-labs/lua, end-to-end, in this isolated git worktree (a fresh checkout of main). You MUST follow the ship-a-plan contract precisely.
+
+${SHIP_RULES}
+
+Plan title: ${plan.title}
+Branch: ${item.branch}
+Commit/PR subject scope: ${item.type}(${item.scope})  (confirm against ship-a-plan; scope is the subsystem, never the plan id)
+Plan file to create/update: ${item.planFile}
+Files expected in scope: ${(plan.filesToTouch || []).join(', ') || '(see plan)'}
+
+The plan file contents to write (status: in-progress for the first commit, then status: review at the end):
+--- BEGIN PLAN ---
+${plan.planMarkdown}
+--- END PLAN ---
+
+${item.guidance}
+
+Work the contract: pre-flight (you are already on a clean main checkout), branch, plan-start commit, implement, format/compile/test green, implementation commit (Closes #${item.issue}), push, gh pr create, plan status->review commit, push. Return opened:true with prNumber/prUrl only if a PR was actually created with green tests. If you cannot reach green or the scope is too large to finish safely, return opened:false with a precise blockedReason and leave no broken PR.`
+}
+
+function reviewPrompt(item, prNumber, round) {
+  return `You are a skeptical senior reviewer (round ${round}) of PR #${prNumber} (plan ${item.id}, issue #${item.issue}) in tv-labs/lua, an Elixir Lua 5.3 VM.
+
+Inspect it read-only: \`gh pr view ${prNumber}\`, \`gh pr diff ${prNumber}\`, and \`gh pr checks ${prNumber}\` if available. You may also \`git fetch origin ${item.branch}\` and \`git show origin/${item.branch}:<path>\` to read files at the branch HEAD — do NOT check out, edit, branch, or push anything.
+
+Hunt for REAL problems, default to skepticism but mark real:false for anything you cannot substantiate:
+- Correctness bugs / regressions, especially in VM/executor or stdlib hot paths.
+- Scope violations: changes to files not in the plan, or behavior changes in a perf-only/docs-only PR.
+- Missing or weak tests for the behavior changed; for fix/perf PRs, is there a regression test?
+- ship-a-plan rule violations: plan id used as a commit/PR subject scope (e.g. "fix(A47): ..."), a "Co-Authored-By" AI trailer present, red tests, or merged-without-review.
+- Doc/quality PRs: accuracy, broken links, claims that don't match the code.
+
+Classify each finding severity (blocker|major|minor|nit) and real (true/false). Set clean:true ONLY if no real blocker or major findings remain (minor/nit do not block).`
+}
+
+function fixPrompt(item, prNumber, review) {
+  return `You are addressing review feedback on PR #${prNumber} (plan ${item.id}, issue #${item.issue}) in tv-labs/lua, in this isolated worktree.
+
+Check out the PR branch here: \`git fetch origin ${item.branch} && git checkout ${item.branch}\`.
+
+Review findings to address (fix every real blocker/major; fix real minors if quick; ignore nits and real:false):
+${JSON.stringify(review.findings || [], null, 2)}
+
+Make the minimal correct changes, stay within the plan's scope, run \`mix format\` and \`mix test\` (and \`mix test --only lua53\` if this plan touches the suite) until green. Commit as "${item.type}(${item.scope}): address review feedback" — NO plan-id scope, NO Co-Authored-By trailer — and \`git push\`. Do NOT merge. Return pushed:true only if you committed and pushed a fix; pushed:false if nothing needed changing.`
+}
+
+// ---------------- run ----------------
+
+phase('Preflight')
+const pre = await agent(
+  `In the tv-labs/lua repo working dir, verify the base is shippable before a batch of PRs is opened. Run: \`git status --porcelain\`, \`git rev-parse --abbrev-ref HEAD\` (should be main), \`mix compile --warnings-as-errors\`, and \`mix test\`. The tree is "clean enough" if the ONLY entries in git status are untracked files under .agents/workflows/ (the orchestration scripts themselves — these never enter a worktree checkout and are not part of any PR); ignore those. Report ok:true only if, ignoring .agents/workflows/ untracked files, the tree has no other changes, you are on main, it compiles with no warnings, and the full test suite passes. Include the test pass/fail counts in baseline.`,
+  { phase: 'Preflight', schema: { type: 'object', required: ['ok', 'baseline'], properties: { ok: { type: 'boolean' }, baseline: { type: 'string' }, detail: { type: 'string' } } } },
+)
+if (!pre || !pre.ok) {
+  log(`Preflight FAILED — aborting before any PR is opened: ${pre ? pre.detail || pre.baseline : 'no result'}`)
+  return { aborted: true, reason: 'preflight failed', preflight: pre }
+}
+log(`Preflight green (${pre.baseline}). Fanning out ${ITEMS.length} issues: plan -> implement -> review.`)
+
+const results = await pipeline(
+  ITEMS,
+  // Stage 1: plan
+  (item) => agent(planPrompt(item), { label: `plan:${item.id}`, phase: 'Plan', schema: PLAN_SCHEMA })
+    .then((plan) => ({ item, plan })),
+
+  // Stage 2: implement + PR (worktree-isolated)
+  ({ item, plan }) => {
+    if (!plan || !plan.ready) {
+      log(`Skip implement ${item.id}: plan not ready (${plan ? plan.notes || 'not ready' : 'no plan'})`)
+      return { item, plan, impl: { opened: false, testsGreen: false, summary: 'plan not ready', blockedReason: 'plan not ready' } }
+    }
+    return agent(implPrompt(item, plan), { label: `impl:${item.id}`, phase: 'Implement', isolation: 'worktree', schema: IMPL_SCHEMA })
+      .then((impl) => ({ item, plan, impl }))
+  },
+
+  // Stage 3: review loop (max 3), fix in worktree until clean
+  async ({ item, plan, impl }) => {
+    if (!impl || !impl.opened || !impl.prNumber) {
+      return { id: item.id, issue: item.issue, opened: false, prNumber: null, blockedReason: impl ? impl.blockedReason : 'implement failed', summary: impl ? impl.summary : 'no impl result' }
+    }
+    const rounds = []
+    for (let r = 1; r <= 3; r++) {
+      const review = await agent(reviewPrompt(item, impl.prNumber, r), { label: `review:${item.id}#${r}`, phase: 'Review', schema: REVIEW_SCHEMA })
+      rounds.push(review)
+      const actionable = review && review.findings ? review.findings.filter((f) => f.real && (f.severity === 'blocker' || f.severity === 'major')) : []
+      if (!review || review.clean || actionable.length === 0) {
+        log(`PR #${impl.prNumber} (${item.id}) clean after ${r} review round(s).`)
+        break
+      }
+      if (r === 3) {
+        log(`PR #${impl.prNumber} (${item.id}) still has ${actionable.length} actionable finding(s) after 3 rounds — left for human review.`)
+        break
+      }
+      const fix = await agent(fixPrompt(item, impl.prNumber, review), { label: `fix:${item.id}#${r}`, phase: 'Review', isolation: 'worktree', schema: FIX_SCHEMA })
+      if (!fix || !fix.pushed) {
+        log(`PR #${impl.prNumber} (${item.id}): fix round ${r} pushed nothing — stopping loop.`)
+        break
+      }
+    }
+    return { id: item.id, issue: item.issue, opened: true, prNumber: impl.prNumber, prUrl: impl.prUrl, reviewRounds: rounds.length, finalClean: rounds.length ? !!rounds[rounds.length - 1].clean : false, summary: impl.summary }
+  },
+)
+
+const opened = results.filter((r) => r && r.opened)
+const notOpened = results.filter((r) => !r || !r.opened)
+return {
+  preflight: pre.baseline,
+  opened: opened.map((r) => ({ issue: r.issue, plan: r.id, pr: r.prNumber, url: r.prUrl, reviewRounds: r.reviewRounds, finalClean: r.finalClean })),
+  notOpened: notOpened.map((r) => ({ issue: r ? r.issue : null, plan: r ? r.id : null, reason: r ? r.blockedReason || r.summary : 'null result' })),
+}


### PR DESCRIPTION
## What

Adds two background workflow orchestration scripts under `.agents/workflows/`, siblings to the existing `triage-implement-review.mjs`:

- **`pr-feedback-stabilize.mjs`** — for each open PR, loops *address feedback (pr-feedback-handler method) → push → independent review* until the PR stabilizes (no actionable findings) or a round cap is hit. Posts each review to the PR. Never merges.
- **`ship-issue-batch.mjs`** — plans, implements, PRs, and loop-reviews a batch of `tv-labs/lua` issues following the `ship-a-plan` method, worktree-isolated per issue.

## Why

These were sitting untracked in the working tree. They're reusable orchestration tooling, so they belong in version control alongside the other tracked workflows.

## Notes

Tooling-only change — no library code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)