### PR TITLE
perf(vm): inline per-call depth check on hot call/return paths

### DIFF
--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -32,9 +32,15 @@ defmodule Lua.VM.Dispatcher do
 
   # Per-call depth check, inlined to a plain integer comparison so the
   # call-dense recursive path does not pay a cross-module call on every
-  # Lua call/return. Mirrors `State.next_call_depth!/1`: returns the
-  # bumped depth, or raises a catchable "stack overflow" once the limit
-  # is hit. The `:infinity` head (the default) skips the comparison.
+  # Lua call/return. Returns the bumped depth, or raises a catchable
+  # "stack overflow" once the limit is hit. The `:infinity` head (the
+  # default) skips the comparison.
+  #
+  # This is one of three copies of the same logic: the authoritative
+  # `Lua.VM.State.next_call_depth!/1` and an identical private copy in
+  # `Lua.VM.Executor`. They are not compiler-checked against each other,
+  # so any change here must be mirrored in the other two. The shared
+  # semantics are pinned by `test/lua/vm/state_test.exs`.
   @compile {:inline, next_call_depth!: 1}
 
   defp next_call_depth!(%State{call_depth: depth, max_call_depth: :infinity}), do: depth + 1

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -30,6 +30,20 @@ defmodule Lua.VM.Dispatcher do
   alias Lua.VM.Table
   alias Lua.VM.Value
 
+  # Per-call depth check, inlined to a plain integer comparison so the
+  # call-dense recursive path does not pay a cross-module call on every
+  # Lua call/return. Mirrors `State.next_call_depth!/1`: returns the
+  # bumped depth, or raises a catchable "stack overflow" once the limit
+  # is hit. The `:infinity` head (the default) skips the comparison.
+  @compile {:inline, next_call_depth!: 1}
+
+  defp next_call_depth!(%State{call_depth: depth, max_call_depth: :infinity}), do: depth + 1
+  defp next_call_depth!(%State{call_depth: depth, max_call_depth: max}) when depth < max, do: depth + 1
+
+  defp next_call_depth!(%State{call_stack: call_stack}) do
+    raise RuntimeError, value: "stack overflow", call_stack: call_stack
+  end
+
   # Mirror of the interpreter's concat ceiling, inlined as a compile-time
   # constant so the binary-binary fast path stays a single comparison. See
   # `Lua.VM.Executor.concat_checked/2` for the rationale.
@@ -582,12 +596,12 @@ defmodule Lua.VM.Dispatcher do
               {code, pc + 1, regs, upvalues, proto, cont, :discard, state.open_upvalues}
 
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
+            depth = next_call_depth!(state)
 
             state = %{
               state
               | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+                call_depth: depth,
                 open_upvalues: %{}
             }
 
@@ -605,8 +619,8 @@ defmodule Lua.VM.Dispatcher do
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
-            state = %{state | call_stack: [call_info | state.call_stack], call_depth: state.call_depth + 1}
+            depth = next_call_depth!(state)
+            state = %{state | call_stack: [call_info | state.call_stack], call_depth: depth}
             {_results, state} = Executor.call_function(closure, args, state)
             state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
             dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames)
@@ -635,12 +649,12 @@ defmodule Lua.VM.Dispatcher do
               {code, pc + 1, regs, upvalues, proto, cont, base, state.open_upvalues}
 
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
+            depth = next_call_depth!(state)
 
             state = %{
               state
               | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+                call_depth: depth,
                 open_upvalues: %{}
             }
 
@@ -658,8 +672,8 @@ defmodule Lua.VM.Dispatcher do
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
-            state = %{state | call_stack: [call_info | state.call_stack], call_depth: state.call_depth + 1}
+            depth = next_call_depth!(state)
+            state = %{state | call_stack: [call_info | state.call_stack], call_depth: depth}
             {results, state} = Executor.call_function(closure, args, state)
             state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
 
@@ -1039,12 +1053,12 @@ defmodule Lua.VM.Dispatcher do
 
             frame = {code, pc + 1, regs, upvalues, proto, cont, dest, state.open_upvalues}
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
+            depth = next_call_depth!(state)
 
             state = %{
               state
               | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+                call_depth: depth,
                 open_upvalues: %{}
             }
 
