### PR TITLE
chore(workflow): post reviews to PRs and harden worktree git isolation

### DIFF
--- a/.agents/workflows/pr-feedback-stabilize.mjs
+++ b/.agents/workflows/pr-feedback-stabilize.mjs
@@ -43,9 +43,21 @@ NON-NEGOTIABLE CONVENTIONS:
 - NEVER push red tests to a ready PR. NEVER force-push. NEVER merge — the PR
   stays open for human review.
 
+WORKTREE ISOLATION (CRITICAL): you run in an ISOLATED git worktree under
+.claude/worktrees/, NOT the operator's primary checkout at the canonical path.
+Run EVERY git command from your current working directory. NEVER \`cd\` to the
+canonical checkout and NEVER pass \`git -C <canonical-path>\`. Before ANY
+state-changing git command (fetch is fine; checkout/detach/reset/commit/push are
+not), run \`git rev-parse --show-toplevel\` and confirm it points at your worktree
+under .claude/worktrees/ — NOT the canonical checkout. If it points at the primary
+repo, STOP. Running \`git checkout --detach\` against the primary checkout detaches
+the operator's HEAD and corrupts their working tree — this has happened and must
+not recur. Reading files at the canonical path is fine; state-changing git is not.
+
 GIT PUSH PROTOCOL (you run in a fresh worktree off 'main'; the PR's local
 branch may already be checked out in another worktree, so do NOT check it out
-by name — work in DETACHED HEAD off the remote tip):
+by name — work in DETACHED HEAD off the remote tip, FROM YOUR WORKTREE CWD):
+  git rev-parse --show-toplevel   # MUST be your .claude/worktrees/ path, not the primary repo
   git fetch origin <branch>
   git checkout --detach origin/<branch>
   mix deps.get            # only if deps/_build are missing in this worktree

--- a/.agents/workflows/recover-triage-implement-review.mjs
+++ b/.agents/workflows/recover-triage-implement-review.mjs
@@ -12,6 +12,17 @@ const CONV = `
 REPO: tv-labs/lua — an embedded Lua 5.3 VM written in Elixir. Working dir is a
 git worktree off 'main'. Use the gh CLI (authenticated as davydog187).
 
+WORKTREE ISOLATION (CRITICAL): you run in an ISOLATED git worktree under
+.claude/worktrees/, NOT the operator's primary checkout. Run EVERY git command
+from your current working directory. NEVER \`cd\` to the canonical checkout and
+NEVER pass \`git -C <canonical-path>\`. Before ANY state-changing git command
+(checkout/branch/reset/commit/push), run \`git rev-parse --show-toplevel\` and
+confirm it points at your worktree under .claude/worktrees/ — NOT the primary
+repo. If it points at the primary checkout, STOP. Mutating the primary checkout
+(detaching its HEAD, leaving uncommitted/broken files behind) corrupts the
+operator's working tree and must not happen. Reading files at the canonical path
+is fine; state-changing git there is forbidden.
+
 NON-NEGOTIABLE CONVENTIONS (from .agents/skills/ship-a-plan/SKILL.md and CLAUDE.md):
 - Commit subject and PR title scope = the affected SUBSYSTEM, never a plan id.
   e.g. 'feat(stdlib): ...', 'fix(vm): ...', 'feat(pattern): ...'. NEVER 'feat(A45): ...'.

--- a/.agents/workflows/ship-issue-batch.mjs
+++ b/.agents/workflows/ship-issue-batch.mjs
@@ -120,6 +120,19 @@ const FIX_SCHEMA = {
 }
 
 const SHIP_RULES = `
