### PR TITLE
perf(vm): size dispatcher register files from emitted bytecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Performance
+
+- **Deep recursion regression recovered (#324).** Call-dense, work-light
+  workloads (naive `fib(30)` most visibly) were ~25%+ slower than rc.0.
+  The rc.1/rc.2 changelog attributed this to the call-depth bookkeeping
+  added in #283, but bisection showed that bookkeeping is now negligible;
+  the dominant regressor was the blanket `+16` register-slack buffer #347
+  reserved on every prototype's register tuple, paid on every call frame
+  by the dispatcher's `init_callee_regs/4`. The dispatcher now sizes each
+  register file to an exact `reg_file_size` derived from the emitted
+  bytecode (authoritative even where codegen's `max_registers` undercounts
+  the peak); runtime-dynamic expansion still grows the tuple on demand.
+  `fib(30)` improves from ~1.32× slower than Luerl to ~1.11× (Apple M-series,
+  drift-controlled), with no other workload slower. Fixes the latent
+  register undercount the slack had been masking.
+
 ### Fixed
 
 - **`tostring` on a function now returns a `function: 0x...` address**

--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -124,10 +124,179 @@ defmodule Lua.Compiler.Bytecode do
 
     case encode_list(proto.instructions, [], 0) do
       {:ok, encoded} ->
-        %{proto_with_children | bytecode: List.to_tuple(encoded)}
+        bytecode = List.to_tuple(encoded)
+
+        %{
+          proto_with_children
+          | bytecode: bytecode,
+            reg_file_size: reg_file_size(bytecode, proto.param_count)
+        }
 
       :fallback ->
         proto_with_children
+    end
+  end
+
+  # The exact register-file size the dispatcher must allocate to run
+  # `bytecode`: one past the highest register index any encoded op reads or
+  # writes, floored at `param_count` so the argument-copy range always fits.
+  #
+  # This is derived from the emitted bytecode rather than trusting
+  # `proto.max_registers`, which codegen can undercount for some expression
+  # shapes (it lost the peak of a few transient-register chains). The
+  # dispatcher used to paper over that with a blanket `+16` slack on every
+  # register tuple — costly on call-dense code that allocates a fresh tuple
+  # per frame (issue #324). Sizing exactly removes that per-call overhead
+  # while staying correct: runtime-dynamic expansion (vararg spread,
+  # multi-return results) is not counted here because the dispatcher grows
+  # the tuple on demand at those sites (`grow_regs/2`).
+  defp reg_file_size(bytecode, param_count) do
+    max(max_register_used(bytecode) + 1, param_count)
+  end
+
+  # Highest register index referenced anywhere in `bytecode`, or -1 if none.
+  # Recurses into the nested instruction tuples carried by branch/loop
+  # opcodes so the bound holds at every level.
+  defp max_register_used(bytecode) when is_tuple(bytecode) do
+    bytecode
+    |> Tuple.to_list()
+    |> Enum.reduce(-1, fn instr, acc -> max(acc, max_in_instr(instr)) end)
+  end
+
+  defp max_in_instr(instr) do
+    case register_positions(:erlang.element(1, instr)) do
+      :load_nil ->
+        # {tag, dest, count}: writes dest..dest+count-1.
+        :erlang.element(2, instr) + :erlang.element(3, instr) - 1
+
+      :vararg ->
+        # {tag, base, count}: writes base..base+count-1 when count>0; the
+        # count==0 spread grows on demand in the dispatcher, so bound by base.
+        base = :erlang.element(2, instr)
+        count = :erlang.element(3, instr)
+        if count == 0, do: base, else: base + count - 1
+
+      :return_multi ->
+        # {tag, base, count}: reads base..base+count-1.
+        :erlang.element(2, instr) + :erlang.element(3, instr) - 1
+
+      :numeric_for ->
+        # {tag, base, loop_var, body}: reads base..base+2, writes loop_var.
+        base = :erlang.element(2, instr)
+        Enum.max([base + 2, :erlang.element(3, instr), max_register_used(:erlang.element(4, instr))])
+
+      :while_loop ->
+        # {tag, test_reg, cond_body, loop_body}.
+        Enum.max([
+          :erlang.element(2, instr),
+          max_register_used(:erlang.element(3, instr)),
+          max_register_used(:erlang.element(4, instr))
+        ])
+
+      :repeat_loop ->
+        # {tag, test_reg, loop_body, cond_body}.
+        Enum.max([
+          :erlang.element(2, instr),
+          max_register_used(:erlang.element(3, instr)),
+          max_register_used(:erlang.element(4, instr))
+        ])
+
+      :generic_for ->
+        # {tag, base, var_regs_tuple, body, line}.
+        base = :erlang.element(2, instr)
+        var_max = Enum.reduce(Tuple.to_list(:erlang.element(3, instr)), -1, &max/2)
+        Enum.max([base + 2, var_max, max_register_used(:erlang.element(4, instr))])
+
+      :test ->
+        # {tag, reg, then_body, else_body}.
+        Enum.max([
+          :erlang.element(2, instr),
+          max_register_used(:erlang.element(3, instr)),
+          max_register_used(:erlang.element(4, instr))
+        ])
+
+      :self ->
+        # {tag, base, obj_reg, method, hint}: reads obj_reg, writes the
+        # resolved method into base and the receiver into base+1 (base+1
+        # dominates base). The base+1 write is not a syntactic operand, so it
+        # must be added explicitly — a zero-arg `obj:m()` call has no later op
+        # to cover it.
+        max(:erlang.element(2, instr) + 1, :erlang.element(3, instr))
+
+      positions when is_list(positions) ->
+        Enum.reduce(positions, -1, fn pos, acc -> max(acc, :erlang.element(pos + 1, instr)) end)
+    end
+  end
+
+  # Register operand positions per opcode, where position 0 is the opcode
+  # tag. Reads and writes fold together — any out-of-bounds index would
+  # crash the dispatcher's `:erlang.element/2` or `:erlang.setelement/3`.
+  # Opcodes whose register footprint needs structural handling (ranges,
+  # nested bodies) return an atom dispatched above. Mirror this when adding
+  # an encodable opcode; `max_registers_invariant_test.exs` pins the
+  # contract across the compilable surface.
+  defp register_positions(op) do
+    case op do
+      @op_load_constant -> [1]
+      @op_load_boolean -> [1]
+      @op_load_nil -> :load_nil
+      @op_move -> [1, 2]
+      @op_load_env -> [1]
+      @op_get_upvalue -> [1]
+      @op_get_global -> [1]
+      @op_get_field -> [1, 2]
+      @op_add -> [1, 2, 3]
+      @op_subtract -> [1, 2, 3]
+      @op_multiply -> [1, 2, 3]
+      @op_divide -> [1, 2, 3]
+      @op_floor_divide -> [1, 2, 3]
+      @op_modulo -> [1, 2, 3]
+      @op_power -> [1, 2, 3]
+      @op_negate -> [1, 2]
+      @op_bitwise_and -> [1, 2, 3]
+      @op_bitwise_or -> [1, 2, 3]
+      @op_bitwise_xor -> [1, 2, 3]
+      @op_shift_left -> [1, 2, 3]
+      @op_shift_right -> [1, 2, 3]
+      @op_bitwise_not -> [1, 2]
+      @op_less_than -> [1, 2, 3]
+      @op_less_equal -> [1, 2, 3]
+      @op_greater_than -> [1, 2, 3]
+      @op_greater_equal -> [1, 2, 3]
+      @op_equal -> [1, 2, 3]
+      @op_not_equal -> [1, 2, 3]
+      @op_not -> [1, 2]
+      @op_test -> :test
+      @op_call_zero -> [1]
+      @op_call_one -> [1]
+      @op_call_multi -> [1]
+      @op_return_one -> [1]
+      @op_return_zero -> []
+      @op_return_collect -> [1]
+      @op_return_multi -> :return_multi
+      @op_return_proto_varargs -> []
+      @op_new_table -> [1]
+      @op_get_table -> [1, 2, 3]
+      @op_set_table -> [1, 2, 3]
+      @op_set_field -> [1, 3]
+      @op_set_list -> [1, 2]
+      @op_set_list_multi -> [1, 2]
+      @op_length -> [1, 2]
+      @op_numeric_for -> :numeric_for
+      @op_closure -> [1]
+      @op_set_upvalue -> [2]
+      @op_get_open_upvalue -> [1, 2]
+      @op_set_open_upvalue -> [1, 2]
+      @op_vararg -> :vararg
+      @op_self -> :self
+      @op_concatenate -> [1, 2, 3]
+      @op_break -> []
+      @op_while_loop -> :while_loop
+      @op_repeat_loop -> :repeat_loop
+      @op_generic_for -> :generic_for
+      # Carries a register *watermark* (pre-block next_register), not an
+      # operand it touches; the watermark can be one past the last live slot.
+      @op_close_upvalues -> []
     end
   end
 

--- a/lib/lua/compiler/prototype.ex
+++ b/lib/lua/compiler/prototype.ex
@@ -22,7 +22,8 @@ defmodule Lua.Compiler.Prototype do
           max_registers: non_neg_integer(),
           source: binary(),
           lines: {non_neg_integer(), non_neg_integer()},
-          bytecode: tuple() | nil
+          bytecode: tuple() | nil,
+          reg_file_size: non_neg_integer()
         }
 
   # `bytecode` is an optional dense encoding produced by `Lua.Compiler.Bytecode`.
