### PR TITLE
fix(parser): gate parse-error ANSI on IO.ANSI.enabled?/0

### DIFF
--- a/lib/lua/parser/error.ex
+++ b/lib/lua/parser/error.ex
@@ -239,7 +239,7 @@ defmodule Lua.Parser.Error do
     lines = String.split(source_code, "\n")
 
     header = [
-      IO.ANSI.red() <> IO.ANSI.bright() <> "Parse Error" <> IO.ANSI.reset(),
+      color("Parse Error", IO.ANSI.red() <> IO.ANSI.bright()),
       ""
     ]
 
@@ -268,7 +268,7 @@ defmodule Lua.Parser.Error do
       if error.suggestion do
         [
           "",
-          IO.ANSI.cyan() <> "Suggestion:" <> IO.ANSI.reset(),
+          color("Suggestion:", IO.ANSI.cyan()),
           indent(error.suggestion, 2)
         ]
       else
@@ -279,7 +279,7 @@ defmodule Lua.Parser.Error do
       if length(error.related) > 0 do
         [
           "",
-          IO.ANSI.yellow() <> "Related errors:" <> IO.ANSI.reset()
+          color("Related errors:", IO.ANSI.yellow())
         ] ++ Enum.flat_map(error.related, fn rel -> ["", indent(format(rel, source_code), 2)] end)
       else
         []
@@ -294,10 +294,10 @@ defmodule Lua.Parser.Error do
   @spec format_multiple([t()], String.t()) :: String.t()
   def format_multiple(errors, source_code) do
     header = [
-      IO.ANSI.red() <>
-        IO.ANSI.bright() <>
-        "Found #{length(errors)} parse error#{if length(errors) == 1, do: "", else: "s"}" <>
-        IO.ANSI.reset(),
+      color(
+        "Found #{length(errors)} parse error#{if length(errors) == 1, do: "", else: "s"}",
+        IO.ANSI.red() <> IO.ANSI.bright()
+      ),
       ""
     ]
 
@@ -306,7 +306,7 @@ defmodule Lua.Parser.Error do
       |> Enum.with_index(1)
       |> Enum.flat_map(fn {error, idx} ->
         [
-          IO.ANSI.yellow() <> "Error #{idx}:" <> IO.ANSI.reset(),
+          color("Error #{idx}:", IO.ANSI.yellow()),
           format(error, source_code),
           ""
         ]
@@ -316,6 +316,18 @@ defmodule Lua.Parser.Error do
   end
 
   # Private helpers
+
+  # ANSI helpers — no-ops unless the terminal actually supports color, so
+  # piping to a file or a non-TTY never embeds raw escape codes. Mirrors
+  # `Lua.VM.ErrorFormatter.color/2` so parse and runtime errors gate the same
+  # way (see issue #382).
+  defp color(text, ansi) do
+    if IO.ANSI.enabled?() do
+      ansi <> text <> IO.ANSI.reset()
+    else
+      text
+    end
+  end
 
   defp format_context(lines, position) do
     line_num = position.line
@@ -335,15 +347,15 @@ defmodule Lua.Parser.Error do
         if num == line_num do
           # Error line
           pointer = String.duplicate(" ", String.length(format_line_number(num)) + 3 + column - 1)
-          pointer = pointer <> IO.ANSI.red() <> "^" <> IO.ANSI.reset()
+          pointer = pointer <> color("^", IO.ANSI.red())
 
           [
-            IO.ANSI.red() <> line_str <> IO.ANSI.reset(),
+            color(line_str, IO.ANSI.red()),
             pointer
           ]
         else
           # Context line
-          [IO.ANSI.faint() <> line_str <> IO.ANSI.reset()]
+          [color(line_str, IO.ANSI.faint())]
         end
       end)
 

--- a/test/lua/parser/error_ansi_test.exs
+++ b/test/lua/parser/error_ansi_test.exs
@@ -1,0 +1,39 @@
+defmodule Lua.Parser.ErrorAnsiTest do
+  @moduledoc """
+  Locks the ANSI gating on parser error output.
+
+  Parse errors color their output only when `IO.ANSI.enabled?/0` is true,
+  matching the runtime `Lua.VM.ErrorFormatter` path. The suite otherwise runs
+  with ANSI disabled (see test/test_helper.exs), so these tests flip it on
+  locally and restore it. That toggle mutates global application env, so this
+  module is `async: false` to keep it from racing concurrent tests that assert
+  on plain-text output.
+  """
+  use ExUnit.Case, async: false
+
+  alias Lua.Parser
+
+  setup do
+    Application.put_env(:elixir, :ansi_enabled, true)
+    on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, false) end)
+  end
+
+  describe "with ANSI enabled" do
+    test "uses ANSI colors for better readability" do
+      assert {:error, msg} = Parser.parse("if x then")
+      # Red for errors
+      assert msg =~ "\e[31m"
+      # Bold
+      assert msg =~ "\e[1m"
+      # Reset
+      assert msg =~ "\e[0m"
+      # Cyan for suggestions
+      assert msg =~ "\e[36m"
+    end
+
+    test "parse_chunk/1 carries colored errors when ANSI is on" do
+      assert {:error, %Lua.CompilerException{errors: errors}} = Lua.parse_chunk("asdf")
+      assert Enum.any?(errors, &(&1 =~ "\e["))
+    end
+  end
+end

