### PR TITLE
fix(parser): propagate deep errors past function-call argument lists

### DIFF
--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -1254,6 +1254,9 @@ defmodule Lua.Parser do
   end
 
   defp error_position({:unexpected_token, _type, pos, _message}), do: pos
+  defp error_position({:bare_expression, pos, _expr_struct}), do: pos
+  defp error_position({:invalid_assign_target, pos, _expr_struct}), do: pos
+  defp error_position({:unclosed_delimiter, _delimiter, open_pos}), do: open_pos
   defp error_position(_), do: nil
 
   defp parse_expr_list_until(tokens, terminator, delimiter, open_pos) do

--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -642,7 +642,7 @@ defmodule Lua.Parser do
   end
 
   defp parse_assignment(targets, [{:operator, :assign, pos} | rest]) do
-    case validate_assign_targets(targets) do
+    case validate_assign_targets(targets, pos) do
       :ok ->
         case parse_expr_list(rest) do
           {:ok, values, rest2} ->
@@ -669,13 +669,17 @@ defmodule Lua.Parser do
   # Name | prefixexp '[' exp ']' | prefixexp '.' Name. Anything else
   # (number, string, function call, parenthesised expression) is a
   # syntax error.
-  defp validate_assign_targets(targets) do
+  # `assign_pos` is the position of the `=` operator, used as a fallback when
+  # the offending target node carries no position (e.g. an `Expr.Call` LHS,
+  # built with `meta: nil`) so the error still points at the right line rather
+  # than degrading to a nil position.
+  defp validate_assign_targets(targets, assign_pos) do
     Enum.reduce_while(targets, :ok, fn target, :ok ->
       case target do
         %Expr.Var{} -> {:cont, :ok}
         %Expr.Property{} -> {:cont, :ok}
         %Expr.Index{} -> {:cont, :ok}
-        other -> {:halt, {:error, {:invalid_assign_target, target_position(other), other.__struct__}}}
+        other -> {:halt, {:error, {:invalid_assign_target, target_position(other) || assign_pos, other.__struct__}}}
       end
     end)
   end
@@ -1238,11 +1242,20 @@ defmodule Lua.Parser do
   # A sub-parse "committed" if it consumed input before failing. We detect
   # this by comparing the error's byte offset against the offset of the
   # token the sub-parse started on: an error positioned strictly past the
-  # start means tokens were consumed. `:unexpected_end` (EOF) is always
-  # committed — running out of input mid-list is a real error, never a
-  # clean list terminator. A missing position falls back to "not
+  # start means tokens were consumed. A missing position falls back to "not
   # committed", preserving the previous recovery behaviour.
+  #
+  # Some error shapes are always committed regardless of their reported
+  # position: `:unexpected_end` (EOF) means we ran out of input mid-list,
+  # and `:bare_expression` / `:invalid_assign_target` are statement-level
+  # errors only reachable through a `function() ... end` body — i.e. only
+  # after a full prefix expression has been consumed. None of these can ever
+  # represent a clean list terminator, so they propagate even when their
+  # position is absent (e.g. an invalid-assign target on a `meta: nil`
+  # postfix node, whose `target_position/1` is `nil`).
   defp committed?({:unexpected_end, _message, _pos}, _tokens), do: true
+  defp committed?({:bare_expression, _pos, _expr_struct}, _tokens), do: true
+  defp committed?({:invalid_assign_target, _pos, _expr_struct}, _tokens), do: true
 
   defp committed?(reason, tokens) do
     with %{byte_offset: error_offset} <- error_position(reason),
@@ -1253,9 +1266,11 @@ defmodule Lua.Parser do
     end
   end
 
+  # `:unclosed_delimiter` stays position-based (via its opener): a delimiter
+  # that *begins* an argument has `open_pos == start_offset`, so the list
+  # still recovers at the outer boundary, while a delimiter opened mid-element
+  # propagates as the genuine deep error.
   defp error_position({:unexpected_token, _type, pos, _message}), do: pos
-  defp error_position({:bare_expression, pos, _expr_struct}), do: pos
-  defp error_position({:invalid_assign_target, pos, _expr_struct}), do: pos
   defp error_position({:unclosed_delimiter, _delimiter, open_pos}), do: open_pos
   defp error_position(_), do: nil
 