@@ -31,6 +32,17 @@ defmodule Lua.Compiler.Prototype do
   # The two representations are kept independent so the human-readable
   # `instructions` list (used by error reporting, debugging, and any future
   # tooling) survives untouched.
+  #
+  # `reg_file_size` is the exact number of registers the dispatcher must
+  # allocate to run `bytecode` — the highest register index any encoded op
+  # reads or writes, plus one (and never below `param_count`). It is derived
+  # from the emitted bytecode in `Lua.Compiler.Bytecode.compile/1`, which is
+  # authoritative even where codegen's `max_registers` undercounts the peak;
+  # runtime-dynamic expansion (vararg spread, multi-return) grows the tuple
+  # on demand in the dispatcher. Sizing to this exact value rather than a
+  # blanket slack buffer keeps call-dense code (deep recursion) off a
+  # per-call register over-allocation (issue #324). Zero for prototypes that
+  # fell back to the interpreter, which sizes its own register file.
   defstruct instructions: [],
             prototypes: [],
             upvalue_descriptors: [],
@@ -41,7 +53,8 @@ defmodule Lua.Compiler.Prototype do
             source: <<"-no-source-">>,
             lines: {0, 0},
             varargs: [],
-            bytecode: nil
+            bytecode: nil,
+            reg_file_size: 0
 
   @doc """
   Creates a new prototype with the given options.

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -165,18 +165,15 @@ defmodule Lua.VM.Dispatcher do
     end
   end
 
-  # The interpreter sizes register tuples with a +16 slack buffer
-  # (executor.ex:135) because codegen's `max_registers` undercounts the
-  # transient scratch slots a few constructs use — notably table
-  # constructors whose last element is a multi-return call (`{x, f()}`),
-  # which write through registers past the syntactic peak. The dispatcher
-  # mirrors that buffer so the same prototypes run safely once they
-  # compile; multi-return expansion still grows on demand beyond it.
-  @reg_slack 16
-
+  # Register tuples are sized to the prototype's exact `reg_file_size`
+  # (computed from the emitted bytecode in `Lua.Compiler.Bytecode`). No slack
+  # buffer: every runtime-dynamic write — vararg spread, multi-return result
+  # distribution — grows the tuple on demand via `grow_regs/2`, so the static
+  # size only has to cover the syntactic register peak. This avoids
+  # over-allocating a register tuple on every call frame, which dominated
+  # call-dense workloads like deep recursion (issue #324).
   defp init_regs(proto, args) do
-    size = max(proto.max_registers, proto.param_count) + @reg_slack
-    regs = Tuple.duplicate(nil, size)
+    regs = Tuple.duplicate(nil, proto.reg_file_size)
     copy_args(regs, 0, args, proto.param_count)
   end
 
@@ -1529,11 +1526,10 @@ defmodule Lua.VM.Dispatcher do
   end
 
   defp init_callee_regs(callee_proto, src_regs, src_off, arg_count) do
-    # Same +16 slack buffer as `init_regs/2` (executor.ex:1113): the callee
-    # body may use scratch registers past its reported `max_registers` for
-    # multi-return constructor tails.
-    size = max(callee_proto.max_registers, callee_proto.param_count) + @reg_slack
-    regs = Tuple.duplicate(nil, size)
+    # Exact-sized like `init_regs/2`; runs on every compiled-closure call,
+    # so sizing to the callee's true register peak (no slack) is what keeps
+    # deep recursion off a per-frame over-allocation (issue #324).
+    regs = Tuple.duplicate(nil, callee_proto.reg_file_size)
     copy_n = min(arg_count, callee_proto.param_count)
     copy_regs(src_regs, src_off, regs, 0, copy_n)
   end

--- a/test/lua/compiler/max_registers_invariant_test.exs
+++ b/test/lua/compiler/max_registers_invariant_test.exs
@@ -1,16 +1,18 @@
 defmodule Lua.Compiler.MaxRegistersInvariantTest do
   @moduledoc """
