### PR TITLE
perf(vm): batch :set_list writes through Table.put_many/2

### DIFF
--- a/.agents/plans/B11-setlist-batch-insert.md
+++ b/.agents/plans/B11-setlist-batch-insert.md
@@ -2,10 +2,10 @@
 id: B11
 title: batch insert for :setlist instead of per-key Table.put
 issue: 308
-pr: null
+pr: 321
 branch: perf/setlist-batch-insert
 base: main
-status: in-progress
+status: review
 direction: B
 ---
 
@@ -140,3 +140,46 @@ regressed at `n=1000`.
   vararg/multi-return call. Ensure the batch path handles `total == 0`
   (empty) and the multi-return slot offsets identically to the current
   reduce.
+
+## What changed
+
+Shipped as PR #321.
+
+- `lib/lua/vm/table.ex` — added `put_many/2` (plus accumulator-threaded
+  `insert_acc`/`delete_acc` mirrors of `insert/3`/`delete/2`). It folds an
+  ordered `{key, value}` list into the table making the same
+  `order`/`order_tail`/`dead` decisions as repeated `put/3`, but rebuilds
+  the `%Table{}` struct once. Deliberately not routed through
+  `replace_data/2` (which clears `dead` and rebuilds `order` from
+  `Map.keys/1` — not behavior-identical).
+- `lib/lua/vm/dispatcher.ex` — `set_list_into_table/6` now collects the
+  run's pairs via a new `set_list_pairs/7` register walk and applies them
+  with a single `put_many/2`.
+- `lib/lua/vm/executor.ex` — both `:set_list` arms (the `{:multi, _}` form
+  and the integer-count form, including its `count == 0` multi-return
+  branch) route through a shared `set_list_pairs/4` helper + `put_many/2`.
+  `total == 0` yields `[]` and leaves the table untouched.
+- `test/lua/vm/stdlib/table_test.exs` — added a `table constructor
+  backfill` describe block (5 tests) pinning constructor `pairs`/`ipairs`
+  order, `ipairs` stop-at-hole, dead-key revival ordering (`1,2,4,5,3`),
+  overwrite position stability, and the empty constructor.
+
+Suite: 2114 → 2119 passing (+5 new tests), 0 failing, 19 skipped.
+
+Numbers: benchee table-build n=100 ratio ~1.05× luerl (median; n=100 is
+very noisy at ±20–195% deviation), no regression at n=1000. A tight
+back-to-back A/B (200k iterations over a 100-element literal constructor)
+isolates a stable ~5% improvement on the `:set_list` path (baseline
+~43.7–44.4 µs/op → ~41.2–41.8 µs/op after).
+
+## Discoveries
+
+- The plan's cited 1.14× luerl baseline at n=100 did not reproduce on the
+  benchmarking machine; the table-build workload was already ~1.0–1.05×
+  luerl there. The benchee n=100 microbenchmark is too noisy to show the
+  change's effect (relative ordering flips run to run), so the win was
+  confirmed via a tight isolated A/B loop instead. No scope change.
+- `benchmarks/setup_luaport.sh` is required to build the optional
+  `luaport` (C Lua 5.4) dep under `MIX_ENV=benchmark`; without it the
+  whole benchmark env fails to compile (`lua.h` not found). Not changed by
+  this plan.

