### PR TITLE
feat(vfs): in-memory virtual filesystem + state integration

### DIFF
--- a/lib/lua/vfs.ex
+++ b/lib/lua/vfs.ex
@@ -1,0 +1,128 @@
+defmodule Lua.VFS do
+  @moduledoc """
+  An in-memory virtual filesystem backing the sandboxed VM.
+
+  The VM is virtual by default: filesystem-touching operations (`require`,
+  `loadfile`/`dofile`, the `io` library, and the file-oriented `os` functions)
+  read and write here instead of the host disk, so a sandboxed script can never
+  reach the real machine. Embedding hosts seed it (e.g. `Lua.write_file/3`,
+  `Lua.put_dep/3`) and harvest from it (`Lua.read_file/2`).
+
+  Files are stored as a flat map keyed by **normalized absolute path**
+  (`"/a/b.lua" => contents`); directories are implicit (a path is a directory
+  when some stored key is nested beneath it). There is no host I/O and no
+  pluggable backend — the boundary is entirely in-tree.
+
+  Errors are tagged atoms that map onto Lua's `nil, message, errno` `io`/`os`
+  contract: `:enoent` (no such file), `:eisdir` (path is a directory), and
+  `:einval` (path is not absolute).
+  """
+
+  defstruct files: %{}
+
+  @type path :: binary()
+  @type error :: :enoent | :eisdir | :einval
+  @type t :: %__MODULE__{files: %{optional(path()) => binary()}}
+
+  @doc """
+  Returns a new, empty virtual filesystem.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Reads the contents of `path`.
+
+  Returns `{:ok, contents}`, `{:error, :enoent}` when the file is absent,
+  `{:error, :eisdir}` when `path` names a directory, or `{:error, :einval}`
+  when `path` is not absolute.
+  """
+  @spec read(t(), path()) :: {:ok, binary()} | {:error, error()}
+  def read(%__MODULE__{files: files}, path) do
+    with {:ok, norm} <- normalize(path) do
+      cond do
+        Map.has_key?(files, norm) -> {:ok, Map.fetch!(files, norm)}
+        directory?(files, norm) -> {:error, :eisdir}
+        true -> {:error, :enoent}
+      end
+    end
+  end
+
+  @doc """
+  Writes `contents` to `path`, creating or overwriting the file.
+
+  Returns `{:ok, vfs}` with the updated filesystem, or `{:error, :eisdir}` /
+  `{:error, :einval}`. Parent directories are implicit and need not exist.
+  """
+  @spec write(t(), path(), binary()) :: {:ok, t()} | {:error, error()}
+  def write(%__MODULE__{files: files} = vfs, path, contents) when is_binary(contents) do
+    with {:ok, norm} <- normalize(path) do
+      if directory?(files, norm) do
+        {:error, :eisdir}
+      else
+        {:ok, %{vfs | files: Map.put(files, norm, contents)}}
+      end
+    end
+  end
+
+  @doc """
+  Removes the file at `path`.
+
+  Returns `{:ok, vfs}`, `{:error, :enoent}` when absent, `{:error, :eisdir}`
+  when `path` names a directory, or `{:error, :einval}`.
+  """
+  @spec rm(t(), path()) :: {:ok, t()} | {:error, error()}
+  def rm(%__MODULE__{files: files} = vfs, path) do
+    with {:ok, norm} <- normalize(path) do
+      cond do
+        Map.has_key?(files, norm) -> {:ok, %{vfs | files: Map.delete(files, norm)}}
+        directory?(files, norm) -> {:error, :eisdir}
+        true -> {:error, :enoent}
+      end
+    end
+  end
+
+  @doc """
+  Returns `true` when `path` names an existing file or implicit directory.
+
+  A non-absolute path is never present and returns `false`.
+  """
+  @spec exists?(t(), path()) :: boolean()
+  def exists?(%__MODULE__{files: files}, path) do
+    case normalize(path) do
+      {:ok, norm} -> Map.has_key?(files, norm) or directory?(files, norm)
+      {:error, _} -> false
+    end
+  end
+
+  @doc """
+  Normalizes an absolute path, resolving `.` and `..` segments.
+
+  Returns `{:ok, normalized}` for an absolute path (`"/a/./b/../c"` ->
+  `"/a/c"`), or `{:error, :einval}` for a relative path. `..` at the root is a
+  no-op, matching POSIX.
+  """
+  @spec normalize(path()) :: {:ok, path()} | {:error, :einval}
+  def normalize("/" <> _ = path) do
+    segments =
+      path
+      |> String.split("/", trim: true)
+      |> Enum.reduce([], fn
+        ".", acc -> acc
+        "..", [_ | rest] -> rest
+        "..", [] -> []
+        segment, acc -> [segment | acc]
+      end)
+      |> Enum.reverse()
+
+    {:ok, "/" <> Enum.join(segments, "/")}
+  end
+
+  def normalize(_path), do: {:error, :einval}
+
+  # A normalized path is a directory when some stored key is nested beneath it.
+  defp directory?(files, norm) do
+    prefix = norm <> "/"
+    Enum.any?(files, fn {key, _} -> String.starts_with?(key, prefix) end)
+  end
+end