+WORKTREE ISOLATION (CRITICAL — read first):
+- You run in an ISOLATED git worktree under .claude/worktrees/, NOT the operator's
+  primary checkout. Run EVERY git command from your current working directory.
+- NEVER \`cd\` to the canonical checkout path and NEVER pass \`git -C <canonical-path>\`.
+  Do not use absolute paths that resolve into the primary checkout for any git write.
+- Before ANY state-changing git command (checkout, branch, reset, commit, push), run
+  \`git rev-parse --show-toplevel\` and confirm it points at your worktree under
+  .claude/worktrees/ — NOT the primary repo. If it points at the primary checkout, STOP
+  and do not run the command. Mutating the primary checkout (detaching its HEAD, leaving
+  uncommitted/broken files behind) corrupts the operator's working tree — this has
+  happened before and must not recur. Reading files under the canonical checkout is fine;
+  state-changing git there is forbidden.
+
 SHIP-A-PLAN CONTRACT (.agents/skills/ship-a-plan/SKILL.md) — follow exactly:
 - Branch off main inside this worktree: git checkout -b <branch>.
 - First commit: create/update the plan file with status: in-progress, commit "chore(<id>): start plan" (this commit touches ONLY the plan file).
@@ -177,6 +190,15 @@ Hunt for REAL problems, default to skepticism but mark real:false for anything y
 - Missing or weak tests for the behavior changed; for fix/perf PRs, is there a regression test?
 - ship-a-plan rule violations: plan id used as a commit/PR subject scope (e.g. "fix(A47): ..."), a "Co-Authored-By" AI trailer present, red tests, or merged-without-review.
 - Doc/quality PRs: accuracy, broken links, claims that don't match the code.
+
+POST your review to the PR so it leaves a durable, visible trail (mark it clearly as an
+automated round-${round} review). GitHub blocks self-approval because the PR author is the
+gh user, so use the --comment event, NEVER --approve:
+  gh pr review ${prNumber} --repo tv-labs/lua --comment --body "<your review markdown>"
+The posted body should lead with a one-line verdict (clean / clean-with-nits /
+changes-requested) and then the findings, each tagged [blocker]/[major]/[minor]/[nit] with
+file:line and a concrete rationale. If clean, say so and note what you verified. This is a
+read-only review otherwise: do NOT check out, edit, branch, or push anything.
 
 Classify each finding severity (blocker|major|minor|nit) and real (true/false). Set clean:true ONLY if no real blocker or major findings remain (minor/nit do not block).`
 }

--- a/.agents/workflows/triage-implement-review.mjs
+++ b/.agents/workflows/triage-implement-review.mjs
@@ -15,6 +15,17 @@ const CONV = `
 REPO: tv-labs/lua — an embedded Lua 5.3 VM written in Elixir. Working dir is a
 git worktree off 'main'. Use the gh CLI (authenticated as davydog187).
 
+WORKTREE ISOLATION (CRITICAL): you run in an ISOLATED git worktree under
+.claude/worktrees/, NOT the operator's primary checkout. Run EVERY git command
+from your current working directory. NEVER \`cd\` to the canonical checkout and
+NEVER pass \`git -C <canonical-path>\`. Before ANY state-changing git command
+(checkout/branch/reset/commit/push), run \`git rev-parse --show-toplevel\` and
+confirm it points at your worktree under .claude/worktrees/ — NOT the primary
+repo. If it points at the primary checkout, STOP. Mutating the primary checkout
+(detaching its HEAD, leaving uncommitted/broken files behind) corrupts the
+operator's working tree and must not happen. Reading files at the canonical path
+is fine; state-changing git there is forbidden.
+
 NON-NEGOTIABLE CONVENTIONS (from .agents/skills/ship-a-plan/SKILL.md and CLAUDE.md):
 - Commit subject and PR title scope = the affected SUBSYSTEM, never a plan id.
   e.g. 'feat(stdlib): ...', 'fix(vm): ...', 'feat(pattern): ...'. NEVER 'feat(A43): ...'.


### PR DESCRIPTION
## Summary

Two recurring failures surfaced while running the `pr-feedback-stabilize` and `ship-issue-batch` orchestration scripts against real PRs. Both are fixed here; orchestration scripts only, no VM/stdlib change.

### 1. `ship-issue-batch` never published its reviews
Its review step inspected each PR read-only and fed findings into the fix-loop, but never posted to GitHub — so PRs that the workflow drove to `clean` carried **no visible review trail** (the detailed findings weren't even returned in the run result). The review prompt now posts each round via `gh pr review --comment` (never `--approve`, since GitHub blocks self-approval for the PR author), matching what `pr-feedback-stabilize` already does.

### 2. Worktree agents corrupted the operator's primary checkout
Worktree-isolated agents ran state-changing git commands against the **primary checkout** instead of their isolated worktree. `git checkout --detach origin/<branch>` detached the main checkout's HEAD **twice** in one session and left a broken uncommitted `executor.ex` behind. All four scripts now open their shared rules block with a **WORKTREE ISOLATION** guard: run git only from the worktree cwd, never `cd` to the canonical path or use `git -C <canonical>`, and assert `git rev-parse --show-toplevel` is under `.claude/worktrees/` before any `checkout`/`branch`/`reset`/`commit`/`push`.

## Files
- `ship-issue-batch.mjs` — isolation guard + review step now posts
- `pr-feedback-stabilize.mjs` — isolation guard (review posting already present)
- `triage-implement-review.mjs` — isolation guard
- `recover-triage-implement-review.mjs` — isolation guard

## Verification
- All four scripts parse cleanly (template literals balanced; only the expected top-level-`return` note from `node --check`, which the Workflow runtime wraps).
- `WORKTREE ISOLATION` present in all 4; `gh pr review … --comment` wired into `ship-issue-batch`'s review prompt.

## Out of scope
The plan-id-as-commit-scope nit (`chore(B11): …`) the review agents keep flagging on the perf PRs is a separate ship-a-plan-conformance issue, not addressed here.