### PR TITLE
fix(vm): return terse error value for ArgumentError at protected-call boundary

### DIFF
--- a/lib/lua/vm/argument_error.ex
+++ b/lib/lua/vm/argument_error.ex
@@ -83,13 +83,25 @@ defmodule Lua.VM.ArgumentError do
 
   @impl true
   def message(%__MODULE__{} = e) do
-    base = build_base(e.function_name, e.arg_num, e.expected, e.got, e.details)
-
-    Lua.VM.ErrorFormatter.format(:type_error, base,
+    Lua.VM.ErrorFormatter.format(:type_error, raw_message(e),
       source: e.source,
       line: e.line,
       call_stack: e.call_stack
     )
+  end
+
+  @doc """
+  Returns the unformatted Lua-facing error value — the bare
+  `"bad argument #N to 'F' (expected, got got)"` string with no location
+  header, no ANSI, no stack trace.
+
+  This is the §6.1 error value that `pcall`/`xpcall` and
+  `Lua.call_function/3` hand back at a protected-call boundary. See
+  `Lua.VM.ProtectedCall.error_value/1`.
+  """
+  @spec raw_message(t()) :: String.t()
+  def raw_message(%__MODULE__{} = e) do
+    build_base(e.function_name, e.arg_num, e.expected, e.got, e.details)
   end
 
   defp build_base(function_name, arg_num, expected, got, details) do

--- a/lib/lua/vm/argument_error.ex
+++ b/lib/lua/vm/argument_error.ex
@@ -96,8 +96,7 @@ defmodule Lua.VM.ArgumentError do
   header, no ANSI, no stack trace.
 
   This is the §6.1 error value that `pcall`/`xpcall` and
-  `Lua.call_function/3` hand back at a protected-call boundary. See
-  `Lua.VM.ProtectedCall.error_value/1`.
+  `Lua.call_function/3` hand back at a protected-call boundary.
   """
   @spec raw_message(t()) :: String.t()
   def raw_message(%__MODULE__{} = e) do

--- a/lib/lua/vm/protected_call.ex
+++ b/lib/lua/vm/protected_call.ex
@@ -9,10 +9,16 @@ defmodule Lua.VM.ProtectedCall do
   # 1. `error()`'s §6.1-prefixed string view (`RuntimeError.lua_value`).
   # 2. Raw passthrough on KEY PRESENCE — `value: nil` (from `error()`) and
   #    `value: false` must match here so the boundary returns nil/false like
-  #    PUC-Lua, never an `is_nil`-guarded fallthrough to clause 3.
-  # 3. `ArgumentError` (no `:value` field) and plain Elixir exceptions keep
-  #    their message string.
+  #    PUC-Lua, never an `is_nil`-guarded fallthrough to the next clause.
+  # 3. `ArgumentError` builds its message from individual fields and has no
+  #    `:value` slot, so it gets its own clause that returns the raw
+  #    `"bad argument #N to 'F' ..."` string — never the terminal-rendered
+  #    `Exception.message/1` (ANSI + location header).
+  # 4. Plain Elixir exceptions keep their message string as a last resort.
+  alias Lua.VM.ArgumentError
+
   def error_value(%{lua_value: lv}) when not is_nil(lv), do: lv
   def error_value(%{value: value}), do: value
+  def error_value(%ArgumentError{} = e), do: ArgumentError.raw_message(e)
   def error_value(e), do: Exception.message(e)
 end

--- a/test/lua/call_function_error_value_test.exs
+++ b/test/lua/call_function_error_value_test.exs
@@ -142,4 +142,44 @@ defmodule Lua.CallFunctionErrorValueTest do
       assert message =~ "runtime error:"
     end
   end
+
+  describe "call_function!/3 preserves the original VM exception via :original" do
+    test "ArgumentError passes through with all structured fields" do
+      {ref, lua} = fun!(~S|function() pairs("asdf") end|)
+
+      error =
+        assert_raise Lua.RuntimeException, fn ->
+          Lua.call_function!(lua, ref, [])
+        end
+
+      assert %Lua.VM.ArgumentError{
+               function_name: "pairs",
+               arg_num: 1,
+               expected: "table",
+               got: "string"
+             } = error.original
+    end
+
+    test "RuntimeError from error() passes through with its Lua value" do
+      {ref, lua} = fun!("function() error('boom') end")
+
+      error =
+        assert_raise Lua.RuntimeException, fn ->
+          Lua.call_function!(lua, ref, [])
+        end
+
+      assert %Lua.VM.RuntimeError{value: "boom"} = error.original
+    end
+
+    test "TypeError passes through with error_kind for programmatic dispatch" do
+      {ref, lua} = fun!("function() local t = nil; return t.x end")
+
+      error =
+        assert_raise Lua.RuntimeException, fn ->
+          Lua.call_function!(lua, ref, [])
+        end
+
+      assert %Lua.VM.TypeError{error_kind: :index_non_table} = error.original
+    end
+  end
 end

--- a/test/lua/call_function_error_value_test.exs
+++ b/test/lua/call_function_error_value_test.exs
@@ -54,6 +54,20 @@ defmodule Lua.CallFunctionErrorValueTest do
       refute reason =~ "\e["
       refute reason =~ "\n"
     end
+
+    test "a stdlib bad-argument ArgumentError stays a terse one-line string" do
+      {ref, lua} = fun!(~S|function() for i in pairs("asdf") do end end|)
+
+      assert {:error, reason, %Lua{}} = Lua.call_function(lua, ref, [])
+
+      assert is_binary(reason)
+      assert reason =~ "bad argument #1 to 'pairs'"
+      assert reason =~ "table expected"
+      assert reason =~ "got string"
+      refute reason =~ "\e["
+      refute reason =~ "at -no-source-"
+      refute reason =~ "\n"
+    end
   end
 
   describe "call_function/3 passes non-string error objects through (pcall parity)" do
@@ -92,6 +106,19 @@ defmodule Lua.CallFunctionErrorValueTest do
       assert IO.ANSI.enabled?()
 
       {ref, lua} = fun!("function() error('boom') end")
+      assert {:error, reason, %Lua{}} = Lua.call_function(lua, ref, [])
+
+      refute reason =~ "\e["
+    end
+
+    test "ArgumentError reason has no escape codes when ANSI is enabled" do
+      previous = Application.get_env(:elixir, :ansi_enabled)
+      Application.put_env(:elixir, :ansi_enabled, true)
+      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, previous) end)
+
+      assert IO.ANSI.enabled?()
+
+      {ref, lua} = fun!(~S|function() pairs("asdf") end|)
       assert {:error, reason, %Lua{}} = Lua.call_function(lua, ref, [])
 
       refute reason =~ "\e["

--- a/test/lua/vm/pcall_error_value_test.exs
+++ b/test/lua/vm/pcall_error_value_test.exs
@@ -148,6 +148,22 @@ defmodule Lua.VM.PcallErrorValueTest do
 
         assert results == [false, true]
       end
+
+      test "stdlib bad-argument error returns the terse raw string" do
+        {results, _state} =
+          run(
+            """
+            local ok, err = pcall(function()
+              pairs("asdf")
+            end)
+            return ok, type(err), err
+            """,
+            @engine
+          )
+
+        assert [false, "string", err] = results
+        assert err == "bad argument #1 to 'pairs' (table expected, got string)"
+      end
     end
 
     describe "error() position prefix on string messages (#{engine} engine)" do


### PR DESCRIPTION
## Summary

- `Lua.VM.ProtectedCall.error_value/1` had no clause for `Lua.VM.ArgumentError`, so it fell through to `Exception.message/1` — embedding ANSI codes and the `at <source>:<line>:` header in the reason returned by `Lua.call_function/3` and `pcall`/`xpcall`. PR #337 only fixed the `:value`-bearing exceptions (`RuntimeError`, `TypeError`, `AssertionError`); `ArgumentError` builds its message from individual fields and has no `:value` slot.
- Promote `ArgumentError.build_base/5` to a public `raw_message/1`, and add an `ArgumentError` clause to `error_value/1` that returns it.
- Regression tests for both protected-call boundaries (`call_function/3` and `pcall`), plus tests pinning `call_function!/3`'s structured-exception passthrough.

Fixes #342.

## Repro (before)

```elixir
chunk = ~LUA"""
function foo()
  for i in pairs("asdf") do
    print(i)
  end
end
"""c
{_, lua} = Lua.eval!(chunk)
Lua.call_function(lua, [:foo], [])
# {:error,
#  "\e[2mat -no-source-:\e[0m\n\n  bad argument #1 to 'pairs' (table expected, got string)",
#  #Lua<>}
```

## After

`call_function/3` returns the §6.1-faithful terse string (matching `pcall`'s contract):

```elixir
Lua.call_function(lua, [:foo], [])
# {:error, "bad argument #1 to 'pairs' (table expected, got string)", #Lua<>}
```

`call_function!/3` is the escape hatch for Elixir callers who want the structured exception — it raises `Lua.RuntimeException` whose `:original` field carries the underlying VM exception verbatim, so you can pattern-match on it:

```elixir
try do
  Lua.call_function!(lua, [:foo], [])
rescue
  e in Lua.RuntimeException ->
    case e.original do
      %Lua.VM.ArgumentError{function_name: fn_name, arg_num: n, expected: ex, got: g} ->
        # programmatic dispatch on the structured fields
        ...

      %Lua.VM.RuntimeError{value: v} ->
        # whatever Lua code passed to error()
        ...

      %Lua.VM.TypeError{error_kind: kind} ->
        # :call_nil, :index_non_table, :arith_non_number, etc.
        ...
    end
end
```

## Test plan

- [x] `mix test test/lua/call_function_error_value_test.exs` (14 cases, +6: ArgumentError regression, ANSI-on variant, and 3 cases pinning `call_function!/3`'s `.original` contract for `ArgumentError`/`RuntimeError`/`TypeError`)
- [x] `mix test test/lua/vm/pcall_error_value_test.exs` (+2 cases, one per engine)
- [x] `mix test` — full suite green (2256+ passed, 19 skipped)
- [x] iex repro from #342 returns terse one-line string with no ANSI / no header / no newlines
- [x] `mix docs --warnings-as-errors` clean
- [x] `mix format` clean