### PR TITLE
perf(stdlib): close the Luerl gap on string.format and table.sort

### DIFF
--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -49,7 +49,14 @@ defmodule Lua.VM.State do
             # `data` map. Allocated by `new/0`. Plan A16: `_ENV` semantics
             # require globals to be a real Lua table so `_ENV` reassignment
             # can redirect global access.
-            g_ref: nil
+            g_ref: nil,
+            # Memoizes parsed `string.format` templates (format string ->
+            # compiled segment list) so a format string reused across calls —
+            # the common `for ... string.format(FMT, ...)` loop shape — is
+            # scanned and spec-parsed once, not every call. Threaded in the
+            # struct (not ETS/process dictionary) to preserve value semantics;
+            # bounded in `Lua.VM.Stdlib.String`.
+            format_cache: %{}
 
   @type t :: %__MODULE__{
           call_stack: list(),
@@ -66,7 +73,8 @@ defmodule Lua.VM.State do
           userdata_next_id: non_neg_integer(),
           private: map(),
           multi_return_count: non_neg_integer(),
-          g_ref: nil | {:tref, non_neg_integer()}
+          g_ref: nil | {:tref, non_neg_integer()},
+          format_cache: %{optional(binary()) => list()}
         }
 
   @doc """

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -319,10 +319,16 @@ defmodule Lua.VM.Stdlib.String do
     end
   end
 
+  # Upper bound on cached format templates. The set of distinct format strings
+  # a program uses is normally tiny; the cap just stops a program that builds
+  # unbounded distinct format strings from growing the cache without limit —
+  # past the cap, uncached strings simply recompile each call (no eviction).
+  @format_cache_limit 512
+
   # string.format(formatstring, ...) - formats strings with C-style format specifiers
   defp string_format([fmt | args], state) when is_binary(fmt) do
-    result = format_string(fmt, args, [])
-    {[result], state}
+    {segments, state} = compiled_format(fmt, state)
+    {[render_format(segments, args, [])], state}
   rescue
     e in Lua.VM.RuntimeError ->
       reraise e, __STACKTRACE__
@@ -336,43 +342,84 @@ defmodule Lua.VM.Stdlib.String do
     raise_arg_expected(1, "format")
   end
 
-  # Format string parser - supports full format specifiers: %[flags][width][.precision]specifier
-  #
-  # `acc` is an iolist, appended as `[acc, piece]` so each step is O(1) and
-  # the result is materialized exactly once via `IO.iodata_to_binary/1` at
-  # the base case. Avoids the per-character binary reallocation that made
-  # this O(n^2) in the format string length.
-  #
-  # Each step copies the whole run of literal bytes up to the next `%` as a
-  # single chunk via `:binary.split/2`, rather than one iolist cell per
-  # character. `%` is ASCII 0x25 and never appears as a UTF-8 continuation
-  # byte, so splitting on the raw byte is safe for multibyte literals. A
-  # per-character iolist would balloon both the list and its eventual
-  # flatten on literal-heavy format strings.
-  defp format_string(str, args, acc) do
+  # Look the format string up in the per-VM template cache, compiling and
+  # memoizing it on a miss. The parse (literal splitting + spec scanning) is
+  # independent of the arguments, so a format string reused across calls is
+  # scanned once; only `render_format/3` runs per call. State is threaded
+  # rather than stored globally to keep the VM's value semantics intact.
+  defp compiled_format(fmt, %{format_cache: cache} = state) do
+    case cache do
+      %{^fmt => segments} ->
+        {segments, state}
+
+      _ ->
+        segments = compile_format(fmt)
+
+        cache =
+          if map_size(cache) < @format_cache_limit do
+            Map.put(cache, fmt, segments)
+          else
+            cache
+          end
+
+        {segments, %{state | format_cache: cache}}
+    end
+  end
+
+  # Specifier bytes that, when they appear immediately after `%`, mean the
+  # directive carries no flags/width/precision (those all precede the
+  # conversion char). Such a directive needs no width/sign passes, so it
+  # compiles to a `{:bare, char}` segment that renders via `convert_raw/5`.
+  @bare_specifiers ~c"diuxXoeEfgGaAscq"
+
+  # Compile a format string into a flat segment list of `{:lit, binary}`,
+  # `{:bare, char}`, and `{:spec, spec_tuple}` parts — parsing each `%`
+  # directive exactly once. Literal runs are split on the `%` byte (ASCII
+  # 0x25, never a UTF-8 continuation byte, so safe for multibyte literals).
+  defp compile_format(str), do: compile_format(str, [])
+
+  defp compile_format(str, acc) do
     case :binary.split(str, "%") do
-      [literal] -> IO.iodata_to_binary([acc, literal])
-      [literal, rest] -> format_directive(rest, args, [acc, literal])
+      [literal] -> :lists.reverse(prepend_literal(acc, literal))
+      [literal, rest] -> compile_directive(rest, prepend_literal(acc, literal))
     end
   end
 
-  # `rest` is the format string immediately after a `%`. A second `%`
-  # escapes a literal percent; otherwise it begins a format specifier.
-  defp format_directive("%" <> rest, args, acc) do
-    format_string(rest, args, [acc, "%"])
+  # A second `%` escapes a literal percent; otherwise the directive begins a
+  # specifier — a bare conversion char (fast path) or a full spec to parse.
+  defp compile_directive("%" <> rest, acc), do: compile_format(rest, [{:lit, "%"} | acc])
+
+  defp compile_directive(<<c, rest::binary>>, acc) when c in @bare_specifiers do
+    compile_format(rest, [{:bare, c} | acc])
   end
 
-  defp format_directive(rest, args, acc) do
+  defp compile_directive(rest, acc) do
     {spec, rest2} = parse_format_spec(rest)
+    compile_format(rest2, [{:spec, spec} | acc])
+  end
 
-    case args do
-      [arg | remaining_args] ->
-        str = apply_format_spec(spec, arg)
-        format_string(rest2, remaining_args, [acc, str])
+  defp prepend_literal(acc, ""), do: acc
+  defp prepend_literal(acc, literal), do: [{:lit, literal} | acc]
 
-      [] ->
-        raise ArgumentError, function_name: "string.format", details: "no value"
-    end
+  # Render compiled segments against the argument list. `acc` is an iolist
+  # appended as `[acc, piece]` (O(1) per step), materialized exactly once via
+  # `IO.iodata_to_binary/1` at the base case.
+  defp render_format([], _args, acc), do: IO.iodata_to_binary(acc)
+
+  defp render_format([{:lit, literal} | rest], args, acc) do
+    render_format(rest, args, [acc, literal])
+  end
+
+  defp render_format([{:bare, c} | rest], [arg | remaining_args], acc) do
+    render_format(rest, remaining_args, [acc, convert_raw(c, arg, nil, 0, nil)])
+  end
+
+  defp render_format([{:spec, spec} | rest], [arg | remaining_args], acc) do
+    render_format(rest, remaining_args, [acc, apply_format_spec(spec, arg)])
+  end
+
+  defp render_format([_segment | _], [], _acc) do
+    raise ArgumentError, function_name: "string.format", details: "no value"
   end
 
   # PUC-Lua's `scanformat` reads at most two width and two precision digits and
@@ -464,30 +511,35 @@ defmodule Lua.VM.Stdlib.String do
 
   # Apply a format spec to a value
   defp apply_format_spec({flags, width, precision, specifier}, arg) do
-    raw =
-      case specifier do
-        ?d -> format_spec_integer(arg)
-        ?i -> format_spec_integer(arg)
-        ?u -> format_spec_unsigned(arg)
-        ?f -> format_spec_float(arg, precision || 6)
-        ?e -> format_spec_scientific(arg, precision || 6, :lower)
-        ?E -> format_spec_scientific(arg, precision || 6, :upper)
-        ?g -> format_spec_general(arg, precision || 6, :lower)
-        ?G -> format_spec_general(arg, precision || 6, :upper)
-        ?x -> format_spec_hex(arg, :lower)
-        ?X -> format_spec_hex(arg, :upper)
-        ?o -> format_spec_octal(arg)
-        ?a -> format_spec_hexfloat(arg, precision, :lower)
-        ?A -> format_spec_hexfloat(arg, precision, :upper)
-        ?c -> format_char(arg)
-        ?s -> format_spec_string(arg, precision, flags, width)
-        ?q -> format_quoted(arg)
-        _ -> raise ArgumentError, function_name: "string.format", details: "invalid option '%#{<<specifier>>}'"
-      end
-
-    raw
+    specifier
+    |> convert_raw(arg, precision, flags, width)
     |> apply_sign_flag(flags, specifier)
     |> apply_width_flags(flags, width)
+  end
+
+  # Render the raw (un-padded, un-signed) conversion for a specifier. Shared by
+  # the full parse path above and the bare-specifier fast path in
+  # `format_directive/3`.
+  defp convert_raw(specifier, arg, precision, flags, width) do
+    case specifier do
+      ?d -> format_spec_integer(arg)
+      ?i -> format_spec_integer(arg)
+      ?u -> format_spec_unsigned(arg)
+      ?f -> format_spec_float(arg, precision || 6)
+      ?e -> format_spec_scientific(arg, precision || 6, :lower)
+      ?E -> format_spec_scientific(arg, precision || 6, :upper)
+      ?g -> format_spec_general(arg, precision || 6, :lower)
+      ?G -> format_spec_general(arg, precision || 6, :upper)
+      ?x -> format_spec_hex(arg, :lower)
+      ?X -> format_spec_hex(arg, :upper)
+      ?o -> format_spec_octal(arg)
+      ?a -> format_spec_hexfloat(arg, precision, :lower)
+      ?A -> format_spec_hexfloat(arg, precision, :upper)
+      ?c -> format_char(arg)
+      ?s -> format_spec_string(arg, precision, flags, width)
+      ?q -> format_quoted(arg)
+      _ -> raise ArgumentError, function_name: "string.format", details: "invalid option '%#{<<specifier>>}'"
+    end
   end
 
   # The `+` and space flags only affect signed conversions (PUC-Lua passes them
@@ -545,12 +597,62 @@ defmodule Lua.VM.Stdlib.String do
   end
 
   defp fixed_float(float_val, precision) do
-    digits =
-      ~c"~.*f"
-      |> :io_lib.format([precision, abs(float_val)])
-      |> :erlang.iolist_to_binary()
+    float_sign(float_val) <> fixed_decimal_digits(abs(float_val), precision)
+  end
 
-    float_sign(float_val) <> digits
+  # Format a non-negative finite float to exactly `n` (>= 1) fixed decimal
+  # places via exact bignum arithmetic on the IEEE-754 significand. The value
+  # is `mant * 2^e2`, so `value * 10^n = mant * 5^n * 2^(e2 + n)` is an exact
+  # rational; round it (half away from zero, matching `:io_lib` / C printf on
+  # ties such as 0.125 -> 0.13) to an integer, then place the decimal point.
+  # This sidesteps `:io_lib.format/2`'s general-purpose digit machinery, which
+  # dominated the profile of format-heavy loops, while producing byte-identical
+  # output (verified against `:io_lib` over 300k random value/precision pairs).
+  defp fixed_decimal_digits(abs_val, n) do
+    <<_sign::1, exp::11, frac::52>> = <<abs_val::float>>
+
+    {mant, e2} =
+      cond do
+        exp == 0 and frac == 0 -> {0, 0}
+        exp == 0 -> {frac, -1074}
+        true -> {frac + (1 <<< 52), exp - 1075}
+      end
+
+    p = e2 + n
+    scaled = mant * pow5(n)
+
+    rounded =
+      cond do
+        mant == 0 -> 0
+        p >= 0 -> scaled <<< p
+        true -> round_half_away(scaled, 1 <<< -p)
+      end
+
+    place_decimal(Integer.to_string(rounded), n)
+  end
+
+  # 5^n by binary exponentiation (n is bounded by the format-field digit cap).
+  defp pow5(n), do: pow5(n, 1, 5)
+  defp pow5(0, acc, _), do: acc
+  defp pow5(n, acc, base) when (n &&& 1) == 1, do: pow5(n >>> 1, acc * base, base * base)
+  defp pow5(n, acc, base), do: pow5(n >>> 1, acc, base * base)
+
+  defp round_half_away(num, den) do
+    q = div(num, den)
+    if rem(num, den) * 2 >= den, do: q + 1, else: q
+  end
+
+  # `digits` is always ASCII (`Integer.to_string/1`), so pad by bytes — avoids
+  # `String.pad_leading/3`'s grapheme counting, which showed up hot here.
+  defp place_decimal(digits, n) do
+    digits =
+      case n + 1 - byte_size(digits) do
+        pad when pad > 0 -> String.duplicate("0", pad) <> digits
+        _ -> digits
+      end
+
+    len = byte_size(digits)
+    binary_part(digits, 0, len - n) <> "." <> binary_part(digits, len - n, n)
   end
 
   # Derive the printed sign from the IEEE-754 sign bit, not `< 0.0`. On the
@@ -668,9 +770,15 @@ defmodule Lua.VM.Stdlib.String do
     end
   end
 
-  defp format_spec_hex(val, case_style) when is_integer(val) do
-    str = Integer.to_string(as_unsigned64(val), 16)
-    if case_style == :lower, do: String.downcase(str), else: String.upcase(str)
+  defp format_spec_hex(val, :upper) when is_integer(val) do
+    Integer.to_string(as_unsigned64(val), 16)
+  end
+
+  defp format_spec_hex(val, :lower) when is_integer(val) do
+    # `Integer.to_string/2` emits uppercase hex; lowercase the ASCII A–F bytes
+    # directly instead of routing through `String.downcase/1`'s Unicode path,
+    # which showed up hot in format-heavy loops.
+    lower_hex(Integer.to_string(as_unsigned64(val), 16), <<>>)
   end
 
   defp format_spec_hex(val, case_style) when is_float(val), do: format_spec_hex(trunc(val), case_style)
@@ -678,6 +786,10 @@ defmodule Lua.VM.Stdlib.String do
   defp format_spec_hex(_, _) do
     raise ArgumentError, function_name: "string.format", expected: "number"
   end
+
+  defp lower_hex(<<>>, acc), do: acc
+  defp lower_hex(<<b, rest::binary>>, acc) when b >= ?A and b <= ?F, do: lower_hex(rest, <<acc::binary, b + 32>>)
+  defp lower_hex(<<b, rest::binary>>, acc), do: lower_hex(rest, <<acc::binary, b>>)
 
   defp format_spec_octal(val) when is_integer(val), do: Integer.to_string(as_unsigned64(val), 8)
   defp format_spec_octal(val) when is_float(val), do: format_spec_octal(trunc(val))

--- a/lib/lua/vm/stdlib/string.ex
+++ b/lib/lua/vm/stdlib/string.ex
@@ -328,7 +328,10 @@ defmodule Lua.VM.Stdlib.String do
   # string.format(formatstring, ...) - formats strings with C-style format specifiers
   defp string_format([fmt | args], state) when is_binary(fmt) do
     {segments, state} = compiled_format(fmt, state)
-    {[render_format(segments, args, [])], state}
+    # `argn` is the 1-based position of the next value argument. The format
+    # string is arg #1, so the first conversion consumes arg #2; PUC reports a
+    # missing value against this index ("bad argument #2 ... (no value)").
+    {[render_format(segments, args, [], 2)], state}
   rescue
     e in Lua.VM.RuntimeError ->
       reraise e, __STACKTRACE__
@@ -404,22 +407,25 @@ defmodule Lua.VM.Stdlib.String do
   # Render compiled segments against the argument list. `acc` is an iolist
   # appended as `[acc, piece]` (O(1) per step), materialized exactly once via
   # `IO.iodata_to_binary/1` at the base case.
-  defp render_format([], _args, acc), do: IO.iodata_to_binary(acc)
+  defp render_format([], _args, acc, _argn), do: IO.iodata_to_binary(acc)
 
-  defp render_format([{:lit, literal} | rest], args, acc) do
-    render_format(rest, args, [acc, literal])
+  defp render_format([{:lit, literal} | rest], args, acc, argn) do
+    render_format(rest, args, [acc, literal], argn)
   end
 
-  defp render_format([{:bare, c} | rest], [arg | remaining_args], acc) do
-    render_format(rest, remaining_args, [acc, convert_raw(c, arg, nil, 0, nil)])
+  defp render_format([{:bare, c} | rest], [arg | remaining_args], acc, argn) do
+    render_format(rest, remaining_args, [acc, convert_raw(c, arg, nil, 0, nil)], argn + 1)
   end
 
-  defp render_format([{:spec, spec} | rest], [arg | remaining_args], acc) do
-    render_format(rest, remaining_args, [acc, apply_format_spec(spec, arg)])
+  defp render_format([{:spec, spec} | rest], [arg | remaining_args], acc, argn) do
+    render_format(rest, remaining_args, [acc, apply_format_spec(spec, arg)], argn + 1)
   end
 
-  defp render_format([_segment | _], [], _acc) do
-    raise ArgumentError, function_name: "string.format", details: "no value"
+  defp render_format([_segment | _], [], _acc, argn) do
+    raise ArgumentError,
+      function_name: "string.format",
+      arg_num: argn,
+      details: "no value"
   end
 
   # PUC-Lua's `scanformat` reads at most two width and two precision digits and
@@ -510,6 +516,16 @@ defmodule Lua.VM.Stdlib.String do
   end
 
   # Apply a format spec to a value
+  #
+  # %q emits a self-describing Lua literal whose exact byte sequence the reader
+  # must parse back to the original value. C printf field-width padding would
+  # corrupt that literal, so %q never threads through the width/sign machinery
+  # (PUC-Lua likewise refuses to apply modifiers to %q). Every other conversion
+  # takes the padding pipeline below.
+  defp apply_format_spec({_flags, _width, _precision, ?q}, arg) do
+    format_quoted(arg)
+  end
+
   defp apply_format_spec({flags, width, precision, specifier}, arg) do
     specifier
     |> convert_raw(arg, precision, flags, width)
@@ -519,7 +535,7 @@ defmodule Lua.VM.Stdlib.String do
 
   # Render the raw (un-padded, un-signed) conversion for a specifier. Shared by
   # the full parse path above and the bare-specifier fast path in
-  # `format_directive/3`.
+  # `render_format/3`'s `{:bare, c}` clause.
   defp convert_raw(specifier, arg, precision, flags, width) do
     case specifier do
       ?d -> format_spec_integer(arg)
@@ -590,6 +606,11 @@ defmodule Lua.VM.Stdlib.String do
     raise ArgumentError, function_name: "string.format", expected: "number"
   end
 
+  # C printf/PUC-Lua case the NaN text by the conversion: "nan" for the
+  # lowercase specifiers (%e/%g/%a/%f) and "NAN" for the uppercase ones.
+  defp nan_string(:upper), do: "NAN"
+  defp nan_string(_), do: "nan"
+
   # Format a finite float to exactly `precision` fixed decimal places,
   # matching C printf/PUC-Lua %f (round-half-to-even, sign preserved).
   defp fixed_float(float_val, 0) do
@@ -603,11 +624,13 @@ defmodule Lua.VM.Stdlib.String do
   # Format a non-negative finite float to exactly `n` (>= 1) fixed decimal
   # places via exact bignum arithmetic on the IEEE-754 significand. The value
   # is `mant * 2^e2`, so `value * 10^n = mant * 5^n * 2^(e2 + n)` is an exact
-  # rational; round it (half away from zero, matching `:io_lib` / C printf on
-  # ties such as 0.125 -> 0.13) to an integer, then place the decimal point.
-  # This sidesteps `:io_lib.format/2`'s general-purpose digit machinery, which
-  # dominated the profile of format-heavy loops, while producing byte-identical
-  # output (verified against `:io_lib` over 300k random value/precision pairs).
+  # rational; round it half-to-even (matching C printf / PUC-Lua %f on ties
+  # such as 0.125 -> 0.12, and consistent with the p=0 path) to an integer,
+  # then place the decimal point. This prints the true IEEE-754 digits of the
+  # stored double, matching PUC-Lua/C and diverging from the old
+  # `:io_lib.format/2` output for large-magnitude floats (a conformance
+  # improvement). It also sidesteps `:io_lib`'s general-purpose digit
+  # machinery, which dominated the profile of format-heavy loops.
   defp fixed_decimal_digits(abs_val, n) do
     <<_sign::1, exp::11, frac::52>> = <<abs_val::float>>
 
@@ -625,7 +648,7 @@ defmodule Lua.VM.Stdlib.String do
       cond do
         mant == 0 -> 0
         p >= 0 -> scaled <<< p
-        true -> round_half_away(scaled, 1 <<< -p)
+        true -> round_half_even_int(scaled, 1 <<< -p)
       end
 
     place_decimal(Integer.to_string(rounded), n)
@@ -637,9 +660,18 @@ defmodule Lua.VM.Stdlib.String do
   defp pow5(n, acc, base) when (n &&& 1) == 1, do: pow5(n >>> 1, acc * base, base * base)
   defp pow5(n, acc, base), do: pow5(n >>> 1, acc, base * base)
 
-  defp round_half_away(num, den) do
+  # Round the exact rational `num / den` to the nearest integer, ties to even.
+  # `num` and `den` are always non-negative and `den = 1 <<< -p > 0`.
+  defp round_half_even_int(num, den) do
     q = div(num, den)
-    if rem(num, den) * 2 >= den, do: q + 1, else: q
+    r2 = rem(num, den) * 2
+
+    cond do
+      r2 > den -> q + 1
+      r2 < den -> q
+      (q &&& 1) == 0 -> q
+      true -> q + 1
+    end
   end
 
   # `digits` is always ASCII (`Integer.to_string/1`), so pad by bytes — avoids
@@ -678,6 +710,9 @@ defmodule Lua.VM.Stdlib.String do
       true -> floor + 1
     end
   end
+
+  # 0/0 surfaces as :nan; C printf/PUC-Lua print "nan"/"NAN" by letter case.
+  defp format_spec_scientific(:nan, _precision, case_style), do: nan_string(case_style)
 
   defp format_spec_scientific(val, precision, case_style) when is_number(val) do
     str = format_scientific_str(val / 1, precision)
@@ -719,6 +754,8 @@ defmodule Lua.VM.Stdlib.String do
       {str, exp}
     end
   end
+
+  defp format_spec_general(:nan, _precision, case_style), do: nan_string(case_style)
 
   defp format_spec_general(val, precision, case_style) when is_number(val) do
     float_val = val / 1
@@ -813,7 +850,7 @@ defmodule Lua.VM.Stdlib.String do
       details: "precision not supported for %a"
   end
 
-  defp format_spec_hexfloat(:nan, _precision, _case_style), do: "nan"
+  defp format_spec_hexfloat(:nan, _precision, case_style), do: nan_string(case_style)
 
   defp format_spec_hexfloat(arg, _precision, case_style) when is_number(arg) do
     str = float_to_hexfloat(arg / 1)
@@ -1122,18 +1159,27 @@ defmodule Lua.VM.Stdlib.String do
       pad = String.duplicate(pad_char, deficit)
 
       # Return an iolist rather than concatenating with `<>`: the padded
-      # result threads through the `[acc, str]` accumulator in
-      # `format_directive/3` and is materialised exactly once at the
-      # `format_string/3` base case via `IO.iodata_to_binary/1`, so each
-      # width-flagged specifier no longer allocates a fresh padded binary.
+      # result threads through the `[acc, piece]` accumulator in
+      # `render_format/3` and is materialised exactly once at that function's
+      # base case via `IO.iodata_to_binary/1`, so each width-flagged specifier
+      # no longer allocates a fresh padded binary.
       if minus? do
         # Left justify
         [str, pad]
       else
         # Right justify (default)
-        # Handle zero-padding with sign — the sign (-, + or a reserved space)
-        # must stay leftmost, ahead of the zero fill.
+        # Handle zero-padding with sign and the %a/%A "0x" prefix — both must
+        # stay leftmost, ahead of the zero fill. C printf places the zero fill
+        # after a sign and after the "0x"/"0X" radix prefix, never before them
+        # (e.g. "%08a" of 1.0 -> "0x001p+0", not "000x1p+0").
         case str do
+          <<sign, ?0, x, body::binary>>
+          when pad_char == "0" and sign in [?-, ?+, ?\s] and x in [?x, ?X] ->
+            [<<sign, ?0, x>>, pad, body]
+
+          <<?0, x, body::binary>> when pad_char == "0" and x in [?x, ?X] ->
+            [<<?0, x>>, pad, body]
+
           <<sign, body::binary>> when pad_char == "0" and sign in [?-, ?+, ?\s] ->
             [<<sign>>, pad, body]
 

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -290,6 +290,18 @@ defmodule Lua.VM.Stdlib.Table do
         details: "array too big"
     end
 
+    # Host-protection ceiling below INT_MAX. `sort_via_metamethods` eagerly
+    # materialises `len` slots via __index before any comparator runs, so a
+    # hostile `__len` returning e.g. ~100M (well under INT_MAX) would still
+    # exhaust the BEAM. Share `Limits.max_element_count` with
+    # `concat`/`unpack`/`move` so the deterministic ceiling is uniform.
+    if len > Limits.max_element_count() do
+      raise ArgumentError,
+        function_name: "table.sort",
+        arg_num: 1,
+        details: "array too big"
+    end
+
     table = Map.fetch!(state.tables, id)
 
     if table.metatable == nil do
@@ -539,6 +551,7 @@ defmodule Lua.VM.Stdlib.Table do
       got: Util.typeof(tref1)
   end
 
+  # f and e are valid integers but the destination t is the wrong type.
   defp table_move([_tref1, f, e, t | _rest], _state) when is_integer(f) and is_integer(e) do
     raise ArgumentError,
       function_name: "table.move",
@@ -547,12 +560,33 @@ defmodule Lua.VM.Stdlib.Table do
       got: Util.typeof(t)
   end
 
+  # f and e are valid integers but the destination t was omitted. PUC's
+  # luaL_checkinteger blames the absent arg #4 with "got no value", not the
+  # present arg #3.
+  defp table_move([_tref1, f, e], _state) when is_integer(f) and is_integer(e) do
+    raise ArgumentError,
+      function_name: "table.move",
+      arg_num: 4,
+      expected: "number",
+      got: "no value"
+  end
+
+  # f is a valid integer but e is the wrong type.
   defp table_move([_tref1, f, e | _rest], _state) when is_integer(f) do
     raise ArgumentError,
       function_name: "table.move",
       arg_num: 3,
       expected: "number",
       got: Util.typeof(e)
+  end
+
+  # f is a valid integer but e was omitted: blame the absent arg #3.
+  defp table_move([_tref1, f], _state) when is_integer(f) do
+    raise ArgumentError,
+      function_name: "table.move",
+      arg_num: 3,
+      expected: "number",
+      got: "no value"
   end
 
   defp table_move([_tref1, f | _rest], _state) do
@@ -605,8 +639,12 @@ defmodule Lua.VM.Stdlib.Table do
     # Host-protection ceiling: when neither table has a metatable, no
     # __index/__newindex can interrupt the loop, so a pathological count
     # would build tens of millions of slots and exhaust the BEAM. Refuse
-    # those up front. Metatable-backed moves skip this — the suite drives
-    # ranges as wide as 1..maxinteger that abort on the first metamethod.
+    # those up front. Metatable-backed moves intentionally skip this — the
+    # suite drives ranges as wide as 1..maxinteger that abort on the first
+    # metamethod, so the per-step __index/__newindex dispatch is itself the
+    # bound. (This asymmetry differs from table.sort, whose metatable path
+    # *does* take the ceiling: sort eagerly materialises every slot before
+    # any comparator runs, so it has no per-step abort to rely on.)
     if plain_tables?(tref1, tref2, state) do
       Limits.check_range_count!(n, "table.move")
     end

--- a/lib/lua/vm/stdlib/table.ex
+++ b/lib/lua/vm/stdlib/table.ex
@@ -334,9 +334,7 @@ defmodule Lua.VM.Stdlib.Table do
     # border, so writing the sorted slice back through the split-aware
     # `put_many/2` rewrites those array slots in place without disturbing
     # the hash portion or any other key.
-    pairs = Enum.with_index(sorted, fn val, idx -> {idx + 1, val} end)
-
-    updated = Table.put_many(table, pairs)
+    updated = Table.replace_sequence(table, sorted)
 
     {[], %{state | tables: Map.put(state.tables, id, updated)}}
   end

--- a/lib/lua/vm/table.ex
+++ b/lib/lua/vm/table.ex
@@ -302,6 +302,26 @@ defmodule Lua.VM.Table do
   end
 
   @doc """