--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -3,6 +3,7 @@ defmodule Lua.VM.State do
   Runtime state for the Lua VM.
   """
 
+  alias Lua.VFS
   alias Lua.VM.Limits
   alias Lua.VM.RuntimeError
   alias Lua.VM.Table
@@ -56,7 +57,13 @@ defmodule Lua.VM.State do
             # scanned and spec-parsed once, not every call. Threaded in the
             # struct (not ETS/process dictionary) to preserve value semantics;
             # bounded in `Lua.VM.Stdlib.String`.
-            format_cache: %{}
+            format_cache: %{},
+            # The in-memory virtual filesystem backing the sandboxed VM.
+            # Filesystem-touching stdlib (`require`, `loadfile`/`dofile`, `io`,
+            # the file-oriented `os` functions) reads/writes here instead of the
+            # host disk, so a sandboxed script never reaches the real machine.
+            # Seeded by `new/0`; threaded via the `vfs_*` helpers below.
+            vfs: nil
 
   @type t :: %__MODULE__{
           call_stack: list(),
@@ -74,7 +81,8 @@ defmodule Lua.VM.State do
           private: map(),
           multi_return_count: non_neg_integer(),
           g_ref: nil | {:tref, non_neg_integer()},
-          format_cache: %{optional(binary()) => list()}
+          format_cache: %{optional(binary()) => list()},
+          vfs: nil | VFS.t()
         }
 
   @doc """
@@ -86,7 +94,7 @@ defmodule Lua.VM.State do
   def new do
     state = %__MODULE__{}
     {g_ref, state} = alloc_table(state)
-    %{state | g_ref: g_ref}
+    %{state | g_ref: g_ref, vfs: VFS.new()}
   end
 
   @doc """
@@ -300,6 +308,60 @@ defmodule Lua.VM.State do
   def get_userdata(state, {:udref, id}) do
     Map.fetch!(state.userdata, id)
   end
+
+  @doc """
+  Updates userdata in-place via a function.
+
+  Mutable userdata is how `io` file handles carry their cursor: the handle is a
+  `{:udref, _}` whose backing struct is rewritten through this helper as the
+  script reads/writes.
+  """
+  @spec update_userdata(t(), {:udref, non_neg_integer()}, (term() -> term())) :: t()
+  def update_userdata(state, {:udref, id}, fun) do
+    %{state | userdata: Map.update!(state.userdata, id, fun)}
+  end
+
+  @doc """
+  Reads a file from the virtual filesystem.
+
+  Returns `{:ok, contents}` or `{:error, reason}` where `reason` is a tagged
+  atom (`:enoent`/`:eisdir`/`:einval`). Reads do not mutate state, so no state
+  is threaded back.
+  """
+  @spec vfs_read(t(), VFS.path()) :: {:ok, binary()} | {:error, VFS.error()}
+  def vfs_read(%__MODULE__{vfs: vfs}, path), do: VFS.read(vfs, path)
+
+  @doc """
+  Writes a file into the virtual filesystem, threading the updated VFS back.
+
+  Returns `{:ok, state}` or `{:error, reason, state}`.
+  """
+  @spec vfs_write(t(), VFS.path(), binary()) :: {:ok, t()} | {:error, VFS.error(), t()}
+  def vfs_write(%__MODULE__{vfs: vfs} = state, path, contents) do
+    case VFS.write(vfs, path, contents) do
+      {:ok, vfs} -> {:ok, %{state | vfs: vfs}}
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  @doc """
+  Removes a file from the virtual filesystem, threading the updated VFS back.
+
+  Returns `{:ok, state}` or `{:error, reason, state}`.
+  """
+  @spec vfs_rm(t(), VFS.path()) :: {:ok, t()} | {:error, VFS.error(), t()}
+  def vfs_rm(%__MODULE__{vfs: vfs} = state, path) do
+    case VFS.rm(vfs, path) do
+      {:ok, vfs} -> {:ok, %{state | vfs: vfs}}
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  @doc """
+  Returns `true` when `path` names an existing file or directory in the VFS.
+  """
+  @spec vfs_exists?(t(), VFS.path()) :: boolean()
+  def vfs_exists?(%__MODULE__{vfs: vfs}, path), do: VFS.exists?(vfs, path)
 
   @doc """
   Stores a private value not exposed to Lua.