--- a/.agents/plans/B11-setlist-batch-insert.md
+++ b/.agents/plans/B11-setlist-batch-insert.md
@@ -1,0 +1,142 @@
+---
+id: B11
+title: batch insert for :setlist instead of per-key Table.put
+issue: 308
+pr: null
+branch: perf/setlist-batch-insert
+base: main
+status: in-progress
+direction: B
+---
+
+# B11 — batch insert for `:setlist` instead of per-key `Table.put`
+
+## Goal
+
+Make `:set_list` (table constructor backfill) accumulate its
+`{index, value}` pairs and apply them to the `%Lua.VM.Table{}` in a
+single mutation, instead of walking one key at a time through
+`Table.put/3` and paying the seven-field struct rebuild on every slot.
+
+Table construction is currently **1.14× slower than luerl** at `n=100`
+(25.5µs vs 22.3µs in `benchmarks/table_ops.exs`). Luerl amortises the
+same work to a single `:array:set` mutation. Batching the inserts should
+close most of that gap. Target: **≤ 1.05× luerl** at `n=100`, with no
+regression at larger `n`.
+
+This is a **performance-only** change. Observable behavior — stored
+values, iteration order, dead-key (nil-clear) semantics, and the public
+`Lua.*` API — must remain identical.
+
+## Out of scope
+
+- The B7-style array/hash split for `Lua.VM.Table` (deferred — see
+  ROADMAP "Tried and deferred"). This plan does not change the table's
+  underlying representation, only how `:set_list` writes into it.
+- Any change to `Table.put/3`, `Table.put_data/3`, or the
+  `order`/`order_tail`/`dead` invariants themselves beyond what is
+  needed to expose a correct batch-write path.
+- Other hot dispatch paths (`set_table`, `set_field`, `rawset`). Only
+  the `:set_list` opcode is in scope.
+- Changes to the encoder/compiler that emits `:set_list`.
+
+## Success criteria
+
+- [ ] `mix test` — full suite stays green, no regressions in pass count.
+- [ ] `mix test test/lua/vm/stdlib/table_test.exs` passes.
+- [ ] `mix run benchmarks/table_ops.exs` records a `setlist` /
+      table-build ratio of **≤ 1.05× luerl** at `n=100`, with the ratio
+      recorded in the PR body.
+- [ ] No regression at larger `n` (`n=1000`) in the table-build
+      workload — record the multi-`n` numbers in the PR body.
+- [ ] `mix compile --warnings-as-errors` is clean.
+- [ ] `mix format` is clean.
+- [ ] Iteration order and dead-key semantics are unchanged: a constructor
+      that backfills consecutive integer keys yields the same `pairs`/
+      `ipairs` order and the same nil-clear behavior as the per-`put`
+      loop (covered by an added/updated test in `table_test.exs` if not
+      already covered).
+
+## Implementation notes
+
+Three files, two mirror sites plus a shared helper:
+
+1. **`lib/lua/vm/table.ex`** — `Table.replace_data/2` already exists
+   (line ~79), but it rebuilds `order` from `Map.keys(data)` and clears
+   `dead`. That is **not** behavior-identical to the per-slot
+   `Table.put/3` loop, which preserves insertion order via `order_tail`
+   and revives dead keys in place. Do **not** route `:set_list` through
+   `replace_data/2` naively. Either:
+   - add a focused batch helper (e.g. `Table.put_many/2` taking the
+     table and an ordered list of `{key, value}` pairs) that folds the
+     pairs into `data` while maintaining `order`/`order_tail`/`dead`
+     exactly as repeated `put/3` would, but rebuilding the struct only
+     once at the end; or
+   - if analysis shows the constructor backfill only ever targets
+     fresh consecutive integer keys (no dead-key revival, no overwrite),
+     document that precondition and use a narrower fast path. Confirm
+     this against the encoder before relying on it; otherwise use the
+     general `put_many/2`.
+   The win comes from rebuilding the `%Table{}` struct once instead of
+   `count` times; the data map and order lists can still be built with
+   an `Enum.reduce`/recursion over the slots.
+
+2. **`lib/lua/vm/dispatcher.ex`** — `set_list_into_table/6` (~1410–1415),
+   called from the `@op_set_list` arm at ~769. Replace the per-slot
+   `Table.put/3` recursion with: collect the `{offset + i + 1, value}`
+   pairs from `regs`, then apply the batch helper once. Keep the inline,
+   allocation-light register walk; only the table mutation collapses to
+   a single struct rebuild.
+
+3. **`lib/lua/vm/executor.ex`** — mirror the change in **both**
+   `:set_list` handlers so the two executors stay in lockstep:
+   - the integer-count form, `do_execute([{:set_list, table_reg, start,
+     count, offset} | rest], ...)` (~1832), including its `count == 0`
+     multi-return branch; and
+   - the `{:multi, init_count}` form, `do_execute([{:set_list, ...,
+     {:multi, init_count}, offset} | rest], ...)` (~1802).
+   Both currently `Enum.reduce` over `Table.put/3`; route them through
+   the same batch helper added in step 1.
+
+Run `mix format` after each change. Keep the dispatcher and executor
+implementations structurally parallel — they are intentional mirrors.
+
+## Verification
+
+```
+mix format
+mix compile --warnings-as-errors
+mix test
+mix test test/lua/vm/stdlib/table_test.exs
+mix run benchmarks/table_ops.exs
+```
+
+Record the `table_ops` luerl ratio at `n=100` and `n=1000` in the PR
+body (use `LUA_BENCH_MODE=full` if the multi-`n` sweep is needed for the
+recorded numbers). Confirm the ratio is ≤ 1.05× luerl at `n=100` and not
+regressed at `n=1000`.
+
+## Risks
+
+- **Behavior drift via `replace_data/2`.** The biggest risk: routing
+  `:set_list` through the existing `replace_data/2` would clear `dead`
+  and rebuild `order` from `Map.keys/1`, silently changing iteration
+  order and dropping the in-place dead-key invariant. Mitigation: use a
+  batch helper that preserves `order`/`order_tail`/`dead` exactly as the
+  `put/3` loop does; cover with the table_test assertion in the success
+  criteria.
+- **Two sites falling out of sync.** Dispatcher and executor must mirror
+  each other. Mitigation: share one helper in `table.ex` so both call
+  the same logic; review both `:set_list` handlers (3 arms total) in the
+  diff.
+- **No measurable win.** Per ROADMAP's Direction-B lessons, BEAM
+  optimisations are subtle and `setelement/3`-style churn dominates some
+  workloads. The struct rebuild is `count` allocations today, so
+  collapsing to one should help, but re-baseline before claiming the
+  win and record the actual ratio. If the win does not materialise,
+  surface it rather than shipping a neutral change as a perf PR.
+- **Multi-return / `count == 0` edge case.** The executor's
+  `count == 0` branch backfills `state.multi_return_count` values from a
+  vararg/multi-return call. Ensure the batch path handles `total == 0`
+  (empty) and the multi-return slot offsets identically to the current
+  reduce.

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -1403,15 +1403,25 @@ defmodule Lua.VM.Dispatcher do
   end
 
   # `:set_list` writes `count` consecutive register values into the table
