### PR TITLE
perf(vm): inline int64 range guard in interpreter integer fast path

### DIFF
--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -21,6 +21,13 @@ defmodule Lua.VM.Executor do
   alias Lua.VM.TypeError
   alias Lua.VM.Value
 
+  # Signed 64-bit integer bounds, matching Dispatcher and Numeric. Inlined as
+  # module-attribute literals so the in-range check is a guard-eligible
+  # compile-time constant in the integer arithmetic fast paths below; the
+  # cross-module `Numeric.to_signed_int64/1` call only fires on actual overflow.
+  @max_int 0x7FFFFFFFFFFFFFFF
+  @min_int -0x8000000000000000
+
   # ── Source position bridge for native callbacks ───────────────────────────
   #
   # In-executor raise sites get `line` / `proto.source` threaded as args
@@ -1277,7 +1284,8 @@ defmodule Lua.VM.Executor do
   defp do_execute([{:add, dest, a, b, _hint_a, _hint_b} | rest], regs, upvalues, proto, state, cont, frames, line)
        when is_integer(:erlang.element(a + 1, regs)) and is_integer(:erlang.element(b + 1, regs)) do
     sum = :erlang.element(a + 1, regs) + :erlang.element(b + 1, regs)
-    regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(sum))
+    wrapped = if sum >= @min_int and sum <= @max_int, do: sum, else: Numeric.to_signed_int64(sum)
+    regs = :erlang.setelement(dest + 1, regs, wrapped)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 
@@ -1304,7 +1312,8 @@ defmodule Lua.VM.Executor do
   defp do_execute([{:subtract, dest, a, b, _hint_a, _hint_b} | rest], regs, upvalues, proto, state, cont, frames, line)
        when is_integer(:erlang.element(a + 1, regs)) and is_integer(:erlang.element(b + 1, regs)) do
     diff = :erlang.element(a + 1, regs) - :erlang.element(b + 1, regs)
-    regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(diff))
+    wrapped = if diff >= @min_int and diff <= @max_int, do: diff, else: Numeric.to_signed_int64(diff)
+    regs = :erlang.setelement(dest + 1, regs, wrapped)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 
@@ -1331,7 +1340,8 @@ defmodule Lua.VM.Executor do
   defp do_execute([{:multiply, dest, a, b, _hint_a, _hint_b} | rest], regs, upvalues, proto, state, cont, frames, line)
        when is_integer(:erlang.element(a + 1, regs)) and is_integer(:erlang.element(b + 1, regs)) do
     prod = :erlang.element(a + 1, regs) * :erlang.element(b + 1, regs)
-    regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(prod))
+    wrapped = if prod >= @min_int and prod <= @max_int, do: prod, else: Numeric.to_signed_int64(prod)
+    regs = :erlang.setelement(dest + 1, regs, wrapped)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 

--- a/test/lua/vm/arithmetic_test.exs
+++ b/test/lua/vm/arithmetic_test.exs
@@ -336,4 +336,51 @@ defmodule Lua.VM.ArithmeticTest do
       assert eval_int("return -1 % 0x7fffffffffffffff") == @maxint - 1
     end
   end
+
+  describe "integer fast-path inline range guard (add/subtract/multiply)" do
+    # In-range results return the plain integer arithmetic value unchanged
+    # (the inline `if … in range` branch, not the to_signed_int64 fallback).
+
+    test "in-range add returns plain sum" do
+      assert eval_int("return 2 + 3") == 5
+    end
+
+    test "in-range subtract returns plain difference" do
+      assert eval_int("return 10 - 4") == 6
+    end
+
+    test "in-range multiply returns plain product" do
+      assert eval_int("return 6 * 7") == 42
+    end
+
+    # Positive overflow takes the wrap (else) branch.
+
+    test "add positive overflow wraps maxint + 1 to minint" do
+      assert eval_int("return 0x7fffffffffffffff + 1") == @minint
+    end
+
+    test "multiply positive overflow wraps maxint * 2 to -2" do
+      assert eval_int("return 0x7fffffffffffffff * 2") == -2
+    end
+
+    # Negative overflow takes the wrap (else) branch.
+
+    test "subtract negative overflow wraps minint - 1 to maxint" do
+      assert eval_int("return -0x8000000000000000 - 1") == @maxint
+    end
+
+    test "multiply negative overflow wraps minint * -1 to minint" do
+      assert eval_int("local x = -0x8000000000000000; return x * -1") == @minint
+    end
+
+    # Exact boundary values stay in range (inclusive bounds) and pass through.
+
+    test "maxint + 0 passes through unchanged" do
+      assert eval_int("return 0x7fffffffffffffff + 0") == @maxint
+    end
+
+    test "minint + 0 passes through unchanged" do
+      assert eval_int("return -0x8000000000000000 + 0") == @minint
+    end
+  end
 end


