### PR TITLE
test(vm): silence unused variable warning in pcall error-value test

### DIFF
--- a/test/lua/vm/pcall_error_value_test.exs
+++ b/test/lua/vm/pcall_error_value_test.exs
@@ -278,7 +278,7 @@ defmodule Lua.VM.PcallErrorValueTest do
             @engine
           )
 
-        assert [false, "string", err] = results
+        assert [false, "string", _err] = results
       end
     end
   end


### PR DESCRIPTION
## Summary

The string-message case in `test/lua/vm/pcall_error_value_test.exs` bound `err` in its assertion pattern but never used it:

```elixir
assert [false, "string", err] = results
```

This produces an `unused variable "err"` compile warning. Prefix it with an underscore (`_err`) to match the surrounding style and clear the warning.

No behavior change.