--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -1253,9 +1253,17 @@ defmodule Lua.Parser do
   # represent a clean list terminator, so they propagate even when their
   # position is absent (e.g. an invalid-assign target on a `meta: nil`
   # postfix node, whose `target_position/1` is `nil`).
+  #
+  # `:unclosed_delimiter` joins them: an opened-but-unclosed delimiter has by
+  # construction consumed an opener and its content, so it can never be a clean
+  # list terminator. Gating it on position would make blame depend on whether
+  # the opener happens to be the argument's first token (`open_pos ==
+  # start_offset`) — the begins-a-non-first-argument case — versus opened
+  # mid-element. Always committing it blames the inner opener uniformly.
   defp committed?({:unexpected_end, _message, _pos}, _tokens), do: true
   defp committed?({:bare_expression, _pos, _expr_struct}, _tokens), do: true
   defp committed?({:invalid_assign_target, _pos, _expr_struct}, _tokens), do: true
+  defp committed?({:unclosed_delimiter, _delimiter, _open_pos}, _tokens), do: true
 
   defp committed?(reason, tokens) do
     with %{byte_offset: error_offset} <- error_position(reason),
@@ -1266,12 +1274,7 @@ defmodule Lua.Parser do
     end
   end
 
-  # `:unclosed_delimiter` stays position-based (via its opener): a delimiter
-  # that *begins* an argument has `open_pos == start_offset`, so the list
-  # still recovers at the outer boundary, while a delimiter opened mid-element
-  # propagates as the genuine deep error.
   defp error_position({:unexpected_token, _type, pos, _message}), do: pos
-  defp error_position({:unclosed_delimiter, _delimiter, open_pos}), do: open_pos
   defp error_position(_), do: nil
 
   defp parse_expr_list_until(tokens, terminator, delimiter, open_pos) do

--- a/test/lua/parser/error_position_test.exs
+++ b/test/lua/parser/error_position_test.exs
@@ -112,7 +112,12 @@ defmodule Lua.Parser.ErrorPositionTest do
      "syntax error near '='"},
     # An unclosed delimiter opened inside a non-first argument propagates as
     # the genuine deep error rather than being swallowed at the outer boundary.
