### PR TITLE
feat(bytecode): coverage guard + drop dead :set_global opcode

### DIFF
--- a/lib/lua/compiler/bytecode.ex
+++ b/lib/lua/compiler/bytecode.ex
@@ -71,8 +71,7 @@ defmodule Lua.Compiler.Bytecode do
   # The bitwise family and the `:set_list` multi-return tail (below) since
   # joined the covered set, so the only opcodes the encoder still rejects
   # are `:goto` / `:label` (label-resolution semantics not yet ported to the
-  # dispatcher's flat tuple model) and `:set_global` (a codegen vestige;
-  # modern codegen emits `:set_field` on `_ENV` instead).
+  # dispatcher's flat tuple model).
   @op_closure 37
   @op_set_upvalue 38
   @op_get_open_upvalue 39
@@ -129,6 +128,21 @@ defmodule Lua.Compiler.Bytecode do
       :fallback ->
         proto_with_children
     end
+  end
+
+  @doc """
+  True when `proto` and every prototype nested within it carry a `bytecode`
+  encoding — i.e. nothing in the tree fell back to the interpreter.
+
+  Use this after `compile/1` to assert dispatcher coverage. A `false` result
+  means at least one prototype contains an opcode the encoder still rejects
+  (today: `:goto` / `:label`).
+  """
+  @spec fully_compiled?(Prototype.t()) :: boolean()
+  def fully_compiled?(%Prototype{bytecode: nil}), do: false
+
+  def fully_compiled?(%Prototype{prototypes: children}) do
+    Enum.all?(children, &fully_compiled?/1)
   end
 
   # ── Encoding ────────────────────────────────────────────────────────────
@@ -424,9 +438,7 @@ defmodule Lua.Compiler.Bytecode do
   defp encode(:break), do: {:ok, {@op_break}}
 
   # Anything else — `:goto` / `:label` (label-resolution semantics not
-  # ported to the dispatcher's flat tuple model) and `:set_global` (codegen
-  # vestige; modern codegen uses `:set_field` on `_ENV` instead) — stays on
-  # the interpreter.
+  # ported to the dispatcher's flat tuple model) — stays on the interpreter.
   #
   # `:source_line` is stripped upstream in `encode_list/2`, so it never
   # reaches this clause table.

--- a/lib/lua/compiler/instruction.ex
+++ b/lib/lua/compiler/instruction.ex
@@ -24,7 +24,6 @@ defmodule Lua.Compiler.Instruction do
   # re-uses of those registers don't read through the stale cell.
   def close_upvalues(threshold), do: {:close_upvalues, threshold}
   def get_global(dest, name), do: {:get_global, dest, name}
-  def set_global(name, source), do: {:set_global, name, source}
 
   # Loads the runtime `_G` table reference into `dest`. Emitted at the start
   # of every chunk to bind `_ENV` as a chunk-level local. Plan A16 (Lua 5.3

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -763,14 +763,6 @@ defmodule Lua.VM.Executor do
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
   end
 
-  # ── set_global ─────────────────────────────────────────────────────────────
-
-  defp do_execute([{:set_global, name, source} | rest], regs, upvalues, proto, state, cont, frames, line) do
-    value = elem(regs, source)
-    state = State.set_global(state, name, value)
-    do_execute(rest, regs, upvalues, proto, state, cont, frames, line)
-  end
-
   # ── load_env ───────────────────────────────────────────────────────────────
   # Loads the chunk's `_ENV` table reference into `dest`. Plan A16 emits this
   # at the start of every chunk so `_ENV` (a chunk-level local at register 0)

--- a/test/lua/compiler/bytecode_test.exs
+++ b/test/lua/compiler/bytecode_test.exs
@@ -247,6 +247,43 @@ defmodule Lua.Compiler.BytecodeTest do
     end
   end
 