-  # at keys `[offset + 1, offset + count]`. Inline loop so the BEAM keeps
-  # the hot path allocation-free apart from the `Table.put/3` updates
-  # themselves (which sit in the table-storage churn category the parent
-  # plan flagged as the post-B5b ceiling).
+  # at keys `[offset + 1, offset + count]`. We collect the `{key, value}`
+  # pairs from the registers in one allocation-light walk and apply them
+  # via a single `Table.put_many/2`, so the `%Table{}` struct is rebuilt
+  # once instead of once per slot.
   defp set_list_into_table(table, _regs, _start, 0, _offset, _i), do: table
 
   defp set_list_into_table(table, regs, start, count, offset, i) do
-    value = :erlang.element(start + i + 1, regs)
-    set_list_into_table(Table.put(table, offset + i + 1, value), regs, start, count - 1, offset, i + 1)
+    Table.put_many(table, set_list_pairs(regs, start, count, offset, i, count - 1, []))
+  end
+
+  # Builds the ordered `{key, value}` list for a `:set_list` run, walking the
+  # registers from the last slot back to the first so the result is in
+  # ascending-key (insertion) order with O(1) prepends. `Table.put_many/2`
+  # then applies the whole run in a single struct rebuild.
+  defp set_list_pairs(_regs, _start, _count, _offset, _i, j, acc) when j < 0, do: acc
+
+  defp set_list_pairs(regs, start, count, offset, i, j, acc) do
+    value = :erlang.element(start + i + j + 1, regs)
+    set_list_pairs(regs, start, count, offset, i, j - 1, [{offset + i + j + 1, value} | acc])
   end
 
   # ── B5c-v2 helpers ──────────────────────────────────────────────────────

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -1814,14 +1814,7 @@ defmodule Lua.VM.Executor do
 
     state =
       State.update_table(state, {:tref, id}, fn table ->
-        if total > 0 do
-          Enum.reduce(0..(total - 1), table, fn i, t ->
-            value = elem(regs, start + i)
-            Table.put(t, offset + i + 1, value)
-          end)
-        else
-          table
-        end
+        Table.put_many(table, set_list_pairs(regs, start, total, offset))
       end)
 
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
@@ -1831,26 +1824,11 @@ defmodule Lua.VM.Executor do
 
   defp do_execute([{:set_list, table_reg, start, count, offset} | rest], regs, upvalues, proto, state, cont, frames, line) do
     {:tref, id} = elem(regs, table_reg)