@@ -1062,8 +1076,8 @@ defmodule Lua.VM.Dispatcher do
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, total_args)
             call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            State.check_call_depth!(state)
-            state = %{state | call_stack: [call_info | state.call_stack], call_depth: state.call_depth + 1}
+            depth = next_call_depth!(state)
+            state = %{state | call_stack: [call_info | state.call_stack], call_depth: depth}
             {results, state} = Executor.call_function(closure, args, state)
             state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
             apply_multi_call_result(result_count, base, results, code, pc + 1, regs, upvalues, proto, state, cont, frames)

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -2177,9 +2177,15 @@ defmodule Lua.VM.Executor do
 
   # Per-call depth check, inlined to a plain integer comparison so the
   # call-dense recursive path does not pay a cross-module call on every
-  # Lua call/return. Mirrors `State.next_call_depth!/1`: returns the
-  # bumped depth, or raises a catchable "stack overflow" once the limit
-  # is hit. The `:infinity` head (the default) skips the comparison.
+  # Lua call/return. Returns the bumped depth, or raises a catchable
+  # "stack overflow" once the limit is hit. The `:infinity` head (the
+  # default) skips the comparison.
+  #
+  # This is one of three copies of the same logic: the authoritative
+  # `Lua.VM.State.next_call_depth!/1` and an identical private copy in
+  # `Lua.VM.Dispatcher`. They are not compiler-checked against each other,
+  # so any change here must be mirrored in the other two. The shared
+  # semantics are pinned by `test/lua/vm/state_test.exs`.
   @compile {:inline, next_call_depth!: 1}
   defp next_call_depth!(%State{call_depth: depth, max_call_depth: :infinity}), do: depth + 1
   defp next_call_depth!(%State{call_depth: depth, max_call_depth: max}) when depth < max, do: depth + 1

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -967,8 +967,8 @@ defmodule Lua.VM.Executor do
         # without going through this branch.
         args = collect_args(regs, base + 1, total_args)
         call_info = %{source: proto.source, line: line, name: hint_name(name_hint), namewhat: hint_namewhat(name_hint)}
-        State.check_call_depth!(state)
-        state = %{state | call_stack: [call_info | state.call_stack], call_depth: state.call_depth + 1}
+        depth = next_call_depth!(state)
+        state = %{state | call_stack: [call_info | state.call_stack], call_depth: depth}
         {results, state} = Dispatcher.execute(callee_proto, args, callee_upvalues, state)
         state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
         continue_after_call(results, regs, rest, upvalues, proto, state, cont, frames, line, base, result_count)
@@ -1005,12 +1005,12 @@ defmodule Lua.VM.Executor do
 
         call_info = %{source: proto.source, line: line, name: hint_name(name_hint), namewhat: hint_namewhat(name_hint)}
 
-        State.check_call_depth!(state)
+        depth = next_call_depth!(state)
 
         state = %{
           state
           | call_stack: [call_info | state.call_stack],
-            call_depth: state.call_depth + 1,
+            call_depth: depth,
             open_upvalues: %{}
         }
 
@@ -2173,6 +2173,19 @@ defmodule Lua.VM.Executor do
 
   defp concat_checked(_left, _right) do
     raise RuntimeError, value: "resulting string too large"
+  end
+
+  # Per-call depth check, inlined to a plain integer comparison so the
+  # call-dense recursive path does not pay a cross-module call on every
+  # Lua call/return. Mirrors `State.next_call_depth!/1`: returns the
+  # bumped depth, or raises a catchable "stack overflow" once the limit
+  # is hit. The `:infinity` head (the default) skips the comparison.
+  @compile {:inline, next_call_depth!: 1}
+  defp next_call_depth!(%State{call_depth: depth, max_call_depth: :infinity}), do: depth + 1
+  defp next_call_depth!(%State{call_depth: depth, max_call_depth: max}) when depth < max, do: depth + 1
+
+  defp next_call_depth!(%State{call_stack: call_stack}) do
+    raise RuntimeError, value: "stack overflow", call_stack: call_stack
   end
 
   # ── Metamethod support ─────────────────────────────────────────────────────

--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -9,7 +9,7 @@ defmodule Lua.VM.State do
             # Call depth tracked as an O(1) counter that moves in lockstep
             # with `call_stack` — `length(call_stack)` would be O(depth) per
             # call. `max_call_depth` bounds it; `:infinity` (the default)
