### PR TITLE
fix(api): deflua/2 preserves function name for guarded heads

### DIFF
--- a/lib/lua/api.ex
+++ b/lib/lua/api.ex
@@ -262,7 +262,11 @@ defmodule Lua.API do
   See `deflua/3`
   """
   defmacro deflua(fa, rest) do
-    {name, _, _} = fa
+    name =
+      case fa do
+        {:when, _, [{name, _, _} | _]} -> name
+        {name, _, _} -> name
+      end
 
     quote do
       @lua_function validate_func!(

--- a/test/lua/api_test.exs
+++ b/test/lua/api_test.exs
@@ -333,6 +333,38 @@ defmodule Lua.APITest do
       assert {1, _} = module.with_state(1, Lua.new())
       assert {"not a int", _} = module.with_state(true, Lua.new())
     end
+
+    test "guarded deflua heads register under their real name, not :when" do
+      assert [{module, _}] =
+               Code.compile_string("""
+               defmodule GuardedRegistration do
+                 use Lua.API
+
+                 deflua has_a_guard(a) when is_integer(a) do
+                   a
+                 end
+
+                 deflua has_a_guard(_) do
+                   "not a int"
+                 end
+
+                 deflua with_state(a) when is_integer(a), state do
+                   {a, state}
+                 end
+               end
+               """)
+
+      names = Enum.map(module.__lua_functions__(), &elem(&1, 0))
+
+      assert :has_a_guard in names
+      assert :with_state in names
+      refute :when in names
+
+      lua = Lua.load_api(Lua.new(), module)
+
+      assert {[1], _} = Lua.eval!(lua, "return has_a_guard(1)")
+      assert {["not a int"], _} = Lua.eval!(lua, "return has_a_guard('foo')")
+    end
   end
 
   describe "guards" do


### PR DESCRIPTION
## Bug

`deflua/2` (a guarded head with no state arg) registered the function under the name `:when` instead of its real name, making it unreachable from Lua. For example:

```elixir
deflua clamp(a) when is_integer(a) do
  a
end
```

would register `clamp` as `:when` in `__lua_functions__/0`, so calling `clamp(...)` from a Lua chunk raised an undefined-function error.

## Root cause

In `lib/lua/api.ex`, the 2-arity `deflua` macro extracted the name with a single binding:

```elixir
{name, _, _} = fa
```

For a guarded head the AST is `{:when, _, [{name, _, _} | _]}`, so the match against the outer tuple bound `name` to `:when`. `deflua/3` (the state-arg variant) already handled this correctly with a `case`, which is why guarded heads with a state arg were never affected.

## Fix

Use the same case-based extraction `deflua/3` already uses to unwrap the `:when` node and reach the real function name, falling back to the plain head for non-guarded definitions. Name-only change; the `def unquote(fa)` body and `@variadic` handling are untouched.

## Regression test

The existing "deflua functions can have guards" test only asserted the generated Elixir function worked (`module.has_a_guard(1) == 1`) and never checked the Lua registration name, which is exactly why the bug slipped through. A new test "guarded deflua heads register under their real name, not :when" asserts:

- `__lua_functions__/0` contains the real names (`:has_a_guard`, `:with_state`) and **not** `:when`
- the guarded function is callable end-to-end from Lua via `Lua.load_api` + `Lua.eval!` (`return has_a_guard(1)`)

Confirmed the new test fails against the unfixed macro (registers `:when`) and passes with the fix.

## Validation

- `mix test test/lua/api_test.exs` — 15 passed
- `mix test` (full suite) — 2247 passed, 19 skipped, 1 excluded
- `mix format --check-formatted` — clean

Closes #343