+    total = if count == 0, do: state.multi_return_count, else: count
 
     state =
       State.update_table(state, {:tref, id}, fn table ->
-        if count == 0 do
-          values_to_collect = state.multi_return_count
-
-          if values_to_collect > 0 do
-            Enum.reduce(0..(values_to_collect - 1), table, fn i, t ->
-              value = elem(regs, start + i)
-              Table.put(t, offset + i + 1, value)
-            end)
-          else
-            table
-          end
-        else
-          Enum.reduce(1..count, table, fn i, t ->
-            value = elem(regs, start + i - 1)
-            Table.put(t, offset + i, value)
-          end)
-        end
+        Table.put_many(table, set_list_pairs(regs, start, total, offset))
       end)
 
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
@@ -1880,6 +1858,22 @@ defmodule Lua.VM.Executor do
 
   defp do_execute([instr | _rest], _regs, _upvalues, _proto, _state, _cont, _frames, _line) do
     raise InternalError, value: "unimplemented instruction: #{inspect(instr)}"
+  end
+
+  # Builds the ordered `{key, value}` list for a `:set_list` run: value `k`
+  # (0-based) reads from register `start + k` and lands at key
+  # `offset + k + 1`. Walks back-to-front so the list is in ascending-key
+  # (insertion) order with O(1) prepends, then `Table.put_many/2` applies it
+  # in a single struct rebuild — matching the old per-slot `Table.put/3`
+  # fold exactly. A `total` of 0 yields `[]` and leaves the table untouched.
+  defp set_list_pairs(regs, start, total, offset) do
+    set_list_pairs(regs, start, offset, total - 1, [])
+  end
+
+  defp set_list_pairs(_regs, _start, _offset, k, acc) when k < 0, do: acc
+
+  defp set_list_pairs(regs, start, offset, k, acc) do
+    set_list_pairs(regs, start, offset, k - 1, [{offset + k + 1, elem(regs, start + k)} | acc])
   end
 
   # ── do_frame_return — restore caller context after a Lua function returns ──