+  describe "fully_compiled?/1 coverage guard" do
+    # A representative corpus exercising every covered opcode family. Each
+    # program must compile end-to-end — root chunk and every nested function —
+    # so the dispatcher never silently falls back to the interpreter. The only
+    # documented exception is `:goto` / `:label` (asserted separately below).
+    @corpus [
+      {"arithmetic", "function f(a, b) return a + b * 2 - 1 end return f(3, 4)"},
+      {"comparison + branch", "function f(n) if n < 0 then return -n end return n end return f(-5)"},
+      {"recursion", "function fib(n) if n < 2 then return n end return fib(n-1)+fib(n-2) end return fib(10)"},
+      {"bitwise", "function f(n) return (n & 1) | (n << 2) end return f(7)"},
+      {"tables + length", "local t = {1, 2, 3} t[4] = 4 return #t"},
+      {"numeric for", "local s = 0 for i = 1, 10 do s = s + i end return s"},
+      {"generic for", "local n = 0 for _ in pairs({a=1, b=2}) do n = n + 1 end return n"},
+      {"while loop", "local i = 0 while i < 5 do i = i + 1 end return i"},
+      {"repeat loop", "local i = 0 repeat i = i + 1 until i >= 5 return i"},
+      {"break", "local i = 0 while true do i = i + 1 if i == 3 then break end end return i"},
+      {"closures + upvalues",
+       "local function counter() local n = 0 return function() n = n + 1 return n end end local c = counter() c() return c()"},
+      {"varargs + multi-return", "local function f(...) return ... end return f(1, 2, 3)"},
+      {"method call (self)", "local t = {v = 10} function t:get() return self.v end return t:get()"},
+      {"string concat", ~s{local function f(a, b) return a .. b end return f("x", "y")}}
+    ]
+
+    for {label, src} <- @corpus do
+      test "compiles fully: #{label}" do
+        assert Bytecode.fully_compiled?(compile!(unquote(src)))
+      end
+    end
+
+    test "goto/label is the one documented exception (not yet covered)" do
+      # Until the goto/label port lands, a program using `goto` is expected to
+      # fall back. This is the only construct codegen emits that the dispatcher
+      # does not yet cover; when it lands this assertion flips.
+      refute Bytecode.fully_compiled?(compile!("local i = 0 ::top:: i = i + 1 if i < 3 then goto top end return i"))
+    end
+  end
+
   describe "bitwise coverage" do
     test "a whole function using `n & 1` compiles end-to-end" do
       proto =


### PR DESCRIPTION
## Context

First of three PRs driving the bytecode **Dispatcher** to 100% opcode coverage so no prototype silently falls back to the interpreter. This PR establishes the invariant the rest of the work defends, and clears one dead-code gap.

The two remaining coverage gaps were `:goto`/`:label` (real, ported in the next PR) and `:set_global` (dead). This PR handles the guard + the dead one.

## What changed

- **`Bytecode.fully_compiled?/1`** — walks the prototype tree, returns `true` iff every prototype carries a `bytecode` encoding. The guard against a prototype quietly reverting to the interpreter.
- **Coverage corpus test** — 14 programs spanning every covered opcode family (arithmetic, comparison/branch, recursion, bitwise, tables, all four loop forms, break, closures/upvalues, varargs/multi-return, method calls, concat) assert `fully_compiled?/1`. One test pins `goto`/`label` as the **only** documented exception — this flips in PR 3.
- **Removed the dead `:set_global` opcode** — builder (`Instruction.set_global/2`) + executor handler. Modern codegen emits `:set_field` on `_ENV` for free-name assignment (Plan A16) and never produces `:set_global`. Confirmed zero emitters repo-wide. `State.set_global/3` (the runtime globals API) is unrelated and untouched.

## Verification

- `mix test test/lua/compiler/bytecode_test.exs` — 39 pass
- `mix test test/lua/vm test/lua/compiler` — 1295 pass, 4 skipped
- `mix format --check-formatted` clean

## Follow-ups

- PR 2: `:goto`/`:label` via the label-map strategy (encoder label-resolution + dispatcher `unwind_blocks`).
- PR 3: flip the coverage guard to strict (goto programs expected to compile).