--- a/test/lua/vfs_test.exs
+++ b/test/lua/vfs_test.exs
@@ -1,0 +1,111 @@
+defmodule Lua.VFSTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.VFS
+
+  describe "new/0" do
+    test "starts empty" do
+      assert VFS.new().files == %{}
+    end
+  end
+
+  describe "write/3 and read/2" do
+    test "round-trips a file" do
+      {:ok, vfs} = VFS.write(VFS.new(), "/a.lua", "return 1")
+      assert VFS.read(vfs, "/a.lua") == {:ok, "return 1"}
+    end
+
+    test "overwrites an existing file" do
+      {:ok, vfs} = VFS.write(VFS.new(), "/a.lua", "old")
+      {:ok, vfs} = VFS.write(vfs, "/a.lua", "new")
+      assert VFS.read(vfs, "/a.lua") == {:ok, "new"}
+    end
+
+    test "normalizes the key on write and read" do
+      {:ok, vfs} = VFS.write(VFS.new(), "/x/./y/../z.lua", "v")
+      assert vfs.files == %{"/x/z.lua" => "v"}
+      assert VFS.read(vfs, "/x/z.lua") == {:ok, "v"}
+    end
+
+    test "reading a missing file is :enoent" do
+      assert VFS.read(VFS.new(), "/nope.lua") == {:error, :enoent}
+    end
+
+    test "relative paths are rejected as :einval" do
+      assert VFS.write(VFS.new(), "rel.lua", "v") == {:error, :einval}
+      assert VFS.read(VFS.new(), "rel.lua") == {:error, :einval}
+      assert VFS.rm(VFS.new(), "rel.lua") == {:error, :einval}
+    end
+  end
+
+  describe "directories (implicit)" do
+    setup do
+      {:ok, vfs} = VFS.write(VFS.new(), "/lua/deps/a/b.lua", "v")
+      %{vfs: vfs}
+    end
+
+    test "an ancestor path reads as :eisdir", %{vfs: vfs} do
+      assert VFS.read(vfs, "/lua/deps/a") == {:error, :eisdir}
+      assert VFS.read(vfs, "/lua") == {:error, :eisdir}
+    end
+
+    test "cannot write over a directory", %{vfs: vfs} do
+      assert VFS.write(vfs, "/lua/deps/a", "x") == {:error, :eisdir}
+    end
+
+    test "cannot remove a directory", %{vfs: vfs} do
+      assert VFS.rm(vfs, "/lua/deps/a") == {:error, :eisdir}
+    end
+  end
+
+  describe "rm/2" do
+    test "removes a file" do
+      {:ok, vfs} = VFS.write(VFS.new(), "/a.lua", "v")
+      {:ok, vfs} = VFS.rm(vfs, "/a.lua")
+      assert VFS.read(vfs, "/a.lua") == {:error, :enoent}
+    end
+
+    test "removing a missing file is :enoent" do
+      assert VFS.rm(VFS.new(), "/a.lua") == {:error, :enoent}
+    end
+  end
+
+  describe "exists?/2" do
+    setup do
+      {:ok, vfs} = VFS.write(VFS.new(), "/dir/file.lua", "v")
+      %{vfs: vfs}
+    end
+
+    test "true for files and implicit directories", %{vfs: vfs} do
+      assert VFS.exists?(vfs, "/dir/file.lua")
+      assert VFS.exists?(vfs, "/dir")
+    end
+
+    test "false for missing and relative paths", %{vfs: vfs} do
+      refute VFS.exists?(vfs, "/missing")
+      refute VFS.exists?(vfs, "relative")
+    end
+  end
+
+  describe "normalize/1" do
+    test "resolves . and .. segments" do
+      assert VFS.normalize("/a/./b/../c") == {:ok, "/a/c"}
+    end
+
+    test "collapses duplicate slashes and trailing slash" do
+      assert VFS.normalize("/a//b/") == {:ok, "/a/b"}
+    end
+
+    test ".. at root is a no-op" do
+      assert VFS.normalize("/../a") == {:ok, "/a"}
+    end
+
+    test "root normalizes to itself" do
+      assert VFS.normalize("/") == {:ok, "/"}
+    end
+
+    test "rejects relative paths" do
+      assert VFS.normalize("a/b") == {:error, :einval}
+    end
+  end
+end

