### PR TITLE
test: make default `mix test` pass quietly and deterministically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
         run: mix deps.get
 
       - name: Run tests
-        run: mix test
+        # :lua53 is opt-in locally (excluded by default); include it here so
+        # the curated Lua 5.3 suite stays enforced in CI.
+        run: mix test --include lua53
 
       - name: Format
         run: mix format --check-formatted

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,9 @@ defmodule Lua.MixProject do
       version: @version,
       elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
+      # test/lua53_skips.exs is suite config data (loaded via Code.eval_file),
+      # not a test file — tell the loader to ignore it instead of warning.
+      test_ignore_filters: [&String.ends_with?(&1, "_skips.exs")],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 

--- a/test/lua53_suite_test.exs
+++ b/test/lua53_suite_test.exs
@@ -61,7 +61,6 @@ defmodule Lua.Lua53SuiteTest do
       ranges = entries |> Enum.reject(&(&1.lines == :all)) |> Enum.map(& &1.lines)
 
       @test_file file
-      @ranges ranges
 
       cond do
         whole_file? ->
@@ -76,6 +75,8 @@ defmodule Lua.Lua53SuiteTest do
           end
 
         true ->
+          @ranges ranges
+
           skipped =
             Enum.reduce(ranges, 0, fn r, acc -> Enum.count(r) + acc end)
 

--- a/test/support/lua_test_case.ex
+++ b/test/support/lua_test_case.ex
@@ -11,9 +11,16 @@ defmodule Lua.TestCase do
 
   @doc false
   def run_lua_file(path, opts \\ []) do
-    case Lua.SuiteRunner.run_file(path, opts) do
-      :ok -> :ok
-      {:error, e} -> raise e
-    end
+    # Suite files print() heavily. Swallow that chatter so test output stays
+    # readable; capture_io re-raises after capturing, so a failing Lua
+    # assert() still fails the ExUnit test with its message intact.
+    ExUnit.CaptureIO.capture_io(fn ->
+      case Lua.SuiteRunner.run_file(path, opts) do
+        :ok -> :ok
+        {:error, e} -> raise e
+      end
+    end)
+
+    :ok
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,14 @@
+# Error formatter output is gated on IO.ANSI.enabled?/0, which returns true
+# when stdout is a real TTY. Force it off so golden-snapshot tests are
+# deterministic regardless of how the suite is launched. Tests that need
+# ANSI on flip it locally and restore it via on_exit/1 (see
+# test/lua/call_function_error_value_test.exs).
+Application.put_env(:elixir, :ansi_enabled, false)
+
 # `:differential` tests shell out to a reference `luac` and compare exact
 # line numbers; they are environment-dependent (luac version / availability)
 # and opt-in. Run them with `mix test --include differential`.
-ExUnit.start(exclude: [:slow, :differential])
+#
+# `:lua53` runs the Lua 5.3 official suite — slow and noisy (the suite files
+# print() heavily). It is opt-in: `mix test --include lua53` (or `--only`).
+ExUnit.start(exclude: [:slow, :differential, :lua53])


### PR DESCRIPTION
## Context

A bare `mix test` in an interactive terminal produced **18 failures, two warnings, and a flood of stdout** — none of which showed up in CI, because CI pipes stdout (not a TTY). The failures were environment-dependent, not code bugs.

## Changes

**ANSI failures (18 tests).** The error formatter (`lib/lua/vm/error_formatter.ex`) gates ANSI escape codes on `IO.ANSI.enabled?/0`, which returns `true` on a real TTY and `false` when piped. Several golden-snapshot tests *assumed* ANSI-off but nothing forced it. `test/test_helper.exs` now sets `Application.put_env(:elixir, :ansi_enabled, false)` before `ExUnit.start`, making formatter output deterministic regardless of how the suite is launched. (The one test that needs ANSI on still flips it locally and restores via `on_exit/1`.)

**Lua 5.3 suite → opt-in + silenced.** `:lua53` is the slow, noisy suite whose files `print()` heavily. It now joins `:slow`/`:differential` as opt-in:
- Excluded by default — run with `mix test --include lua53` (or `--only lua53`).
- `run_lua_file/2` is wrapped in `ExUnit.CaptureIO.capture_io/1`, so even opt-in / CI / `mix lua.suite` runs stay quiet. Failures still raise through with their assertion message intact.
- CI's blocking `build` job now runs `mix test --include lua53` to keep the curated suite enforced; the non-blocking survey job is unchanged.

**Warnings.**
- `mix.exs`: `test_ignore_filters: [&String.ends_with?(&1, "_skips.exs")]` — `test/lua53_skips.exs` is suite config data loaded via `Code.eval_file`, not a test file.
- `test/lua53_suite_test.exs`: `@ranges` moved into the `cond` branch that reads it, fixing "set but never used".

## Verification

- `mix test` → `2331 passed, 7 skipped, 35 excluded` — 0 failures, no warnings, no `print()` flood.
- `mix test --only lua53` → `17 passed, 12 skipped`, quiet.
- `mix format --check-formatted` → clean.