### PR TITLE
chore(release): 1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v1.0.0-rc.2] - 2026-06-10
+
+The third release candidate for `1.0.0`. It builds on rc.1 with a major
+table-storage performance win, two non-standard `os` epoch helpers, and
+a batch of protected-call and error-value correctness fixes that bring
+`pcall` / `xpcall` and `Lua.call_function/3` in line with Lua 5.3 §6.1.
+The public API is unchanged from rc.1.
+
+### Performance
+
+- **Split-storage tables (Erlang `:array` + map)** — dense
+  positive-integer keys (`1..n`) now route to an Erlang `:array` for
+  O(1) functional read/write and dense iteration ordering, while
+  strings, sparse/non-positive integers, and other key types stay in
+  the hash map with the existing iteration bookkeeping (#328).
+  String-keyed reads (globals, fields, metatable lookups) are unchanged.
+  Table-heavy workloads improve **28–37%** at n=1000 (Apple M4, `lua`
+  chunk path): Build **−36%**, Iterate/Sum **−36%**, Map+Reduce
+  **−37%**, Sort **−28%**. Build, Iterate, and Map+Reduce now beat
+  Luerl; Sort closes most of the gap.
+
+### Added
+
+- **`os.time_ms()` and `os.time_us()`** — non-standard extensions
+  returning the current epoch in milliseconds / microseconds, for
+  programs that need sub-second precision (`os.time()` is unchanged and
+  still returns whole seconds). Both are current-time-only and are
+  documented as extensions not present in PUC-Lua (#340).
+- The `os.clock()` monotonic origin is now seeded in `install/1` rather
+  than lazily on the first call, so elapsed time is measured from a
+  stable startup point instead of drifting to whenever a program first
+  happened to call `os.clock()` (#340).
+
 ### Fixed
 
+- **`deflua/2` guarded heads register under their real name** (#344). A
+  guarded head with no state argument
+  (`deflua clamp(a) when is_integer(a)`) was registered under the name
+  `:when` instead of `clamp`, making it uncallable from Lua (calling it
+  raised an undefined-function error). The macro now unwraps the `:when`
+  AST node to reach the real name, matching the `deflua/3` (state-arg)
+  variant, which was never affected.
 - **`Lua.call_function/3` returns the terse Lua error value, not the terminal
   render** (#336). Its `{:error, reason, _}` previously surfaced the
   terminal-formatted error string — ANSI escape codes, the `at <source>:<line>:`
@@ -38,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   protected-call boundaries recover it: heap state is kept, control state
   (call stack, open upvalues) unwinds. The `xpcall` message handler now also
   observes those mutations, matching PUC-Lua's handler semantics.
+
+### Known issues
+
+- **Deep recursion is ~25% slower than rc.0.** Carried forward from
+  rc.1: the configurable call-depth limit (#283) adds per-call
+  bookkeeping that recursion-dense workloads (e.g. naive `fib(30)`) pay
+  in full. Workloads that do real work per call are unaffected or
+  faster. This remains a deliberate safety/speed tradeoff for the RC and
+  will be addressed before `1.0.0` final.
 
 ## [v1.0.0-rc.1] - 2026-06-02
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lua.MixProject do
   use Mix.Project
 
   @url "https://github.com/tv-labs/lua"
-  @version "1.0.0-rc.1"
+  @version "1.0.0-rc.2"
 
   def project do
     [

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -43,6 +43,16 @@ defmodule Website.LuaSandbox do
   @lua_max_string_bytes 16 * 1024 * 1024
 
   @doc """
+  Returns the version of the `:lua` package this site is built against,
+  read from the loaded application spec so it tracks the dependency
+  automatically (no manual edits on a version bump).
+  """
+  @spec lua_version() :: String.t()
+  def lua_version do
+    :lua |> Application.spec(:vsn) |> to_string()
+  end
+
+  @doc """
   Compiles a Lua snippet into a `Lua.Chunk` (without running it) and
   returns the chunk plus the disassembled prototype tree. Returns
   `{:error, formatted_messages}` if parsing or compilation fails.

--- a/website/lib/website_web/components/layouts.ex
+++ b/website/lib/website_web/components/layouts.ex
@@ -318,7 +318,7 @@ defmodule DemoWeb.Layouts do
             </a>
             and three decades of Lua.
           </span>
-          <span>Apache 2.0 licensed</span>
+          <span>v{Website.LuaSandbox.lua_version()} &middot; Apache 2.0 licensed</span>
         </div>
       </div>
     </footer>

--- a/website/lib/website_web/controllers/page_controller.ex
+++ b/website/lib/website_web/controllers/page_controller.ex
@@ -6,7 +6,8 @@ defmodule DemoWeb.PageController do
 
     render(conn, :home,
       fib_source: fib_source,
-      fib_bytecode: compile_bytecode(fib_source)
+      fib_bytecode: compile_bytecode(fib_source),
+      lua_version: Website.LuaSandbox.lua_version()
     )
   end
 

--- a/website/lib/website_web/controllers/page_html/home.html.heex
+++ b/website/lib/website_web/controllers/page_html/home.html.heex
@@ -603,12 +603,12 @@
           id="hex-install"
           class="bg-base-100/50 border border-base-300/60 px-3 py-1.5 rounded-md"
         >
-          {"{:lua, \"~> 1.0.0-rc.1\"}"}
+          {"{:lua, \"~> #{@lua_version}\"}"}
         </code>
         <button
           id="copy-hex"
           phx-hook="CopyButton"
-          data-copy={"{:lua, \"~> 1.0.0-rc.1\"}"}
+          data-copy={"{:lua, \"~> #{@lua_version}\"}"}
           class="btn btn-xs btn-ghost border border-base-300/60 normal-case"
           aria-label="Copy mix dependency"
         >


### PR DESCRIPTION
## Summary

Cuts the **third release candidate** for `1.0.0`. `1.0.0` final (plan A13) is still blocked on the broader Direction-A gates, so this bundles the post-rc.1 work into another RC. Public API is unchanged from rc.1.

Bumps `mix.exs` `@version` → `1.0.0-rc.2` and promotes the `## Unreleased` changelog block to a dated `[v1.0.0-rc.2]` section.

## What's in rc.2 (since rc.1)

**Performance**
- Split-storage tables (Erlang `:array` + map) — dense `1..n` keys route to an `:array`; table-heavy workloads improve 28–37% at n=1000 and now beat Luerl on Build/Iterate/Map+Reduce (#328).

**Added**
- `os.time_ms()` / `os.time_us()` epoch helpers (non-standard extensions); `os.clock()` origin now seeded in `install/1` instead of lazily (#340).

**Fixed**
- `deflua/2` guarded heads registered under `:when` instead of their real name, making them uncallable from Lua (#344).
- `Lua.call_function/3` returns the terse Lua error value, not the terminal render (#336).
- `pcall`/`xpcall` pass the raised value through verbatim + `source:line:` prefix per §6.1 (#334).
- Protected calls no longer roll back heap effects on error (#331).

**Known issues**
- Deep recursion remains ~25% slower than rc.0 (carried forward from rc.1; per-call depth bookkeeping). To be addressed before final.

## Website
Makes the displayed version automatic: `Website.LuaSandbox.lua_version/0` reads `Application.spec(:lua, :vsn)`, so the home-page install snippet and a new footer badge track the dependency with no manual edits on future bumps. Verified the site renders `1.0.0-rc.2`.

## Verification
- `mix format` / `mix compile --warnings-as-errors` — clean
- `mix test` — 2247 passed, 19 skipped
- `mix test --include skip` — only the known-deferred official suite files fail (pm/gc/constructs/etc.), no new regressions
- `mix docs --warnings-as-errors` — clean
- `mix lua.suite` — unchanged deferred-suite status
- `mix hex.build` — succeeds (`Version: 1.0.0-rc.2`)

## Publish (after merge, human-gated)
Tag `v1.0.0-rc.2` on the merge commit and create a GitHub **pre-release** (matching rc.0/rc.1). Publishing the release fires `.github/workflows/release.yml` → `mix hex.publish --yes`. No manual publish needed.