-  Pins the load-bearing invariant that `proto.max_registers` is large
+  Pins the load-bearing invariant that `proto.reg_file_size` is large
   enough to hold every register the encoded bytecode references.
 
-  The dispatcher sizes its register tuple to `max_registers` plus a
-  fixed `+16` slack buffer (`@reg_slack`), so a small codegen undercount
-  is absorbed rather than crashing. Writes beyond that buffer still raise
-  `:badarg` from `:erlang.setelement/3`, so the invariant — that codegen
-  bounds every encoded register index — is what keeps us off the slack.
-  It is enforced by `Lua.Compiler.Codegen.record_peak/1`; this test pins
-  it across the existing compilable surface so undercounts surface in CI
-  rather than as a runtime crash once they exceed the buffer.
+  The dispatcher sizes its register tuple to exactly `reg_file_size`, with
+  no slack buffer — runtime-dynamic writes (vararg spread, multi-return
+  result distribution) grow the tuple on demand instead. `reg_file_size`
+  is derived from the emitted bytecode in `Lua.Compiler.Bytecode.compile/1`
+  precisely so it stays correct even where codegen's own `max_registers`
+  undercounts the peak. Any register index the bytecode reads or writes
+  beyond `reg_file_size` would raise `:badarg` from `:erlang.element/2` or
+  `:erlang.setelement/3`, so this test re-derives the peak with an
+  independent walker and pins that `reg_file_size` bounds it across the
+  compilable surface.
 
   The walker recurses into nested branch bodies (`:test`) and nested
   prototypes so the bound is checked at every level.
