### PR TITLE
feat(os): seed os.clock origin at install, add os.time_ms/os.time_us

### DIFF
--- a/lib/lua/vm/stdlib/os.ex
+++ b/lib/lua/vm/stdlib/os.ex
@@ -10,6 +10,8 @@ defmodule Lua.VM.Stdlib.Os do
   ## Functions
 
   - `os.time([table])` - Epoch seconds, optionally from a date table.
+  - `os.time_ms()` - Current epoch in milliseconds (extension; not in PUC-Lua).
+  - `os.time_us()` - Current epoch in microseconds (extension; not in PUC-Lua).
   - `os.clock()` - Approximate CPU time used, in seconds.
   - `os.difftime(t2, t1)` - Difference in seconds between two times.
   - `os.date([format [, time]])` - Formats a time as a string or table.
@@ -31,6 +33,10 @@ defmodule Lua.VM.Stdlib.Os do
 
   @impl true
   def install(state) do
+    # Seed the monotonic origin at install time so os.clock() measures from a
+    # stable startup point rather than from whenever it is first called.
+    _ = boot_offset()
+
     os_table = %{
       "clock" => {:native_func, &os_clock/2},
       "date" => {:native_func, &os_date/2},
@@ -39,6 +45,8 @@ defmodule Lua.VM.Stdlib.Os do
       "getenv" => {:native_func, &os_getenv/2},
       "setlocale" => {:native_func, &os_setlocale/2},
       "time" => {:native_func, &os_time/2},
+      "time_ms" => {:native_func, &os_time_ms/2},
+      "time_us" => {:native_func, &os_time_us/2},
       "tmpname" => {:native_func, &os_tmpname/2}
     }
 
@@ -108,6 +116,18 @@ defmodule Lua.VM.Stdlib.Os do
 
   defp os_time([arg | _], _state) do
     raise ArgumentError.type_error("os.time", 1, "table", Util.typeof(arg))
+  end
+
+  # os.time_ms() — current epoch in milliseconds. Non-standard extension (not
+  # present in PUC-Lua); use os.time() for portable, whole-second time.
+  defp os_time_ms(_args, state) do
+    {[System.os_time(:millisecond)], state}
+  end
+
+  # os.time_us() — current epoch in microseconds. Non-standard extension (not
+  # present in PUC-Lua); use os.time() for portable, whole-second time.
+  defp os_time_us(_args, state) do
+    {[System.os_time(:microsecond)], state}
   end
 
   # os.date([format [, time]]) — formats a time.
@@ -266,8 +286,10 @@ defmodule Lua.VM.Stdlib.Os do
   defp pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, "0")
   defp pad3(n), do: n |> Integer.to_string() |> String.pad_leading(3, "0")
 
-  # Monotonic clock origin captured at module load so os.clock() reports
-  # elapsed seconds from a stable reference.
+  # Monotonic clock origin so os.clock() reports elapsed seconds from a stable
+  # reference. Seeded at library install (see install/1); the value lives in
+  # :persistent_term, which is BEAM-global, so the first VM to install wins and
+  # all later installs reuse that origin.
   defp boot_offset do
     case :persistent_term.get({__MODULE__, :boot}, nil) do
       nil ->

--- a/lib/lua/vm/stdlib/os.ex
+++ b/lib/lua/vm/stdlib/os.ex
@@ -35,7 +35,7 @@ defmodule Lua.VM.Stdlib.Os do
   def install(state) do
     # Seed the monotonic origin at install time so os.clock() measures from a
     # stable startup point rather than from whenever it is first called.
-    _ = boot_offset()
+    boot_offset()
 
     os_table = %{
       "clock" => {:native_func, &os_clock/2},

--- a/test/lua/vm/stdlib/os_test.exs
+++ b/test/lua/vm/stdlib/os_test.exs
@@ -25,6 +25,24 @@ defmodule Lua.VM.Stdlib.OsTest do
       assert t == 946_684_800
     end
 
+    test "os.time_ms returns the current epoch in milliseconds" do
+      {[t], _} = Lua.eval!("return os.time_ms()")
+      assert is_integer(t)
+      assert t > 1_500_000_000_000
+    end
+
+    test "os.time_us returns the current epoch in microseconds" do
+      {[t], _} = Lua.eval!("return os.time_us()")
+      assert is_integer(t)
+      assert t > 1_500_000_000_000_000
+    end
+
+    test "os.time_ms and os.time_us share the same magnitude as os.time" do
+      {[secs, ms, us], _} = Lua.eval!("return os.time(), os.time_ms(), os.time_us()")
+      assert div(ms, 1000) in (secs - 2)..(secs + 2)
+      assert div(us, 1_000_000) in (secs - 2)..(secs + 2)
+    end
+
     test "os.difftime returns the difference in seconds" do
       {[d], _} = Lua.eval!("return os.difftime(10, 3)")
       assert d == 7.0


### PR DESCRIPTION
Closes #330.

## Context

Issue #330 flagged two problems with the `os` standard library:

1. **`os.clock()` origin was seeded lazily.** The `boot_offset/0` helper's comment claimed the monotonic origin was "captured at module load," but it was actually seeded on the *first call* to `os.clock()` — so the origin drifted to whenever a program first happened to call it.
2. **No sub-second epoch precision.** `os.time()` returns whole seconds (correct PUC-Lua behavior), leaving programs that need finer resolution with no option.

## Changes

- **Seed `boot_offset()` in `install/1`** so `os.clock()` measures elapsed time from a stable startup point. Updated the stale `boot_offset/0` comment to describe the real (`:persistent_term`, BEAM-global, first-installer-wins) semantics.
- **Add `os.time_ms()` and `os.time_us()`** — non-standard extensions returning the current epoch in milliseconds / microseconds via `System.os_time/1`. Both are current-time-only (no date-table arg, since sub-second precision on a whole-second date table is meaningless). `os.time()` is unchanged.
- **`@moduledoc`** lists the new functions and explicitly marks them as extensions not present in PUC-Lua.

## Tests

Added coverage in `test/lua/vm/stdlib/os_test.exs` for integer type and magnitude of both new functions, plus a cross-check that ms/us track `os.time()`. All os tests pass (`mix test test/lua/vm/stdlib/os_test.exs` → 12 passed).

## Out of scope

- Making `os.clock()` per-VM rather than BEAM-global (issue only asks to seed at install).
- Date-table support for the `_ms`/`_us` variants.
- Changing `os.time()`'s whole-second return.