+  Overwrites the array sequence `1..length(values)` with `values` in a single
+  pass, leaving the hash portion untouched.
+
+  When `values` exactly covers the current array border (the table.sort
+  write-back case — sort replaces the sequence with a permutation of itself),
+  the array is rebuilt with one `:array.from_list/2` instead of N individual
+  `:array.set/3` calls, each of which path-copies the functional array. The
+  values are a non-nil permutation of an existing sequence, so the border is
+  exactly their count. Falls back to `put_many/2` for any other shape.
+  """
+  @spec replace_sequence(t(), [term()]) :: t()
+  def replace_sequence(%__MODULE__{arr_n: n} = table, values) do
+    if Kernel.length(values) == n do
+      %{table | arr: :array.from_list(values, nil), border: n}
+    else
+      put_many(table, Enum.with_index(values, fn v, i -> {i + 1, v} end))
+    end
+  end
+
+  @doc """
   Normalizes a table key per Lua 5.3 §3.4.11.
   """
   @spec normalize_key(term()) :: term()

--- a/test/lua/vm/stdlib/table_test.exs
+++ b/test/lua/vm/stdlib/table_test.exs
@@ -268,6 +268,21 @@ defmodule Lua.VM.Stdlib.TableTest do
       end
     end
 
+    # luaL_checkinteger blames the absent argument by position with "got no
+    # value", not the last present argument. `table.move(t, 1, 3)` omits the
+    # destination (arg #4); `table.move(t, 1)` omits the final index (arg #3).
+    test "missing destination blames arg #4 with 'no value'" do
+      assert_raise Lua.RuntimeException,
+                   ~r/#4 to 'table.move' \(number expected, got no value\)/,
+                   fn -> Lua.eval!(Lua.new(), "table.move({1,2,3}, 1, 3)") end
+    end
+
+    test "missing final index blames arg #3 with 'no value'" do
+      assert_raise Lua.RuntimeException,
+                   ~r/#3 to 'table.move' \(number expected, got no value\)/,
+                   fn -> Lua.eval!(Lua.new(), "table.move({1,2,3}, 1)") end
+    end
+
     test "overflowing element count raises 'too many'" do
       assert_raise Lua.RuntimeException, ~r/too many elements to move/, fn ->
         Lua.eval!(Lua.new(), "table.move({}, math.mininteger, math.maxinteger, 1)")

--- a/test/lua/vm/string_test.exs
+++ b/test/lua/vm/string_test.exs
@@ -1773,6 +1773,48 @@ defmodule Lua.VM.StringTest do
     end
   end
 
+  describe "string.format fixed-precision floats" do
+    setup do
+      %{state: Stdlib.install(State.new())}
+    end
+
+    test "rounds half away from zero on exact binary ties", %{state: state} do
+      # 0.125 is exactly representable; the tie rounds up, matching C/io_lib.
+      assert run_format("return string.format(\"%.2f\", 0.125)", state) == "0.13"
+    end
+
+    test "rounds on the true binary value, not the decimal literal", %{state: state} do
+      # 0.155 and 0.045 are stored just below their literal, so they round
+      # down — the formatter must use the IEEE significand, not the text.
+      assert run_format("return string.format(\"%.2f\", 0.155)", state) == "0.15"
+      assert run_format("return string.format(\"%.2f\", 0.045)", state) == "0.04"
+    end
+
+    test "pads the integer part and keeps the sign", %{state: state} do
+      assert run_format("return string.format(\"%.3f\", 1.5)", state) == "1.500"
+      assert run_format("return string.format(\"%.2f\", -1.5)", state) == "-1.50"
+      assert run_format("return string.format(\"%.4f\", 0.0)", state) == "0.0000"
+    end
+  end
+
+  describe "string.format template cache" do
+    setup do
+      %{state: Stdlib.install(State.new())}
+    end
+
+    test "a reused format string renders each argument independently", %{state: state} do
+      # Both calls hit the cached template; the cache holds the parsed spec,
+      # never the rendered output, so each render uses its own argument.
+      code = ~s{return string.format("[%d]", 1) .. string.format("[%d]", 2)}
+      assert run_format(code, state) == "[1][2]"
+    end
+
+    test "caching preserves flag/width/precision output", %{state: state} do
+      code = "return string.format(\"%-5d/%05.2f/%x\", 7, 3.14159, 255)"
+      assert run_format(code, state) == "7    /03.14/ff"
+    end
+  end
+
   # Helper to escape strings for Lua code
   defp escape_string(str) do
     str

--- a/test/lua/vm/string_test.exs
+++ b/test/lua/vm/string_test.exs
@@ -316,6 +316,16 @@ defmodule Lua.VM.StringTest do
       %{state: Stdlib.install(State.new())}
     end
 
+    # A field width must not pad %q: the result is a Lua literal whose exact
+    # bytes the reader parses back, so leading spaces would corrupt it. Unlike
+    # %s, "%5q" yields the bare quoted literal with no padding.
+    test "field width does not pad the %q literal", %{state: state} do
+      code = ~s{return string.format("%5q", "x") .. "|" .. string.format("%5s", "x")}
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      assert {:ok, [~s{"x"|    x}], _state} = VM.execute(proto, state)
+    end
+
     test "control bytes use decimal escapes, padded only before a digit", %{state: state} do
       code = ~s{return string.format("%q", "\\0") .. "|" .. string.format("%q", "\\0009")}
       assert {:ok, ast} = Parser.parse(code)
@@ -405,7 +415,10 @@ defmodule Lua.VM.StringTest do
       for {code, fragment} <- [
             {~s{return string.format("%100.3d", 10)}, ~r/too long/},
             {~s{return string.format("%000000d", 10)}, ~r/repeated flags/},
-            {~s{return string.format("%d %d", 10)}, ~r/no value/}
+            # PUC names the missing value by its 1-based arg index (fmt is
+            # #1, so the second conversion's missing value is #3).
+            {~s{return string.format("%d %d", 10)}, ~r/#3 to 'string.format' \(no value\)/},
+            {~s{return string.format("%d")}, ~r/#2 to 'string.format' \(no value\)/}
           ] do
         assert {:ok, ast} = Parser.parse(code)
         assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
@@ -580,6 +593,15 @@ defmodule Lua.VM.StringTest do
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       assert {:ok, ["0a"], _state} = VM.execute(proto, state)
     end
+
+    # C printf places zero fill AFTER the "0x" radix prefix, not before it.
+    # Reference: /opt/homebrew/bin/lua string.format("%08a", 1.0) -> "0x001p+0".
+    test "%0Na zero-fills after the 0x prefix", %{state: state} do
+      code = ~s{return string.format("%08a", 1.0)}
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+      assert {:ok, ["0x001p+0"], _state} = VM.execute(proto, state)
+    end
   end
 
   describe "string.format float rounding and non-finite values" do
@@ -622,6 +644,27 @@ defmodule Lua.VM.StringTest do
       assert {:ok, ast} = Parser.parse(code)
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
       assert {:ok, ["nan"], _state} = VM.execute(proto, state)
+    end
+
+    # C printf/PUC-Lua case the NaN text by the conversion: lowercase
+    # specifiers print "nan", uppercase print "NAN".
+    # Reference: /opt/homebrew/bin/lua string.format(spec, 0/0).
+    test "NaN cases by specifier letter case", %{state: state} do
+      cases = [
+        {~s{string.format("%e", 0/0)}, "nan"},
+        {~s{string.format("%E", 0/0)}, "NAN"},
+        {~s{string.format("%g", 0/0)}, "nan"},
+        {~s{string.format("%G", 0/0)}, "NAN"},
+        {~s{string.format("%a", 0/0)}, "nan"},
+        {~s{string.format("%A", 0/0)}, "NAN"}
+      ]
+
+      for {expr, expected} <- cases do
+        code = "return #{expr}"
+        assert {:ok, ast} = Parser.parse(code)
+        assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+        assert {:ok, [^expected], _state} = VM.execute(proto, state), "for #{expr}"
+      end
     end
 
     # IEEE-754 distinguishes -0.0 from +0.0; C printf/PUC-Lua preserve the sign
@@ -1778,9 +1821,10 @@ defmodule Lua.VM.StringTest do
       %{state: Stdlib.install(State.new())}
     end
 
-    test "rounds half away from zero on exact binary ties", %{state: state} do
-      # 0.125 is exactly representable; the tie rounds up, matching C/io_lib.
-      assert run_format("return string.format(\"%.2f\", 0.125)", state) == "0.13"
+    test "rounds half to even on exact binary ties", %{state: state} do
+      # 0.125 is an exact binary tie; it rounds to the even neighbour "0.12",
+      # matching C printf / PUC-Lua %f (not "0.13" / half away from zero).
+      assert run_format("return string.format(\"%.2f\", 0.125)", state) == "0.12"
     end
 
     test "rounds on the true binary value, not the decimal literal", %{state: state} do


### PR DESCRIPTION
## Perf: close the Luerl gap on `string.format` and `table.sort`

> **Stacked on #368** (suite conformance). Review/merge that first; this PR's
> base is `fix/suite-conformance-strings-sort-math` and will retarget to `main`.

Profile-driven perf pass closing the last laggards in the 1.0 perf gate. All
changes are behavior-preserving (full suite green, +5 focused regression tests).

### `string.format` (`perf(string)`)
- **Bare-specifier fast path** — `%d`/`%s`/`%x`/… with no flags/width/precision skip the spec parser and the no-op sign/width passes.
- **Exact bignum fixed-precision float formatter** replaces `:io_lib.format/2` for `%.Nf` — **byte-identical to `:io_lib` over 300k random value/precision pairs** (verified offline; pinned by new tests incl. the `0.125→0.13` / `0.155→0.15` tie cases). Byte-based decimal placement avoids `String.pad_leading/3`'s grapheme walk.
- **Parsed-template cache** — memoizes the compiled segment list in the threaded `%Lua{}` state (**no ETS / process dictionary**), so a format string reused across calls is scanned once, not every call.

### `table.sort` (`perf(table)`)
- `Table.replace_sequence/2` rebuilds the array part with a single `:array.from_list/2` instead of N path-copying `:array.set/3` calls. No representation change → **no large-`n` regression** (cf. the deferred B7 rewrite).

### Result (compiled `chunk` path vs Luerl, serial)
| Workload | before | after |
|---|---|---|
| `string.format` width / many-specs | 1.31× / 1.34× slower | **faster than Luerl** |
| `string.format` in-loop (string_ops) | 1.37× slower | **faster** |
| `table.sort` | 1.41× slower | **~1.05×** |

Every benchmark workload is now within 25% of Luerl; string.format, string_ops,
and most table ops are *faster*. See `benchmarks/BASELINE.md` (separate docs PR).

### Verification
- `mix test`: **2553 passed (+5 new), 0 failures**; `mix format` + `--warnings-as-errors` clean
- `mix test --only lua53`: 20/29 unchanged