@@ -80,7 +82,7 @@ defmodule Lua.Compiler.MaxRegistersInvariantTest do
       op == Bytecode.op_return_collect() -> [1]
       op == Bytecode.op_return_multi() -> :return_multi
       op == Bytecode.op_call_multi() -> [1]
-      op == Bytecode.op_self() -> [1, 2]
+      op == Bytecode.op_self() -> :self
       op == Bytecode.op_concatenate() -> [1, 2, 3]
       op == Bytecode.op_break() -> []
       op == Bytecode.op_while_loop() -> :while_loop
@@ -168,6 +170,13 @@ defmodule Lua.Compiler.MaxRegistersInvariantTest do
         var_max = Enum.reduce(Tuple.to_list(var_regs_tuple), -1, &max/2)
         Enum.max([base + 2, var_max, max_register_used(body_bc)])
 
+      :self ->
+        # {tag, base, obj_reg, method, hint}: reads obj_reg, writes base
+        # (method) and base+1 (receiver). The base+1 write is not a syntactic
+        # operand, so it must be counted explicitly — a zero-arg `obj:m()`
+        # call has no later op to cover it.
+        max(:erlang.element(2, instr) + 1, :erlang.element(3, instr))
+
       positions when is_list(positions) ->
         direct = Enum.reduce(positions, -1, fn pos, acc -> max(acc, :erlang.element(pos + 1, instr)) end)
 