-    {"unclosed delimiter in non-first call argument", "outer(1, inner(\n", 1, 15, "Unclosed opening parenthesis"}
+    {"unclosed delimiter in non-first call argument", "outer(1, inner(\n", 1, 15, "Unclosed opening parenthesis"},
+    # An unclosed delimiter that *begins* a non-first argument is blamed at
+    # that opener too, matching the first-argument and mid-element cases —
+    # not at a misleading "Expected )" on the outer call boundary.
+    {"unclosed brace beginning a non-first call argument", "outer(1, {a = 1\n", 1, 10, "Unclosed opening brace"},
+    {"unclosed paren beginning a non-first call argument", "outer(1, (2 + 3\n", 1, 10, "Unclosed opening parenthesis"}
   ]
 
   @statement_errors [

--- a/test/lua/parser/error_position_test.exs
+++ b/test/lua/parser/error_position_test.exs
@@ -103,9 +103,16 @@ defmodule Lua.Parser.ErrorPositionTest do
     # A bare-expression error deep inside a function argument must blame the
     # inner statement, not the `function` keyword at the enclosing call's
     # opener. Regression for a stray `)` reported against the wrong line.
-    {"bare expression in nested function argument",
-     ~s|w:step("a", "b", function(output)\n  device.doesntExist)\nend)\n|, 2, 3,
-     "bare table-access expression"}
+    {"bare expression in nested function argument", ~s|w:step("a", "b", function(output)\n  device.doesntExist)\nend)\n|,
+     2, 3, "bare table-access expression"},
+    # An invalid assignment target deep inside a function argument must blame
+    # the inner statement even though the offending node (`f()`, an Expr.Call)
+    # carries no position — the error is structurally committed.
+    {"invalid assign target in nested function argument", ~s|outer("ok", function()\n  f() = 1\nend)\n|, 2, 7,
+     "syntax error near '='"},
+    # An unclosed delimiter opened inside a non-first argument propagates as
+    # the genuine deep error rather than being swallowed at the outer boundary.
+    {"unclosed delimiter in non-first call argument", "outer(1, inner(\n", 1, 15, "Unclosed opening parenthesis"}
   ]
 
   @statement_errors [

--- a/test/lua/parser/error_position_test.exs
+++ b/test/lua/parser/error_position_test.exs
@@ -99,7 +99,13 @@ defmodule Lua.Parser.ErrorPositionTest do
     {"bad token in function inside function inside call",
      "outer(function()\n  inner(function()\n    x = +\n  end)\nend)\n", 3, 9, "Expected expression"},
     {"deep error in a return list", "function f()\n  return 1, 2, g(\nend\n", 3, 1, "Expected expression"},
-    {"stray statement after nested calls", "outer(mid(inner(\n)))\n.. bad\n", 3, 1, "bare"}
+    {"stray statement after nested calls", "outer(mid(inner(\n)))\n.. bad\n", 3, 1, "bare"},
+    # A bare-expression error deep inside a function argument must blame the
+    # inner statement, not the `function` keyword at the enclosing call's
+    # opener. Regression for a stray `)` reported against the wrong line.
+    {"bare expression in nested function argument",
+     ~s|w:step("a", "b", function(output)\n  device.doesntExist)\nend)\n|, 2, 3,
+     "bare table-access expression"}
   ]
 
   @statement_errors [


### PR DESCRIPTION
## Problem

A parse error deep inside a function-call argument was reported at the **opening** line of the call, not where the mistake actually is. Given:

```lua
w:step("w.h42zel", "code", "My Code", { continueOnError = false }, function(output)
    local usercode = function()
      device.doesntExist)   -- line 3: the real error
    end
    return usercode()
end)
```

the parser emitted `Expected :delimiter::rparen, got :keyword::function` pinned at line 1 (the `w:step(` opener) instead of line 3.

## Root cause

In `parse_expr_list_acc/2`, when an argument sub-parse fails, `committed?/2` decides whether the failure is a real deep error to propagate or a clean signal that the argument list ended. Its fallback clause derives "committed" by comparing the error's byte offset against the start token via `error_position/1`, which only understands `:unexpected_token` errors:

```elixir
defp error_position({:unexpected_token, _type, pos, _message}), do: pos
defp error_position(_), do: nil
```

The actual failure is a `{:bare_expression, …}` error (`device.doesntExist` is a bare table access, not a valid statement). That shape returned `nil`, so the `committed?` fallback reported "not committed", the list "recovered" as if the arguments ended just before `function`, and `expect_closing` produced the misleading "Expected rparen" at the opener. This is exactly the failure mode the comment at `parse_expr_list_acc/2` warns about — it just never covered non-`:unexpected_token` shapes.

## Fix

Special-case the position-independent error shapes in `committed?/2` so they are *always* committed, rather than position-gating them through `error_position/1`:

```elixir
defp committed?({:unexpected_end, _message, _pos}, _tokens), do: true
defp committed?({:bare_expression, _pos, _expr_struct}, _tokens), do: true
defp committed?({:invalid_assign_target, _pos, _expr_struct}, _tokens), do: true
defp committed?({:unclosed_delimiter, _delimiter, _open_pos}, _tokens), do: true
```

These shapes can never represent a clean list terminator:

- `:bare_expression` / `:invalid_assign_target` are statement-level errors only reachable through a `function() … end` body — i.e. only after a full prefix expression has been consumed.
- `:unclosed_delimiter` has by construction consumed an opener and its content. Gating it on position would make blame depend on whether the opener happens to be the argument's first token versus opened mid-element; always committing it blames the inner opener uniformly.

Committing them unconditionally also sidesteps the missing-position problem: an invalid-assign target on a `meta: nil` postfix node (e.g. an `Expr.Call` LHS) has no `target_position/1`. To keep `convert_error/2` pointing at the right line, `validate_assign_targets/2` now takes the `=` operator position and uses it as a fallback:

```elixir
other -> {:halt, {:error, {:invalid_assign_target, target_position(other) || assign_pos, other.__struct__}}}
```

`committed?/2` now classifies these as committed and the genuine deep error propagates. The example above now reports:

```
at line 3, column 7:
A bare table-access expression isn't a Lua statement.
```

This is the inverse companion to #365 ("blame the opener"): don't let a shallow opener-blame swallow a genuine deep error.

## Tests

- New regression rows in the `@deep_propagation_errors` table in `test/lua/parser/error_position_test.exs`, covering each newly-committed shape (bare expression, invalid assign target with a position-less `Expr.Call` node, and unclosed delimiters both mid-element and beginning a non-first argument).
- Full suite green: `mix test` → 2475 passed, 7 skipped.