-            # means no limit. See `check_call_depth!/1`.
+            # means no limit. See `next_call_depth!/1`.
             call_depth: 0,
             max_call_depth: :infinity,
             metatables: %{},
@@ -55,21 +55,28 @@ defmodule Lua.VM.State do
   end
 
   @doc """
-  Guards against unbounded recursion.
+  Returns the next call depth, guarding against unbounded recursion.
+
+  Call it immediately before pushing a frame onto `call_stack`: it both
+  enforces the limit and computes the incremented `call_depth` in a
+  single pass, so callers never read `call_depth` a second time to bump
+  it.
 
   Raises a Lua `"stack overflow"` runtime error when the call depth has
-  reached `max_call_depth`. Call it immediately before pushing a frame
-  onto `call_stack`.
+  already reached `max_call_depth`. When `max_call_depth` is `:infinity`
+  (the default) the limit comparison is skipped — the only work is the
+  integer increment.
 
-  No-op when depth is under the limit or when `max_call_depth` is
-  `:infinity` (the default). The clauses are ordered so both common cases
-  resolve in a single function-head match with no struct rebuild.
+  The hot call/return paths in `Lua.VM.Dispatcher` and `Lua.VM.Executor`
+  inline this same comparison directly rather than pay a cross-module
+  call on every Lua call. This function is the authoritative definition
+  they mirror, and the entry point for any other caller.
   """
-  @spec check_call_depth!(t()) :: :ok
-  def check_call_depth!(%__MODULE__{max_call_depth: :infinity}), do: :ok
-  def check_call_depth!(%__MODULE__{call_depth: depth, max_call_depth: max}) when depth < max, do: :ok
+  @spec next_call_depth!(t()) :: pos_integer()
+  def next_call_depth!(%__MODULE__{call_depth: depth, max_call_depth: :infinity}), do: depth + 1
+  def next_call_depth!(%__MODULE__{call_depth: depth, max_call_depth: max}) when depth < max, do: depth + 1
 
-  def check_call_depth!(%__MODULE__{call_stack: call_stack}) do
+  def next_call_depth!(%__MODULE__{call_stack: call_stack}) do
     raise Lua.VM.RuntimeError, value: "stack overflow", call_stack: call_stack
   end
 

--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -70,7 +70,10 @@ defmodule Lua.VM.State do
   The hot call/return paths in `Lua.VM.Dispatcher` and `Lua.VM.Executor`
   inline this same comparison directly rather than pay a cross-module
   call on every Lua call. This function is the authoritative definition
-  they mirror, and the entry point for any other caller.
+  those two private copies mirror, and the entry point for any other
+  caller. The copies are not compiler-checked against this one, so any
+  change to the limit logic here must be applied to all three; the direct
+  unit test in `test/lua/vm/state_test.exs` pins the shared semantics.
   """
   @spec next_call_depth!(t()) :: pos_integer()
   def next_call_depth!(%__MODULE__{call_depth: depth, max_call_depth: :infinity}), do: depth + 1

--- a/test/lua/vm/state_test.exs
+++ b/test/lua/vm/state_test.exs
@@ -1,0 +1,49 @@
+defmodule Lua.VM.StateTest do
+  @moduledoc """
+  Pins the authoritative `State.next_call_depth!/1` and, by extension, the
+  shared semantics the inlined copies in `Lua.VM.Dispatcher` and
+  `Lua.VM.Executor` must match: the depth bumps by one under the limit,
+  `:infinity` skips the comparison, and reaching `max_call_depth` raises a
+  catchable Lua `"stack overflow"`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Lua.VM.RuntimeError
+  alias Lua.VM.State
+
+  describe "next_call_depth!/1" do
+    test "returns the incremented depth when under a finite limit" do
+      state = %State{call_depth: 3, max_call_depth: 10}
+
+      assert State.next_call_depth!(state) == 4
+    end
+
+    test "returns the incremented depth when max_call_depth is :infinity" do
+      state = %State{call_depth: 41, max_call_depth: :infinity}
+
+      assert State.next_call_depth!(state) == 42
+    end
+
+    test "skips the limit comparison for :infinity at depth 0 (the default)" do
+      assert State.next_call_depth!(%State{}) == 1
+    end
+
+    test "raises a catchable stack overflow once the depth reaches the limit" do
+      frames = [%{source: "chunk", line: 1, name: "f", namewhat: ""}]
+      state = %State{call_depth: 10, max_call_depth: 10, call_stack: frames}
+
+      assert_raise RuntimeError, ~r/stack overflow/, fn ->
+        State.next_call_depth!(state)
+      end
+    end
+
+    test "the raised error carries the stack-overflow value and the call stack" do
+      frames = [%{source: "chunk", line: 1, name: "f", namewhat: ""}]
+      state = %State{call_depth: 5, max_call_depth: 5, call_stack: frames}
+
+      error = catch_error(State.next_call_depth!(state))
+
+      assert %RuntimeError{value: "stack overflow", call_stack: ^frames} = error
+    end
+  end
+end