--- a/test/lua/vm/state_test.exs
+++ b/test/lua/vm/state_test.exs
@@ -1,0 +1,45 @@
+defmodule Lua.VM.StateTest do
+  use ExUnit.Case, async: true
+
+  alias Lua.VFS
+  alias Lua.VM.State
+
+  describe "vfs seeding" do
+    test "new/0 seeds an empty virtual filesystem" do
+      assert %VFS{files: %{}} = State.new().vfs
+    end
+  end
+
+  describe "vfs_write/3, vfs_read/2, vfs_rm/2, vfs_exists?/2" do
+    test "write threads the updated VFS back onto state" do
+      {:ok, state} = State.vfs_write(State.new(), "/a.lua", "return 1")
+      assert State.vfs_read(state, "/a.lua") == {:ok, "return 1"}
+      assert State.vfs_exists?(state, "/a.lua")
+    end
+
+    test "write error returns the reason and the unchanged state" do
+      state = State.new()
+      assert {:error, :einval, ^state} = State.vfs_write(state, "relative", "v")
+    end
+
+    test "rm threads the updated VFS back onto state" do
+      {:ok, state} = State.vfs_write(State.new(), "/a.lua", "v")
+      {:ok, state} = State.vfs_rm(state, "/a.lua")
+      assert State.vfs_read(state, "/a.lua") == {:error, :enoent}
+      refute State.vfs_exists?(state, "/a.lua")
+    end
+
+    test "rm of a missing file returns :enoent and the state" do
+      state = State.new()
+      assert {:error, :enoent, ^state} = State.vfs_rm(state, "/missing")
+    end
+  end
+
+  describe "update_userdata/3" do
+    test "rewrites the backing term in place" do
+      {ref, state} = State.alloc_userdata(State.new(), %{pos: 0})
+      state = State.update_userdata(state, ref, fn data -> %{data | pos: 5} end)
+      assert State.get_userdata(state, ref) == %{pos: 5}
+    end
+  end
+end


### PR DESCRIPTION
## Virtual-by-default, PR 1/4 — foundation

First slice of the 1.0.0 *virtual-by-default* work (tracking: #297; supersedes the draft #302). **No behavior change** — this only adds the storage layer the later PRs route through.

### What
- **`Lua.VFS`** — a vendored, in-memory virtual filesystem: a flat map keyed by normalized **absolute** path, directories implicit, with tagged-tuple errors (`:enoent`/`:eisdir`/`:einval`) that map onto Lua's `nil, message, errno` io/os contract. No external dependency (keeps the Elixir floor at `~> 1.16` and `mix hex.publish` clean — unlike #302's `ivarvong/vfs` git dep).
- **`Lua.VM.State`** — `vfs` field seeded in `new/0`; threaded helpers `vfs_read/2`, `vfs_write/3`, `vfs_rm/2`, `vfs_exists?/2`; plus `update_userdata/3` for the mutable file-handle cursors coming in the io PR.

### Why this shape
A git dependency blocks `mix hex.publish` and bumps the Elixir floor; the surface actually needed is tiny (read/write/rm/exists over one in-memory tree), so it's vendored in-tree where the security boundary belongs.

### Next in the stack
2. `sandbox:`/`env:` API + Os.Common/Virtual/Host split + virtual/host loaders (removes the per-path deny-list)
3. `io.*` virtualization over the VFS
4. Docs / ROADMAP / CHANGELOG

### Verification
- `mix test`: **2588 passed** (+24 new), 0 failures
- `mix format` + `mix compile --warnings-as-errors`: clean