### PR DESCRIPTION
## What changed and why

Inlines the signed-int64 range guard directly into the interpreter's integer
add/sub/mul fast path in `lib/lua/vm/executor.ex`, mirroring the guard-eligible
inlining already done in the Dispatcher, to avoid the call into
`Numeric.to_signed_int64/1` on the hot path.

## Benchmark delta

Scenario: fib(30) recursive, executed via a pre-compiled Lua chunk
(`Lua.load_chunk!` once, then `Lua.eval!(lua, chunk)` per iteration). This
exercises the interpreter integer add/sub fast path the branch touches.

- Baseline: `origin/main` @ 016fa35. fib(30) chunk, Benchee full mode
  (time:10s, warmup:2s, memory_time:1s), 3 runs: 955.01 ms / 1.05 ips (±4.10%),
  899.23 ms / 1.11 ips (±4.33%), 912.87 ms / 1.10 ips (±3.93%). Mean avg ~922 ms.
  Memory 3.75 GB (identical to branch).
- Branch: `perf/executor-int-narrow-fastpath` @ 06df434 (one commit on top of
  016fa35). fib(30) chunk, same Benchee full config, 3 runs: 892.66 ms /
  1.12 ips (±3.60%), ~1040 ms / 0.97 ips (±13.63%), 928.04 ms / 1.08 ips (±0.64%).
  Mean avg ~954 ms. Memory 3.75 GB (identical to baseline).

**delta_pct: +3.4%** (mean branch avg 953.6 ms vs mean baseline avg 922.4 ms;
positive = branch slightly slower by the mean).

**INCONCLUSIVE / NOISY:** distributions fully overlap; the best baseline run
(899 ms) beats 2 of 3 branch runs, and one branch run had ±13.6% deviation —
larger than the mean delta. No reliable speedup observed at this n on this
machine (macOS darwin 25.5.0, BEAM, not isolated from background load).

Harness: minimal uncommitted Benchee script `benchmarks/fib30_chunk.exs`
(isolated to only `lua (chunk) fib(30)` = `Lua.eval!(lua, pre-loaded fib_chunk)`;
no Luerl/luaport to reduce noise; asserts fib(30)==832040), reusing the existing
`benchmarks/helpers.exs` `Bench.opts()`. Run command:
`LUA_BENCH_MODE=full MIX_ENV=benchmark mix run benchmarks/fib30_chunk.exs`.
Each ref checked out into the worktree and recompiled between runs; the script
was removed and the worktree restored afterward (not committed to this branch).

## Review verdict

Verdict: **ready** (tests pass after change). One nit, no fixes applied:

- nit: The inline guard duplicates the `@max_int`/`@min_int` constants and the
  in-range short-circuit logic now in three places (`Numeric.to_signed_int64/1`
  first clause, `Dispatcher`, and now `Executor`). This is intentional (mirrors
  Dispatcher for guard-eligible inlining) and `Numeric.to_signed_int64/1` is
  itself `@compile`-inlined, but it is a maintenance coupling: a future change to
  the int64 bounds must be made in three spots. Not a correctness issue.

## Merge gating

Given the benchmark result is inconclusive (no measurable speedup, mean is
marginally slower than baseline and well within run-to-run variance), **merge is
human-gated.** This PR is opened as a draft for human review of whether the
inlining is worth keeping absent a demonstrable performance win. The motivation
came from an external performance review of the interpreter integer fast path,
not from an internal plan.
