### PR TITLE
perf(vm): close the fibonacci gap with Luerl — register reclaim + lazy call frames

### DIFF
--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -1218,87 +1218,100 @@ defmodule Lua.Compiler.Codegen do
           end
       end
 
-    case last_arg_type do
-      :vararg ->
-        # f(a, b, ...) - load a, b then all varargs
-        init_args = Enum.slice(args, 0..-2//1)
-        arg_count = length(init_args)
-        ctx = %{ctx | next_reg: base_reg + 1 + arg_count}
+    {instructions, ctx} =
+      case last_arg_type do
+        :vararg ->
+          # f(a, b, ...) - load a, b then all varargs
+          init_args = Enum.slice(args, 0..-2//1)
+          arg_count = length(init_args)
+          ctx = %{ctx | next_reg: base_reg + 1 + arg_count}
 
-        {arg_instructions, arg_regs, ctx} =
-          Enum.reduce(init_args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
-            {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
-            {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
-          end)
+          {arg_instructions, arg_regs, ctx} =
+            Enum.reduce(init_args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
+              {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
+              {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
+            end)
 
-        move_instructions = gen_move_args(arg_regs, base_reg + 1)
+          move_instructions = gen_move_args(arg_regs, base_reg + 1)
 
-        vararg_base = base_reg + 1 + arg_count
-        vararg_instruction = Instruction.vararg(vararg_base, 0)
-        call_instruction = Instruction.call(base_reg, -(arg_count + 1), 1, name_hint)
+          vararg_base = base_reg + 1 + arg_count
+          vararg_instruction = Instruction.vararg(vararg_base, 0)
+          call_instruction = Instruction.call(base_reg, -(arg_count + 1), 1, name_hint)
 
-        {function_instructions ++
-           move_function ++
-           arg_instructions ++
-           move_instructions ++
-           [vararg_instruction, call_instruction], base_reg, ctx}
+          {function_instructions ++
+             move_function ++
+             arg_instructions ++
+             move_instructions ++
+             [vararg_instruction, call_instruction], ctx}
 
-      :multi_call ->
-        # f(a, b, g()) - load a, b then expand all results of g()
-        init_args = Enum.slice(args, 0..-2//1)
-        last_call = List.last(args)
-        fixed_count = length(init_args)
+        :multi_call ->
+          # f(a, b, g()) - load a, b then expand all results of g()
+          init_args = Enum.slice(args, 0..-2//1)
+          last_call = List.last(args)
+          fixed_count = length(init_args)
 
-        ctx = %{ctx | next_reg: base_reg + 1 + fixed_count}
+          ctx = %{ctx | next_reg: base_reg + 1 + fixed_count}
 
-        {arg_instructions, arg_regs, ctx} =
-          Enum.reduce(init_args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
-            {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
-            {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
-          end)
+          {arg_instructions, arg_regs, ctx} =
+            Enum.reduce(init_args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
+              {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
+              {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
+            end)
 
-        move_instructions = gen_move_args(arg_regs, base_reg + 1)
+          move_instructions = gen_move_args(arg_regs, base_reg + 1)
 
-        # Ensure next_reg is positioned for the inner call
-        ctx = %{ctx | next_reg: base_reg + 1 + fixed_count}
+          # Ensure next_reg is positioned for the inner call
+          ctx = %{ctx | next_reg: base_reg + 1 + fixed_count}
 
-        # Compile the inner call — its results will be placed at base+1+fixed_count
-        {inner_call_instructions, _inner_base, ctx} = gen_expr(last_call, ctx)
+          # Compile the inner call — its results will be placed at base+1+fixed_count
+          {inner_call_instructions, _inner_base, ctx} = gen_expr(last_call, ctx)
 
-        # Patch the inner call's result_count to -2 (expand all results)
-        inner_call_instructions = patch_call_result_count(inner_call_instructions, -2)
+          # Patch the inner call's result_count to -2 (expand all results)
+          inner_call_instructions = patch_call_result_count(inner_call_instructions, -2)
 
-        # Outer call uses {:multi, fixed_count} to collect fixed + expanded args
-        call_instruction = Instruction.call(base_reg, {:multi, fixed_count}, 1, name_hint)
+          # Outer call uses {:multi, fixed_count} to collect fixed + expanded args
+          call_instruction = Instruction.call(base_reg, {:multi, fixed_count}, 1, name_hint)
 
-        {function_instructions ++
-           move_function ++
-           arg_instructions ++
-           move_instructions ++
-           inner_call_instructions ++
-           [call_instruction], base_reg, ctx}
+          {function_instructions ++
+             move_function ++
+             arg_instructions ++
+             move_instructions ++
+             inner_call_instructions ++
+             [call_instruction], ctx}
 
-      :normal ->
-        # Normal function call
-        arg_count = length(args)
-        ctx = %{ctx | next_reg: base_reg + 1 + arg_count}
+        :normal ->
+          # Normal function call
+          arg_count = length(args)
+          ctx = %{ctx | next_reg: base_reg + 1 + arg_count}
 
-        {arg_instructions, arg_regs, ctx} =
-          Enum.reduce(args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
-            {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
-            {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
-          end)
+          {arg_instructions, arg_regs, ctx} =
+            Enum.reduce(args, {[], [], ctx}, fn arg, {instructions, regs, ctx} ->
+              {arg_instructions, arg_reg, ctx} = gen_expr(arg, ctx)
+              {instructions ++ arg_instructions, regs ++ [arg_reg], ctx}
+            end)
 
-        move_instructions = gen_move_args(arg_regs, base_reg + 1)
+          move_instructions = gen_move_args(arg_regs, base_reg + 1)
 
-        call_instruction = Instruction.call(base_reg, arg_count, 1, name_hint)
+          call_instruction = Instruction.call(base_reg, arg_count, 1, name_hint)
 
-        {function_instructions ++
-           move_function ++
-           arg_instructions ++
-           move_instructions ++
-           [call_instruction], base_reg, ctx}
-    end
+          {function_instructions ++
+             move_function ++
+             arg_instructions ++
+             move_instructions ++
+             [call_instruction], ctx}
+      end
+
+    # A single-result call leaves its result in `base_reg`; the callee,
+    # argument, and vararg temp registers above it are dead. Record the
+    # peak so `max_registers` still covers that transient spread (the
+    # `instruction_size` backstop scans the emitted writes regardless),
+    # then reclaim everything above the result so sibling subexpressions
+    # — e.g. the second call in `fib(n-1) + fib(n-2)` — reuse the same
+    # registers instead of stacking fresh ones on top.
+    ctx = record_peak(ctx)
+    ctx = %{ctx | next_reg: base_reg + 1}
+
+    {instructions, base_reg, ctx}
   end
 
   defp gen_expr(%Expr.Table{fields: fields}, ctx) do

--- a/lib/lua/vm/error_formatter.ex
+++ b/lib/lua/vm/error_formatter.ex
@@ -27,6 +27,8 @@ defmodule Lua.VM.ErrorFormatter do
   the category. Stacking a second header would be redundant.
   """
 
+  alias Lua.VM.Executor
+
   @doc """
   Formats a runtime error into a multi-line string.
 
@@ -224,9 +226,9 @@ defmodule Lua.VM.ErrorFormatter do
   defp build_call_stack(call_stack) when is_list(call_stack) do
     Enum.map(call_stack, fn frame ->
       %{
-        source: Map.get(frame, :source),
-        line: Map.get(frame, :line),
-        name: Map.get(frame, :name)
+        source: Executor.frame_source(frame),
+        line: Executor.frame_line(frame),
+        name: Executor.frame_name(frame)
       }
     end)
   end

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -604,10 +604,45 @@ defmodule Lua.VM.Executor do
   end
 
   @doc false
-  @spec dispatcher_call_info(term(), term(), non_neg_integer()) :: map()
+  @spec dispatcher_call_info(term(), term(), non_neg_integer()) :: call_frame()
   def dispatcher_call_info(proto, name_hint, line) do
-    %{source: proto.source, line: line, name: hint_name(name_hint), namewhat: hint_namewhat(name_hint)}
+    # Hot path: every Lua call pushes one of these. Keep it a flat 3-tuple
+    # carrying the raw `name_hint` tag, and defer the `hint_name`/
+    # `hint_namewhat` decoding to the cold readers (`frame_name/1`,
+    # `frame_namewhat/1`) that only run during traceback formatting and
+    # `debug.getinfo`. A tuple is ~4 words vs ~7 for the old 4-key map, and
+    # skips two function calls per call frame.
+    {proto.source, line, name_hint}
   end
+
+  @typedoc false
+  @type call_frame() :: {term(), non_neg_integer(), term()} | map()
+
+  # Frame accessors decode either the runtime's flat 3-tuple
+  # `{source, line, name_hint}` or a caller-supplied map frame
+  # (`%{source:, line:, name:}` — accepted by the public `ErrorFormatter`
+  # entry points and used in tests). Map frames already carry decoded
+  # `:name`/`:namewhat`, so there is no hint to expand.
+
+  @doc false
+  @spec frame_source(call_frame()) :: term()
+  def frame_source({source, _line, _hint}), do: source
+  def frame_source(frame) when is_map(frame), do: Map.get(frame, :source)
+
+  @doc false
+  @spec frame_line(call_frame()) :: non_neg_integer() | nil
+  def frame_line({_source, line, _hint}), do: line
+  def frame_line(frame) when is_map(frame), do: Map.get(frame, :line)
+
+  @doc false
+  @spec frame_name(call_frame()) :: String.t() | nil
+  def frame_name({_source, _line, hint}), do: hint_name(hint)
+  def frame_name(frame) when is_map(frame), do: Map.get(frame, :name)
+
+  @doc false
+  @spec frame_namewhat(call_frame()) :: String.t()
+  def frame_namewhat({_source, _line, hint}), do: hint_namewhat(hint)
+  def frame_namewhat(frame) when is_map(frame), do: Map.get(frame, :namewhat, "")
 
   # ── Break ──────────────────────────────────────────────────────────────────
 
@@ -1101,7 +1136,7 @@ defmodule Lua.VM.Executor do
         # `:call_one` clause handles dispatcher → dispatcher chains
         # without going through this branch.
         args = collect_args(regs, base + 1, total_args)
-        call_info = %{source: proto.source, line: line, name: hint_name(name_hint), namewhat: hint_namewhat(name_hint)}
+        call_info = {proto.source, line, name_hint}
         State.check_call_depth!(state)
         state = %{state | call_stack: [call_info | state.call_stack], call_depth: state.call_depth + 1}
         {results, state} = Dispatcher.execute(callee_proto, args, callee_upvalues, state)
@@ -1143,7 +1178,7 @@ defmodule Lua.VM.Executor do
           open_upvalues: state.open_upvalues
         }
 
-        call_info = %{source: proto.source, line: line, name: hint_name(name_hint), namewhat: hint_namewhat(name_hint)}
+        call_info = {proto.source, line, name_hint}
 
         State.check_call_depth!(state)
 

--- a/lib/lua/vm/stdlib/debug.ex
+++ b/lib/lua/vm/stdlib/debug.ex
@@ -141,7 +141,7 @@ defmodule Lua.VM.Stdlib.Debug do
   defp name_info_for_level(level, state) when level >= 1 do
     case Enum.at(state.call_stack, level - 1) do
       nil -> {nil, ""}
-      frame -> {Map.get(frame, :name), Map.get(frame, :namewhat, "")}
+      frame -> {Executor.frame_name(frame), Executor.frame_namewhat(frame)}
     end
   end
 
@@ -157,7 +157,7 @@ defmodule Lua.VM.Stdlib.Debug do
   defp stack_position_for_level(level, state) when level > 1 do
     case Enum.at(state.call_stack, level - 2) do
       nil -> nil
-      frame -> {Map.get(frame, :line), Map.get(frame, :source)}
+      frame -> {Executor.frame_line(frame), Executor.frame_source(frame)}
     end
   end
 
@@ -172,8 +172,8 @@ defmodule Lua.VM.Stdlib.Debug do
       state.call_stack
       |> Enum.with_index(1)
       |> Enum.map(fn {frame, _i} ->
-        source = Map.get(frame, :source, "?")
-        line = Map.get(frame, :line, 0)
+        source = Executor.frame_source(frame) || "?"
+        line = Executor.frame_line(frame) || 0
         "\t#{source}:#{line}: in ?"
       end)
 


### PR DESCRIPTION
## Summary

Closes the recursive-fibonacci performance gap with Luerl by attacking the two costs the profiler flagged. On `fib(30)`, the time gap shrinks from **1.18x slower → 1.03x** (parity within Luerl's own ±3.3% run-to-run noise) and total allocations fall **~26%**.

Driven data-first with the profiling loop: baseline → `mix profile.tprof` (time + memory) → one fix → re-baseline.

## What the profile showed

On `fib(26)` through the dispatcher:

| Function | Time % | Alloc % | Notes |
|---|---|---|---|
| `:erlang.setelement/3` | 22.6% | **61.6%** | register tuple copied on every write |
| `Dispatcher.dispatch/8` | 46.2% | 19.2% | the interpreter loop |
| `Executor.dispatcher_call_info/3` | 5.0% | 3.7% | per-call traceback map |
| `hint_name/1` + `hint_namewhat/1` | 3.4% | — | name decoding, per call |

## Changes

**1. Defer call-frame name decoding (`perf(vm)`)**
Every call eagerly built a 4-key `%{source, line, name, namewhat}` map and decoded the call-site name tag — but those fields are read only by error traceback formatting and `debug.getinfo`, both cold. Now stores a flat 3-tuple `{source, line, name_hint}` and decodes lazily at the cold readers. `dispatcher_call_info` drops 5.0%→2.0% CPU; the `hint_*` functions leave the profile; per-frame alloc 7→4 words.

**2. Reclaim register window after single-result calls (`perf(codegen)`)**
`Expr.Call` left `next_reg` above the dead argument registers, so `fib(n-1) + fib(n-2)` stacked the two calls into disjoint register ranges and reported `max_registers = 10`. Resetting `next_reg` to `base_reg + 1` after the call lets siblings reuse the freed registers — fib drops to `max_registers = 6`. Since each register file is a tuple sized to `max_registers`, this shrinks `setelement`/`copy_regs`/`make_tuple`/`init_callee_regs` proportionally. This is the dominant win.

## Results (full-mode `benchmarks/fibonacci.exs`, vs Luerl)

| | Before | After |
|---|---|---|
| Time (chunk) | 1.18x slower | **1.03x** |
| Time (eval) | 1.14x slower | **1.04x** |
| Allocations (fib(26), tprof) | 73.6M words | 54.4M words (−26%) |

Memory remains 1.13x Luerl, dominated by `setelement` on the now-smaller tuples — further reduction is structural (the register representation itself).

## Testing

- `mix test --include slow` — **2413 passed**, 0 failures (includes the official Lua 5.3 suite)
- `mix test --only differential --only lua53` — all pass
- Spot-checked nested/multi-return calls and the closures/OOP benchmarks (compute correctly; register reclamation can only shrink tuples, never regress)