--- a/lib/lua/vm/table.ex
+++ b/lib/lua/vm/table.ex
@@ -165,6 +165,70 @@ defmodule Lua.VM.Table do
   end
 
   @doc """
+  Applies an ordered list of `{key, value}` writes to the table, producing
+  the same result as folding `put/3` over the list left-to-right, but
+  rebuilding the `%Table{}` struct only once at the end.
+
+  This is the batch entry point for table-constructor backfill
+  (`:set_list`), where a run of consecutive integer keys is written in one
+  go. The `order`/`order_tail`/`dead` invariants are maintained identically
+  to repeated `put/3`: new keys append (via `order_tail`), existing live
+  keys keep their position, dead keys revive to the end, and `nil` values
+  clear a live key into `dead`. The win is collapsing `count` struct
+  rebuilds into one.
+
+  `pairs` are applied in order; keys are normalized per `normalize_key/1`.
+  """
+  @spec put_many(t(), [{term(), term()}]) :: t()
+  def put_many(%__MODULE__{} = table, []), do: table
+
+  def put_many(%__MODULE__{data: data, order: order, order_tail: order_tail, dead: dead} = table, pairs)
+      when is_list(pairs) do
+    {data, order, order_tail, dead} = put_many_reduce(pairs, data, order, order_tail, dead)
+    %{table | data: data, order: order, order_tail: order_tail, dead: dead}
+  end
+
+  defp put_many_reduce([], data, order, order_tail, dead), do: {data, order, order_tail, dead}
+
+  defp put_many_reduce([{key, value} | rest], data, order, order_tail, dead) do
+    key = normalize_key(key)
+
+    {data, order, order_tail, dead} =
+      case value do
+        nil -> delete_acc(data, order, order_tail, dead, key)
+        _ -> insert_acc(data, order, order_tail, dead, key, value)
+      end
+
+    put_many_reduce(rest, data, order, order_tail, dead)
+  end
+
+  # Accumulator-threaded mirrors of `insert/3` and `delete/2`. They make the
+  # exact same `order`/`order_tail`/`dead` decisions, but operate on bare
+  # fields so `put_many/2` can rebuild the struct just once.
+  defp insert_acc(data, order, order_tail, dead, key, value) do
+    cond do
+      Map.has_key?(dead, key) ->
+        merged_order = order ++ Enum.reverse(order_tail)
+        new_order = Enum.reject(merged_order, &(&1 === key))
+        {Map.put(data, key, value), new_order, [key], Map.delete(dead, key)}
+
+      Map.has_key?(data, key) ->
+        {Map.put(data, key, value), order, order_tail, dead}
+
+      true ->
+        {Map.put(data, key, value), order, [key | order_tail], dead}
+    end
+  end
+
+  defp delete_acc(data, order, order_tail, dead, key) do
+    if Map.has_key?(data, key) do
+      {Map.delete(data, key), order, order_tail, Map.put(dead, key, true)}
+    else
+      {data, order, order_tail, dead}
+    end
+  end
+
+  @doc """
   Normalizes a table key per Lua 5.3 §3.4.11.
 
   Float keys that hold an exact integer value are coerced to integers so

--- a/test/lua/vm/stdlib/table_test.exs
+++ b/test/lua/vm/stdlib/table_test.exs
@@ -216,6 +216,74 @@ defmodule Lua.VM.Stdlib.TableTest do
     end
   end
 
+  describe "table constructor backfill" do
+    test "constructor entries iterate in insertion order via pairs" do
+      # The constructor backfill writes consecutive integer keys in one
+      # batch; `pairs` must still walk them in ascending insertion order.
+      code = """
+      local t = {10, 20, 30, 40, 50}
+      local keys, vals = {}, {}
+      for k, v in pairs(t) do
+        keys[#keys + 1] = k
+        vals[#vals + 1] = v
+      end
+      return table.concat(keys, ","), table.concat(vals, ",")
+      """
+
+      assert ["1,2,3,4,5", "10,20,30,40,50"] = run!(code)
+    end
+
+    test "ipairs over a constructor stops at the first hole" do
+      code = """
+      local t = {1, 2, 3}
+      local out = {}
+      for i, v in ipairs(t) do
+        out[#out + 1] = v
+      end
+      return #out, out[1], out[2], out[3]
+      """
+
+      assert [3, 1, 2, 3] = run!(code)
+    end
+
+    test "clearing a constructor key to nil is a hole, not a reorder" do
+      # Backfill five keys, clear one in the middle, then re-add it. The
+      # revived key counts as a fresh insertion and moves to the end of
+      # iteration order — identical to the per-`put` loop's dead-key revival.
+      code = """
+      local t = {1, 2, 3, 4, 5}
+      t[3] = nil
+      t[3] = 30
+      local keys = {}
+      for k in pairs(t) do
+        keys[#keys + 1] = k
+      end
+      return table.concat(keys, ",")
+      """
+
+      assert ["1,2,4,5,3"] = run!(code)
+    end
+
+    test "an overwritten constructor slot keeps its original position" do
+      code = """
+      local t = {1, 2, 3}
+      t[2] = 99
+      local keys, vals = {}, {}
+      for k, v in pairs(t) do
+        keys[#keys + 1] = k
+        vals[#vals + 1] = v
+      end
+      return table.concat(keys, ","), table.concat(vals, ",")
+      """
+
+      assert ["1,2,3", "1,99,3"] = run!(code)
+    end
+
+    test "empty constructor leaves no entries" do
+      assert [0] = run!("local t = {}\nlocal n = 0\nfor _ in pairs(t) do n = n + 1 end\nreturn n")
+    end
+  end
+
   describe "table.insert edge cases" do
     test "insert at position 1 shifts every existing element up" do
       code = """


### PR DESCRIPTION
## batch insert for `:set_list` instead of per-key `Table.put`

Plan: [`.agents/plans/B11-setlist-batch-insert.md`](https://github.com/tv-labs/lua/blob/perf/setlist-batch-insert/.agents/plans/B11-setlist-batch-insert.md)
Closes #308

### Goal

Make `:set_list` (table-constructor backfill) accumulate its `{index, value}` pairs and apply them to the `%Lua.VM.Table{}` in a single mutation, instead of walking one key at a time through `Table.put/3` and paying the seven-field struct rebuild on every slot. Performance-only: stored values, iteration order, dead-key (nil-clear) semantics, and the public `Lua.*` API are unchanged.

### Approach

- Added `Lua.VM.Table.put_many/2`: folds an ordered list of `{key, value}` pairs into the table, making the **exact same** `order`/`order_tail`/`dead` decisions as repeated `put/3` (new keys append, live keys keep position, dead keys revive to the end, `nil` clears into `dead`), but rebuilding the struct only once. Deliberately **not** routed through the existing `replace_data/2`, which would clear `dead` and rebuild `order` from `Map.keys/1` — that is not behavior-identical.
- `dispatcher.ex` `set_list_into_table/6` and **both** `executor.ex` `:set_list` arms (integer-count incl. its `count == 0` multi-return branch, and the `{:multi, init_count}` form) collect their pairs in one register walk and call the shared `put_many/2` once. The two executors stay mirror-parallel via the same helper.

### Success criteria

- [x] `mix test` — full suite green, no regressions (2114 → 2119 passing; +5 from the new constructor tests, 0 failing, 19 skipped).
- [x] `mix test test/lua/vm/stdlib/table_test.exs` passes (60 → 65).
- [x] Iteration order and dead-key semantics unchanged — new tests in `table_test.exs` assert constructor `pairs`/`ipairs` order, `ipairs` stop-at-hole, dead-key revival moving to the end (`1,2,4,5,3`), overwrite keeping position, and empty constructor.
- [x] `mix compile --warnings-as-errors` clean.
- [x] `mix format` clean.
- [x] luerl ratio at n=100 and n=1000 recorded below.

### Benchmark (table build, `benchmarks/table_ops.exs`, `LUA_BENCH_MODE=full`)

The benchee n=100 microbenchmark is extremely noisy on this machine (deviation ±20–195%; the luerl vs lua-chunk ordering flips run to run), so the recorded benchee ratios are reported alongside a tight back-to-back A/B that isolates the `:set_list` path.

**benchee medians, this build vs luerl:**

| n | luerl (median) | lua (chunk, median) | ratio |
|---|---|---|---|
| 100 | 17.25 µs | 18.17 µs | **1.05×** |
| 1000 | 157.0 µs | 220.4 µs | 1.40× |

Baseline (pre-change) on the same machine measured n=100 build at ~1.04× luerl (median), i.e. the gap the plan cited as 1.14× did not reproduce here — the build was already ~1.0–1.05× luerl, so there was little headroom for the benchee number to move, and the benchee n=100 ratio is within noise of baseline. No regression at n=1000.

**Tight A/B (200k iterations, eval of a 100-element literal constructor; full eval overhead included, so it understates the per-opcode delta), reproducible across runs:**

| build | µs/op |
|---|---|
| baseline (per-slot `put/3`) | 43.7 – 44.4 |
| after (`put_many/2`) | 41.2 – 41.8 |

~5% faster on the set_list-heavy path, stable across repeated runs. Behavior-identical and modestly faster — not a neutral change.

### Changes
```
 lib/lua/vm/dispatcher.ex          | 22 +++++++++----
 lib/lua/vm/executor.ex            | 44 +++++++++++--------------
 lib/lua/vm/table.ex               | 64 ++++++++++++++++++++++++++++++++++++
 test/lua/vm/stdlib/table_test.exs | 68 +++++++++++++++++++++++++++++++++++++++
```

### Verification
```
mix format
mix compile --warnings-as-errors
mix test
# Result: 2119 passed (60 doctests, 51 properties, 2008 tests), 19 skipped, 1 excluded
mix test test/lua/vm/stdlib/table_test.exs
# Result: 65 passed (6 properties, 59 tests)
PKG_CONFIG_PATH=... MIX_ENV=benchmark LUA_BENCH_MODE=full mix run benchmarks/table_ops.exs
```

### Out of scope (intentional)
- The B7-style array/hash split for `Lua.VM.Table` (deferred).
- Changes to `Table.put/3`, `Table.put_data/3`, or the `order`/`order_tail`/`dead` invariants themselves.
- Other hot dispatch paths (`set_table`, `set_field`, `rawset`).
- Encoder/compiler changes that emit `:set_list`.