@@ -192,12 +201,12 @@ defmodule Lua.Compiler.MaxRegistersInvariantTest do
         bytecode ->
           max_used = max_register_used(bytecode)
 
-          assert max_used < proto.max_registers,
+          assert max_used < proto.reg_file_size,
                  """
-                 #{proto.source} declares max_registers=#{proto.max_registers}
+                 #{proto.source} declares reg_file_size=#{proto.reg_file_size}
                  but the encoded bytecode writes/reads index #{max_used}.
                  The dispatcher sizes its register tuple to exactly
-                 max_registers, so this would crash with :badarg.
+                 reg_file_size, so this would crash with :badarg.
                  """
 
           :ok
@@ -288,6 +297,28 @@ defmodule Lua.Compiler.MaxRegistersInvariantTest do
        local t = {...}
        return t[1], t[2], t[3]
      end
+     """},
+    # Short-circuit compositions threaded through concat build deep
+    # transient-register chains whose peak codegen's `max_registers`
+    # undercounts. This shape crashed the dispatcher while it sized from
+    # `max_registers` and only escaped CI because the slack buffer hid it;
+    # it is the case that drove sizing from `reg_file_size` instead.
+    {"short-circuit chain through concat",
+     """
+     function f(a, b, c)
+       return "(" .. tostring(a and b) .. " and " .. tostring(b and c) .. ")"
+     end
+     """},
+    # A zero-arg method call writes the receiver into register base+1 with no
+    # later op to raise the counted peak, so `:self` must contribute base+1 to
+    # the bound. Sized from the receiver's own register, this undercounts by
+    # one unless `:self` is handled structurally — it crashed `obj:m()`.
+    {"zero-arg method call (:self base+1)",
+     """
+     local function f(obj)
+       return obj:m()
+     end
+     return f
      """}
   ]
 

--- a/test/lua/vm/dispatcher_test.exs
+++ b/test/lua/vm/dispatcher_test.exs
@@ -870,6 +870,22 @@ defmodule Lua.VM.DispatcherTest do
 
       assert results == ["hello 42"]
     end
+
+    test "zero-arg method call where base+1 is the register peak" do
+      # `:self` writes the receiver into register base+1. With no arguments
+      # and a receiver living at a low register, base+1 is the prototype's
+      # high-water mark — which the register-file sizing must account for.
+      # Sized one short, `:erlang.setelement(base + 2, ...)` raised :badarg
+      # once the dispatcher dropped its register-slack buffer (issue #324).
+      {_proto, results} =
+        run!("""
+        local obj = { m = function(self) return 42 end }
+        local function f(o) return o:m() end
+        return f(obj)
+        """)
+
+      assert results == [42]
+    end
   end
 
   describe "loops + break" do
@@ -974,6 +990,10 @@ defmodule Lua.VM.DispatcherTest do
         },
         param_count: 0,
         max_registers: 1,
+        # Hand-forged bytecode bypasses Bytecode.compile/1, so set the
+        # register-file size the dispatcher allocates from (one slot for
+        # register 0) explicitly.
+        reg_file_size: 1,
         source: "test-synthetic"
       }
 


### PR DESCRIPTION
## Summary

Recovers the deep-recursion performance regression tracked in #324. `fib(30)` goes from **~1.32× slower than Luerl to ~1.11×** (Apple M-series, drift-controlled by running Luerl identically before/after), with **no other workload slower**.

## What the investigation found

The issue (and the rc.1/rc.2 CHANGELOG "Known issues") attributed the regression to the per-call depth bookkeeping added in #283. Bisecting `fib(30)` on this machine told a different story:

| Ref | fib(30) | Note |
|-----|---------|------|
| v1.0.0-rc.0 | ~590 ms | baseline |
| #283 (`3a4a0c8`) | ~812 ms | depth bookkeeping (+15% **at the time**) |
| v1.0.0-rc.2 | ~800 ms | |
| **#347 (`df79f8f`)** | **~996 ms** | **+26% — register slack** |
| origin/main | ~943 ms | |

Two findings:

1. **#283's depth bookkeeping is no longer the cause.** Removing it *entirely* from current code recovers ~0% — later commits absorbed its cost. Inlining/cheapening the check (the issue's suggested fix) measures flat.
2. **The dominant regressor is #347** — a "perf" commit that added a blanket `+16` register-slack buffer to `init_callee_regs/4`, which runs on **every** compiled-closure call. fib(30) is ~2.7M calls, each over-allocating a register tuple (e.g. 10 → 26 slots). That's the +26%.

## The fix

The `+16` slack existed to cover prototypes whose register file can transiently exceed `max_registers` (multi-return constructor tails like `{x, f()}`). But every **runtime-dynamic** write in the dispatcher already grows the tuple on demand via `grow_regs/2` (vararg spread, multi-return result distribution, `{:multi, …}` expansion, `pad_nils`). The slack's *only* real job was masking a latent **static** undercount in codegen's `max_registers`.

So:
- Compute an exact per-prototype `reg_file_size` in `Lua.Compiler.Bytecode` by walking the emitted bytecode for the highest register index any op references — authoritative even where codegen undercounts.
- Size the dispatcher's register tuples to exactly that, **no slack**.
- `grow_regs/2` continues to cover runtime-dynamic growth.

This recovers the perf for **all** compiled prototypes (not just fib — register tuples shrink across the board) and fixes the latent undercount the slack had been hiding (see the short-circuit/concat regression case added to the invariant test).

## Review-stabilization cycle

An adversarial review caught a **critical latent bug in the first version of this change** (verified with a reproduction): the `:self` opcode (`obj:m()`) writes register `base+1` — not one of its syntactic operands — so the walker undercounted and a **zero-arg method call crashed with `:badarg`**. Fixed by handling `:self` structurally in both the production walker and the invariant test's walker, plus:
- an execution-level regression test (`obj:m()` through the dispatcher), and
- a `:self` corpus entry in `max_registers_invariant_test.exs`.

A follow-up focused audit (independent peak re-derivation across 88 programs + 15 end-to-end executions) confirmed no other opcode has the same bug class.

## Validation

- `mix test` (default + `--include slow --include differential --include lua53`, i.e. the official Lua 5.3 suite): **all green** (2368 passed with the heavy suites).
- Both new regression tests fail without the `:self` fix and pass with it.
- `mix format --check-formatted`: clean.
- Full benchmark suite: every workload equal or faster vs `origin/main` (lua/luerl ratio).

## Follow-ups (out of scope)

- Codegen's `max_registers` still undercounts for some expression shapes (now harmless on the dispatcher; the interpreter retains its own `+16` buffer). Worth fixing at the root in codegen's peak tracking.

Closes #324.