--- a/test/lua/parser/error_test.exs
+++ b/test/lua/parser/error_test.exs
@@ -110,8 +110,16 @@ defmodule Lua.Parser.ErrorTest do
       assert msg =~ "│"
       # Error pointer
       assert msg =~ "^"
-      # ANSI color codes
-      assert msg =~ "\e["
+    end
+
+    test "format output is gated on IO.ANSI.enabled?" do
+      refute IO.ANSI.enabled?(), "test env should have ANSI disabled"
+
+      # Regression for #382: parse errors must not embed raw ANSI escape
+      # codes when color is disabled. The strings flow out of parse_chunk/1
+      # inside %Lua.CompilerException{}, so a leak here surfaces there too.
+      assert {:error, msg} = Parser.parse("asdf")
+      refute msg =~ "\e["
     end
 
     test "includes line and column information" do
@@ -148,20 +156,6 @@ defmodule Lua.Parser.ErrorTest do
 
       assert {:error, msg} = Parser.parse(code)
       assert msg =~ "Suggestion"
-    end
-
-    test "uses ANSI colors for better readability" do
-      code = "if x then"
-
-      assert {:error, msg} = Parser.parse(code)
-      # Red for errors
-      assert msg =~ "\e[31m"
-      # Bold
-      assert msg =~ "\e[1m"
-      # Reset
-      assert msg =~ "\e[0m"
-      # Cyan for suggestions
-      assert msg =~ "\e[36m"
     end
   end
 

--- a/test/lua_test.exs
+++ b/test/lua_test.exs
@@ -475,6 +475,17 @@ defmodule LuaTest do
       refute message =~ "Lua.CompilerException"
     end
 
+    test "parse_chunk/1 errors carry no ANSI escapes when color is disabled" do
+      refute IO.ANSI.enabled?(), "test env should have ANSI disabled"
+
+      # Regression for #382: the formatted parse-error strings stored in
+      # %Lua.CompilerException{} must respect IO.ANSI.enabled?/0 rather than
+      # embedding raw escape codes unconditionally.
+      assert {:error, %Lua.CompilerException{errors: errors}} = Lua.parse_chunk("asdf")
+      refute Enum.any?(errors, &(&1 =~ "\e["))
+      refute Exception.message(Lua.CompilerException.exception(formatted: errors)) =~ "\e["
+    end
+
     test "chunks can be loaded multiple times" do
       lua = Lua.new()
       chunk = ~LUA[print("hello")]c


### PR DESCRIPTION
## Problem

Closes #382. `Lua.parse_chunk("asdf")` returned error strings full of raw ANSI escape codes (`\e[31m…`) even when ANSI is disabled. `Lua.Parser.Error.format/2` emitted `IO.ANSI` escapes **unconditionally**, bypassing the `IO.ANSI.enabled?/0` gating that the runtime VM path (`Lua.VM.ErrorFormatter`, #304) already respects. Those strings flow through `parse_chunk/1` into `%Lua.CompilerException{errors: [...]}`, so the escapes leaked into the returned tuple regardless of environment.

(The contributor's follow-up ask on the issue — return a `%Lua.CompilerException{}` rather than a bare string list — was already delivered by #380.)

## Fix

- `lib/lua/parser/error.ex` — add a private `color/2` helper mirroring `Lua.VM.ErrorFormatter.color/2`, and route every colorized fragment in `format/2`, `format_context/2`, and `format_multiple/2` through it. No message text or public API changes — only the presence of escape codes, and only when ANSI is disabled.

## Behavior

```
# ANSI off (default non-TTY) — clean
{:error, %Lua.CompilerException{errors: ["Parse Error\n\n  at line 1, column 1:\n\n  A bare variable reference isn't a Lua statement.\n..."]}}

# ANSI on (real TTY) — colored, as before
{:error, %Lua.CompilerException{errors: ["\e[31m\e[1mParse Error\e[0m\n..."]}}
```

## Tests

- `test/lua/parser/error_test.exs` — drops the now-invalid "ANSI always present" assertions; adds a gating regression (ANSI off → no `\e[`).
- `test/lua/parser/error_ansi_test.exs` (new, `async: false`) — the ANSI-**on** assertions, isolated into a sync module so toggling the global `ansi_enabled` can't race concurrent async tests asserting plain text.
- `test/lua_test.exs` — end-to-end guard that `parse_chunk/1`'s `%Lua.CompilerException{}` errors carry no escapes when color is disabled.

Full suite: 2580 passed, 7 skipped, 30 excluded.

## Note on #384

#384 reports the same class of bug at a deeper level: exceptions memoize their gated render at *construction* time, so a render frozen in a TTY keeps its escapes into non-TTY sinks. This PR adds the parser gate that a construction-time fix depends on, but the full deferral fix is tracked separately in #384.