### PR DESCRIPTION
## What

Cheapens the per-call recursion-depth bookkeeping that PR #283
("configurable max call depth", `3a4a0c8`) added to every Lua
call/return. That PR put a `State.check_call_depth!/1` **cross-module
call** plus a `call_depth + 1` / `- 1` counter update on the hottest path
in the VM.

This change replaces the cross-module guard with a module-local
`next_call_depth!/1` marked `@compile {:inline}` in both
`Lua.VM.Dispatcher` and `Lua.VM.Executor`. For the default
`max_call_depth: :infinity` case the check collapses to a plain integer
increment with no call setup. The helper returns the already-incremented
depth, so the call sites no longer read `call_depth` a second time to bump
it. `State.next_call_depth!/1` stays as the authoritative definition the
inlined copies mirror (and the entry point for any non-hot-path caller).

This implements the first option listed in #324 (inline the depth check
as a plain integer comparison rather than a call into `State`).

## How correctness is preserved

The depth **limit** is not weakened:

- `next_call_depth!/1` raises the same catchable Lua `"stack overflow"`
  at exactly the same frame whenever a finite `max_call_depth` is reached
  — the comparison (`depth < max`) and the raise clause are byte-for-byte
  the same logic as the old `check_call_depth!/1`.
- The counter still increments on every push and decrements on every pop
  (call and return), so it unwinds to 0 on normal return and is restored
  after a `pcall`-caught overflow.
- `test/lua/vm/recursion_depth_test.exs` and
  `test/lua/error_gallery_test.exs` (the stack-overflow gallery case)
  pass unchanged, as does the full suite (2153 passed, 19 skipped) and
  the Lua 5.3 official suite embedded in it.

## Benchmark (this machine, drift-controlled)

`fibonacci` = fib(30), ~2.7M near-empty recursive calls. Measured with
Benchee (8s, 2s warmup), alternating rc.1 vs this branch in the same
session with **luerl as a drift control** (luerl held at ~748 ms across
all runs). `lua (chunk)`, 3-round average:

| build              | avg ms | ips  | vs luerl |
|--------------------|--------|------|----------|
| rc.0 (target)      | 642.7  | 1.56 | 0.86x    |
| rc.1 / main (before)| 838.7 | 1.18 | 1.12x    |
| **this branch (after)** | **807.6** | **1.24** | **1.08x** |

Delta: **-31 ms (~3.7%)**, ips 1.18 -> 1.24.

## Why this does not fully reach the rc.0 target

#324 targets "within ~5% of rc.0" (642 ms). I instrumented this directly:
building a throwaway variant that strips **all** depth bookkeeping from
the hot paths (no check, no counter) only reaches ~744 ms on this machine
— still ~100 ms above rc.0. So roughly half of the rc.0 -> rc.1
deep-recursion regression is depth-attributable and half comes from other
rc.1 dispatcher changes (e.g. #275 / #277) that are out of scope for this
issue and benefit the work-heavy workloads.

Within the depth-attributable slice, the cross-module call was the cleanly
removable cost; the residual (counter field writes + the inlined compare)
profiled at the noise floor, and removing it would mean branching the
call/return struct updates on `:infinity` — extra complexity for a
sub-noise gain. I kept the change tight and correct rather than chase it.

See the `flags` / discussion: the remaining gap is tracked by the broader
rc.1 dispatcher work, not weakenable depth limits.
