### PR TITLE
fix(errors): render exception messages lazily so ANSI gating holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,19 @@ is in the [`1.0.0-rc.0`](#100-rc0---2026-05-26) entry below.
     `pcall` hands back inside Lua. Code matching on a string reason should
     switch to the struct (or call `Exception.message/1` on it).
   - `Lua.parse_chunk/1` returns `{:error, %Lua.CompilerException{}}` instead of
-    `{:error, [String.t()]}`. The formatted diagnostics are on the
-    exception's `:errors` field; `Exception.message/1` renders them.
+    `{:error, [String.t()]}`. Call `Exception.message/1` to render the full,
+    human-readable report; the `:errors` field carries the bare, ANSI-free
+    messages for programmatic inspection.
+- Lua exceptions render their message lazily at `Exception.message/1` call
+  time, so the `:message` **struct field** is removed from
+  `Lua.VM.RuntimeError`, `Lua.VM.TypeError`, and `Lua.VM.AssertionError`, and
+  is `nil` on the `Lua.RuntimeException` wrapper when it wraps a VM exception.
+  Read the message through `Exception.message/1` (the idiomatic accessor)
+  rather than the `e.message` field. Likewise `Lua.CompilerException`'s
+  `:errors` field now holds bare, ANSI-free messages rather than the fully
+  formatted (and previously ANSI-colored) diagnostics — the rich report moved
+  to `Exception.message/1`. This is what lets the ANSI gate hold at output time
+  (#384).
 
 ### Changed
 - `Lua.new/1`'s `:max_string_bytes` now accepts `:infinity` for no limit,
@@ -94,6 +105,13 @@ is in the [`1.0.0-rc.0`](#100-rc0---2026-05-26) entry below.
   populated (always `nil`); `:errors` carries all the formatted diagnostics.
 
 ### Fixed
+- Lua exception messages no longer leak ANSI escape codes (and multi-line rich
+  rendering) into non-terminal sinks such as log files, container stdout, or a
+  Sentry/AppSignal title. Messages were formatted eagerly during VM execution —
+  where `IO.ANSI.enabled?/0` is true — freezing escape codes into the struct
+  that survived long after the TTY gate. They now render at `Exception.message/1`
+  call time, so the ANSI gate is evaluated where the message is actually written
+  (#384).
 - `Lua.eval!/3` now accepts a `:source` option when evaluating a pre-compiled
   `Lua.Chunk`, matching the string-script clause. Previously
   `eval!(lua, chunk, source: "x")` raised via `Keyword.validate!`. For a chunk

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -499,7 +499,7 @@ defmodule Lua do
   def eval!(%__MODULE__{state: state} = lua, script, opts) when is_binary(script) do
     opts = Keyword.validate!(opts, decode: true, source: "<eval>")
 
-    case Lua.Parser.parse(script) do
+    case Lua.Parser.parse_structured(script) do
       {:ok, ast} ->
         case Lua.Compiler.compile(ast, source: opts[:source]) do
           {:ok, proto} ->
@@ -520,8 +520,8 @@ defmodule Lua do
             raise Lua.CompilerException, msg
         end
 
-      {:error, msg} ->
-        raise Lua.CompilerException, msg
+      {:error, parse_errors} ->
+        raise Lua.CompilerException, {:parse_errors, parse_errors, script}
     end
   rescue
     e in [Lua.RuntimeException, Lua.CompilerException] ->
@@ -641,7 +641,7 @@ defmodule Lua do
   """
   @spec parse_chunk(String.t()) :: {:ok, Lua.Chunk.t()} | {:error, Lua.CompilerException.t()}
   def parse_chunk(code) do
-    case Lua.Parser.parse(code) do
+    case Lua.Parser.parse_structured(code) do
       {:ok, ast} ->
         case Lua.Compiler.compile(ast) do
           {:ok, proto} ->
@@ -651,8 +651,8 @@ defmodule Lua do
             {:error, Lua.CompilerException.exception(msg)}
         end
 
-      {:error, msg} ->
-        {:error, Lua.CompilerException.exception(msg)}
+      {:error, parse_errors} ->
+        {:error, Lua.CompilerException.exception({:parse_errors, parse_errors, code})}
     end
   end
 

--- a/lib/lua/compiler_exception.ex
+++ b/lib/lua/compiler_exception.ex
@@ -75,5 +75,6 @@ defmodule Lua.CompilerException do
     """
   end
 
-  defp clean_message(%Error{message: message}), do: String.trim(message)
+  defp clean_message(%Error{message: message}) when is_binary(message), do: String.trim(message)
+  defp clean_message(%Error{}), do: ""
 end

--- a/lib/lua/compiler_exception.ex
+++ b/lib/lua/compiler_exception.ex
@@ -1,13 +1,35 @@
 defmodule Lua.CompilerException do
   @moduledoc """
-  Raised when Lua source cannot be lexed, parsed, or compiled. Carries
-  a list of formatted error messages in `:errors`.
+  Raised when Lua source cannot be lexed, parsed, or compiled.
+
+  Use `Exception.message/1` to render the full, human-readable report (location,
+  source context, pointer, and suggestions). ANSI color is applied only when
+  `IO.ANSI.enabled?/0` is true *at render time*, so the same exception logs
+  cleanly to a file and renders in color on a TTY (issue #384).
+
+  The `:errors` field carries the bare, ANSI-free error messages (no location
+  header or source context) for programmatic inspection and clean logging.
   """
+  alias Lua.Parser.Error
   alias Lua.Util
 
   @type t :: %__MODULE__{}
 
-  defexception [:errors]
+  # `:diagnostics` holds structured `Lua.Parser.Error` structs and `:source` the
+  # original code, so `message/1` can render the rich report lazily. They stay
+  # `nil` for non-parser inputs (compiler/lexer errors), which fall back to
+  # joining the `:errors` strings.
+  defexception errors: [], diagnostics: nil, source: nil
+
+  # Structured parse errors — defer formatting to `message/1` so the ANSI gate
+  # is evaluated when the message is written, not frozen at construction.
+  def exception({:parse_errors, diagnostics, source}) when is_list(diagnostics) do
+    %__MODULE__{
+      diagnostics: diagnostics,
+      source: source,
+      errors: Enum.map(diagnostics, &clean_message/1)
+    }
+  end
 
   def exception(formatted: errors) when is_list(errors) do
     %__MODULE__{errors: errors}
@@ -30,10 +52,21 @@ defmodule Lua.CompilerException do
   end
 
   # Compile-time errors don't have a meaningful runtime stack trace — they're
-  # produced by the lexer/parser before any code is executed. The rich source
-  # context (line, column, pointer to the offending token) is embedded in
-  # `errors` by `Lua.Parser.Error.format/2` (and the lexer's equivalent), so
-  # we just join those messages under a clear "Failed to compile" header.
+  # produced by the lexer/parser/compiler before any code is executed. The rich
+  # source context (line, column, pointer to the offending token) is rendered
+  # here from the structured diagnostics, so we join it under a clear
+  # "Failed to compile" header.
+  @impl true
+  def message(%__MODULE__{diagnostics: [_ | _] = diagnostics, source: source}) do
+    rendered = Enum.map_join(diagnostics, "\n", &Error.format(&1, source))
+
+    """
+    Failed to compile Lua!
+
+    #{rendered}
+    """
+  end
+
   def message(%__MODULE__{errors: errors}) do
     """
     Failed to compile Lua!
@@ -41,4 +74,6 @@ defmodule Lua.CompilerException do
     #{Enum.join(errors, "\n")}
     """
   end
+
+  defp clean_message(%Error{message: message}), do: String.trim(message)
 end

--- a/lib/lua/runtime_exception.ex
+++ b/lib/lua/runtime_exception.ex
@@ -4,9 +4,15 @@ defmodule Lua.RuntimeException do
   arithmetic on a non-number, indexing a nil, an explicit `error()`
   call from Lua, or any other dynamic failure inside the VM.
 
+  Use `Exception.message/1` to render the message — do not read the `:message`
+  field directly. When this wraps a VM exception the field is `nil` and the
+  message is rendered lazily so ANSI color is gated on `IO.ANSI.enabled?/0` at
+  output time rather than frozen at construction (issue #384).
+
   Fields:
 
-    * `:message`     — formatted error string
+    * `:message`     — pre-rendered string for terminal-independent errors, or
+      `nil` when rendered lazily from `:original`
     * `:original`    — the underlying VM error term
     * `:state`       — the internal VM state at the point of failure
     * `:line`        — line number where the error was raised
@@ -50,25 +56,38 @@ defmodule Lua.RuntimeException do
   end
 
   def exception(error) do
-    message =
-      if is_exception(error) do
-        Exception.message(error)
-      else
-        inspect(error)
-      end
-
     # Copy structured fields off VM exceptions (TypeError, RuntimeError,
     # AssertionError) so consumers can pattern-match on `:line` / `:source`
     # without having to re-parse the message string.
     {line, source, call_stack} = extract_context(error)
 
+    # `:message` is left nil so `message/1` renders the wrapped error lazily.
+    # The inner VM exceptions gate ANSI on `IO.ANSI.enabled?/0` at render time
+    # (issue #384); freezing their rendered message here would bake in escape
+    # codes from the TTY-attached VM process and leak them into log sinks.
     %__MODULE__{
       original: error,
-      message: prefix_message(message),
       line: line,
       source: source,
       call_stack: call_stack
     }
+  end
+
+  # The `:lua_error`, `:api_error`, keyword-list, and binary clauses build
+  # ANSI-free strings that don't depend on the terminal, so they memoize into
+  # `:message`. The generic clause defers to keep the ANSI gate honest.
+  @impl true
+  def message(%__MODULE__{message: message}) when is_binary(message), do: message
+
+  def message(%__MODULE__{original: original}) do
+    rendered =
+      if is_exception(original) do
+        Exception.message(original)
+      else
+        inspect(original)
+      end
+
+    prefix_message(rendered)
   end
 
   defp prefix_message(@runtime_prefix <> _ = msg), do: msg

--- a/lib/lua/vm/assertion_error.ex
+++ b/lib/lua/vm/assertion_error.ex
@@ -16,26 +16,27 @@ defmodule Lua.VM.AssertionError do
   # rolling back to their entry snapshot. It is out-of-band metadata: it never
   # participates in `message` and stays `nil` when no state was in scope.
   @derive {Inspect, except: [:state]}
-  defexception [:value, :source, :message, :call_stack, :line, :state]
+  defexception [:value, :source, :call_stack, :line, :state]
 
   @impl true
   def exception(opts) do
     {auto_line, auto_source} = Lua.VM.Executor.current_position()
 
-    value = Keyword.get(opts, :value)
-    source = Keyword.get(opts, :source) || auto_source
-    call_stack = Keyword.get(opts, :call_stack, [])
-    line = Keyword.get(opts, :line) || auto_line
-    message = Keyword.get(opts, :message) || format_message(value, source, line, call_stack)
-
     %__MODULE__{
-      value: value,
-      source: source,
-      message: message,
-      call_stack: call_stack,
-      line: line,
+      value: Keyword.get(opts, :value),
+      source: Keyword.get(opts, :source) || auto_source,
+      call_stack: Keyword.get(opts, :call_stack, []),
+      line: Keyword.get(opts, :line) || auto_line,
       state: Keyword.get(opts, :state)
     }
+  end
+
+  # Rendered lazily so `IO.ANSI.enabled?/0` is evaluated when the message is
+  # actually written rather than frozen at construction time. See issue #384;
+  # mirrors `Lua.VM.ArgumentError.message/1`.
+  @impl true
+  def message(%__MODULE__{} = error) do
+    format_message(error.value, error.source, error.line, error.call_stack)
   end
 
   @doc """

--- a/lib/lua/vm/runtime_error.ex
+++ b/lib/lua/vm/runtime_error.ex
@@ -30,27 +30,29 @@ defmodule Lua.VM.RuntimeError do
   # raw `:value`, so host-facing rendering (which adds its own
   # `at source:line:` header) never doubles the location.
   @derive {Inspect, except: [:state]}
-  defexception [:value, :lua_value, :source, :message, :call_stack, :line, :state]
+  defexception [:value, :lua_value, :source, :call_stack, :line, :state]
 
   @impl true
   def exception(opts) do
     {auto_line, auto_source} = Lua.VM.Executor.current_position()
 
-    value = Keyword.get(opts, :value)
-    source = Keyword.get(opts, :source) || auto_source
-    call_stack = Keyword.get(opts, :call_stack, [])
-    line = Keyword.get(opts, :line) || auto_line
-    message = Keyword.get(opts, :message) || format_message(value, source, line, call_stack)
-
     %__MODULE__{
-      value: value,
+      value: Keyword.get(opts, :value),
       lua_value: Keyword.get(opts, :lua_value),
-      source: source,
-      message: message,
-      call_stack: call_stack,
-      line: line,
+      source: Keyword.get(opts, :source) || auto_source,
+      call_stack: Keyword.get(opts, :call_stack, []),
+      line: Keyword.get(opts, :line) || auto_line,
       state: Keyword.get(opts, :state)
     }
+  end
+
+  # Rendered lazily so `IO.ANSI.enabled?/0` is evaluated when the message is
+  # actually written (log sink, TTY, Sentry) rather than frozen at construction
+  # time — where it would run inside a Lua execution and always see a TTY. See
+  # issue #384; mirrors `Lua.VM.ArgumentError.message/1`.
+  @impl true
+  def message(%__MODULE__{} = error) do
+    format_message(error.value, error.source, error.line, error.call_stack)
   end
 
   @doc """

--- a/lib/lua/vm/type_error.ex
+++ b/lib/lua/vm/type_error.ex
@@ -21,33 +21,36 @@ defmodule Lua.VM.TypeError do
   # rolling back to their entry snapshot. It is out-of-band metadata: it never
   # participates in `message` and stays `nil` when no state was in scope.
   @derive {Inspect, except: [:state]}
-  defexception [:value, :source, :message, :call_stack, :line, :error_kind, :value_type, :state]
+  defexception [:value, :source, :call_stack, :line, :error_kind, :value_type, :state]
 
   @impl true
   def exception(opts) do
     {auto_line, auto_source} = Lua.VM.Executor.current_position()
 
-    value = Keyword.get(opts, :value)
-    source = Keyword.get(opts, :source) || auto_source
-    call_stack = Keyword.get(opts, :call_stack, [])
-    line = Keyword.get(opts, :line) || auto_line
-    error_kind = Keyword.get(opts, :error_kind)
-    value_type = Keyword.get(opts, :value_type)
-
-    message =
-      Keyword.get(opts, :message) ||
-        format_message(value, source, line, call_stack, error_kind, value_type)
-
     %__MODULE__{
-      value: value,
-      source: source,
-      message: message,
-      call_stack: call_stack,
-      line: line,
-      error_kind: error_kind,
-      value_type: value_type,
+      value: Keyword.get(opts, :value),
+      source: Keyword.get(opts, :source) || auto_source,
+      call_stack: Keyword.get(opts, :call_stack, []),
+      line: Keyword.get(opts, :line) || auto_line,
+      error_kind: Keyword.get(opts, :error_kind),
+      value_type: Keyword.get(opts, :value_type),
       state: Keyword.get(opts, :state)
     }
+  end
+
+  # Rendered lazily so `IO.ANSI.enabled?/0` is evaluated when the message is
+  # actually written rather than frozen at construction time. See issue #384;
+  # mirrors `Lua.VM.ArgumentError.message/1`.
+  @impl true
+  def message(%__MODULE__{} = error) do
+    format_message(
+      error.value,
+      error.source,
+      error.line,
+      error.call_stack,
+      error.error_kind,
+      error.value_type
+    )
   end
 
   @doc """

--- a/test/lua/error_messages_test.exs
+++ b/test/lua/error_messages_test.exs
@@ -46,7 +46,7 @@ defmodule Lua.ErrorMessagesTest do
           VM.execute(proto, state)
         end
 
-      assert error.message =~ "number"
+      assert Exception.message(error) =~ "number"
     end
 
     test "error message includes source location" do
@@ -211,9 +211,9 @@ defmodule Lua.ErrorMessagesTest do
         end
 
       # Error message should be a formatted string
-      assert is_binary(error.message)
+      assert is_binary(Exception.message(error))
       # Should contain error type
-      assert error.message =~ ~r/Error/i
+      assert Exception.message(error) =~ ~r/Error/i
     end
   end
 
@@ -386,8 +386,8 @@ defmodule Lua.ErrorMessagesTest do
       # and IDE integrations can only string-scrape the formatted message.
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "attempt to perform arithmetic on a string value"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "attempt to perform arithmetic on a string value"
     end
 
     test "indexing a nil value carries line and source" do
@@ -403,7 +403,7 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
     end
 
     test "calling a nil value carries line and source" do
@@ -419,8 +419,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "attempt to call a nil value"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "attempt to call a nil value"
     end
 
     test "assert(false) from Lua carries line and source" do
@@ -436,8 +436,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "check.lua"
-      assert e.message =~ "check.lua:#{e.line}"
-      assert e.message =~ "must be positive"
+      assert Exception.message(e) =~ "check.lua:#{e.line}"
+      assert Exception.message(e) =~ "must be positive"
     end
 
     test "default source name is <eval> when no source: given" do
@@ -449,7 +449,7 @@ defmodule Lua.ErrorMessagesTest do
         end
 
       assert e.source == "<eval>"
-      assert e.message =~ "<eval>:"
+      assert Exception.message(e) =~ "<eval>:"
     end
 
     test "source: option threads through to the compiled chunk" do
@@ -459,7 +459,7 @@ defmodule Lua.ErrorMessagesTest do
         end
 
       assert e.source == "user_input.lua"
-      assert e.message =~ "user_input.lua:"
+      assert Exception.message(e) =~ "user_input.lua:"
     end
 
     test "successful eval doesn't pay any line-tracking cost on the public path" do
@@ -498,8 +498,8 @@ defmodule Lua.ErrorMessagesTest do
       # The wrapped public exception preserves the structured fields.
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "bad argument #1 to 'string.upper'"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "bad argument #1 to 'string.upper'"
     end
 
     test "math.floor on string carries line and source" do
@@ -515,8 +515,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "bad argument #1 to 'math.floor'"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "bad argument #1 to 'math.floor'"
     end
 
     test "table.insert with bad pos carries line and source" do
@@ -532,8 +532,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "table.insert"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "table.insert"
     end
 
     test "select with non-numeric index carries line and source" do
@@ -549,8 +549,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "select"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "select"
     end
 
     test "setmetatable on non-table carries line and source" do
@@ -566,8 +566,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line)
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:"
-      assert e.message =~ "setmetatable"
+      assert Exception.message(e) =~ "demo.lua:"
+      assert Exception.message(e) =~ "setmetatable"
     end
 
     test "ArgumentError raised outside a Lua execution has nil line/source" do
@@ -623,8 +623,8 @@ defmodule Lua.ErrorMessagesTest do
 
       assert is_integer(e.line) and e.line > 0
       assert e.source == "demo.lua"
-      assert e.message =~ "demo.lua:#{e.line}"
-      assert e.message =~ "select"
+      assert Exception.message(e) =~ "demo.lua:#{e.line}"
+      assert Exception.message(e) =~ "select"
     end
   end
 end

--- a/test/lua/exception_ansi_gating_test.exs
+++ b/test/lua/exception_ansi_gating_test.exs
@@ -1,0 +1,97 @@
+defmodule Lua.ExceptionAnsiGatingTest do
+  @moduledoc """
+  Locks the fix for issue #384: exceptions must render their message when
+  `Exception.message/1` is called, gating ANSI on `IO.ANSI.enabled?/0` at that
+  point — never freezing a TTY-colored render at construction time.
+
+  Each case builds the exception while ANSI is enabled (as it would be
+  constructed inside a TTY-attached VM execution), then renders with ANSI
+  disabled and asserts no escape codes survive. The reverse direction proves
+  it is a gate, not a blanket strip.
+
+  Toggling `:ansi_enabled` mutates global application env, so this module is
+  `async: false` to avoid racing tests that assert on plain-text output.
+  """
+  use ExUnit.Case, async: false
+
+  alias Lua.VM.ArgumentError
+  alias Lua.VM.AssertionError
+  alias Lua.VM.RuntimeError
+  alias Lua.VM.TypeError
+
+  setup do
+    on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, false) end)
+  end
+
+  # Build each exception with ANSI enabled to simulate construction inside a
+  # TTY-attached VM. `message/1` must still consult the gate at call time.
+  defp built_with_ansi_on(build) do
+    Application.put_env(:elixir, :ansi_enabled, true)
+    exception = build.()
+    Application.put_env(:elixir, :ansi_enabled, false)
+    exception
+  end
+
+  defp build(:runtime_error), do: RuntimeError.exception(value: "kaboom", source: "demo", line: 1)
+
+  defp build(:type_error),
+    do: TypeError.exception(value: "attempt to call a nil value", source: "demo", line: 2, error_kind: :call_nil)
+
+  defp build(:assertion_error), do: AssertionError.exception(value: "nope", source: "demo", line: 3)
+
+  defp build(:argument_error),
+    do: ArgumentError.exception(function_name: "string.rep", arg_num: 2, expected: "number", source: "demo", line: 2)
+
+  for {name, key} <- [
+        {"RuntimeError", :runtime_error},
+        {"TypeError", :type_error},
+        {"AssertionError", :assertion_error},
+        {"ArgumentError", :argument_error}
+      ] do
+    test "#{name}: message carries no ANSI when disabled at render time" do
+      exception = built_with_ansi_on(fn -> build(unquote(key)) end)
+
+      refute Exception.message(exception) =~ "\e[",
+             "#{unquote(name)} froze ANSI at construction (issue #384)"
+    end
+
+    test "#{name}: message carries ANSI when enabled at render time" do
+      exception = built_with_ansi_on(fn -> build(unquote(key)) end)
+
+      Application.put_env(:elixir, :ansi_enabled, true)
+      assert Exception.message(exception) =~ "\e[", "#{unquote(name)} should color on a TTY"
+    end
+  end
+
+  describe "Lua.RuntimeException wrapper" do
+    test "does not freeze the wrapped VM exception's ANSI render" do
+      exception =
+        built_with_ansi_on(fn ->
+          Lua.RuntimeException.exception(RuntimeError.exception(value: "kaboom", source: "demo", line: 1))
+        end)
+
+      refute Exception.message(exception) =~ "\e["
+
+      Application.put_env(:elixir, :ansi_enabled, true)
+      assert Exception.message(exception) =~ "\e["
+    end
+  end
+
+  describe "Lua.CompilerException (parse errors)" do
+    test "message gates ANSI at render time; :errors stays ANSI-free" do
+      exception =
+        built_with_ansi_on(fn ->
+          {:error, exception} = Lua.parse_chunk("asdf")
+          exception
+        end)
+
+      # The bare messages never carry escapes, in any environment.
+      refute Enum.any?(exception.errors, &(&1 =~ "\e["))
+
+      refute Exception.message(exception) =~ "\e["
+
+      Application.put_env(:elixir, :ansi_enabled, true)
+      assert Exception.message(exception) =~ "\e["
+    end
+  end
+end

--- a/test/lua/parser/error_ansi_test.exs
+++ b/test/lua/parser/error_ansi_test.exs
@@ -31,9 +31,14 @@ defmodule Lua.Parser.ErrorAnsiTest do
       assert msg =~ "\e[36m"
     end
 
-    test "parse_chunk/1 carries colored errors when ANSI is on" do
-      assert {:error, %Lua.CompilerException{errors: errors}} = Lua.parse_chunk("asdf")
-      assert Enum.any?(errors, &(&1 =~ "\e["))
+    test "parse_chunk/1 renders a colored message when ANSI is on" do
+      # The `:errors` field stays ANSI-free (issue #384); color lives in the
+      # lazily-rendered message so the gate is honored at output time.
+      assert {:error, %Lua.CompilerException{errors: errors} = exception} =
+               Lua.parse_chunk("asdf")
+
+      refute Enum.any?(errors, &(&1 =~ "\e["))
+      assert Exception.message(exception) =~ "\e["
     end
   end
 end

--- a/test/lua/runtime_exception_test.exs
+++ b/test/lua/runtime_exception_test.exs
@@ -31,8 +31,8 @@ defmodule Lua.RuntimeExceptionTest do
           e in RuntimeException -> e
         end
 
-      assert exception.message =~ "Lua runtime error:"
-      assert exception.message =~ "custom error message"
+      assert Exception.message(exception) =~ "Lua runtime error:"
+      assert Exception.message(exception) =~ "custom error message"
     end
 
     test "handles parse errors" do
@@ -60,7 +60,7 @@ defmodule Lua.RuntimeExceptionTest do
           e in RuntimeException -> e
         end
 
-      assert exception.message =~ "Lua runtime error:"
+      assert Exception.message(exception) =~ "Lua runtime error:"
     end
 
     test "handles illegal index errors" do
@@ -74,7 +74,7 @@ defmodule Lua.RuntimeExceptionTest do
           e in RuntimeException -> e
         end
 
-      assert exception.message =~ "Lua runtime error:"
+      assert Exception.message(exception) =~ "Lua runtime error:"
     end
   end
 
@@ -85,7 +85,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception({:api_error, details, state})
 
-      assert exception.message == "Lua API error: invalid function call"
+      assert Exception.message(exception) == "Lua API error: invalid function call"
       assert exception.original == details
       assert exception.state == state
     end
@@ -96,7 +96,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception({:api_error, details, state})
 
-      assert exception.message ==
+      assert Exception.message(exception) ==
                "Lua API error: function returned invalid type: expected table, got nil"
 
       assert exception.original == details
@@ -113,7 +113,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "invalid arguments"
         )
 
-      assert exception.message == "Lua runtime error: my_function() failed, invalid arguments"
+      assert Exception.message(exception) == "Lua runtime error: my_function() failed, invalid arguments"
 
       assert exception.original == [
                scope: [],
@@ -132,7 +132,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "negative number not allowed"
         )
 
-      assert exception.message ==
+      assert Exception.message(exception) ==
                "Lua runtime error: math.sqrt() failed, negative number not allowed"
 
       assert exception.original == [
@@ -152,7 +152,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "data validation failed"
         )
 
-      assert exception.message ==
+      assert Exception.message(exception) ==
                "Lua runtime error: my.module.nested.process() failed, data validation failed"
 
       assert exception.original == [
@@ -196,7 +196,7 @@ defmodule Lua.RuntimeExceptionTest do
     test "formats simple binary error" do
       exception = RuntimeException.exception("something went wrong")
 
-      assert exception.message == "Lua runtime error: something went wrong"
+      assert Exception.message(exception) == "Lua runtime error: something went wrong"
       assert exception.original == nil
       assert exception.state == nil
     end
@@ -204,7 +204,7 @@ defmodule Lua.RuntimeExceptionTest do
     test "trims whitespace from binary error" do
       exception = RuntimeException.exception("  error with spaces  \n")
 
-      assert exception.message == "Lua runtime error: error with spaces"
+      assert Exception.message(exception) == "Lua runtime error: error with spaces"
       assert exception.original == nil
       assert exception.state == nil
     end
@@ -212,7 +212,7 @@ defmodule Lua.RuntimeExceptionTest do
     test "handles empty binary string" do
       exception = RuntimeException.exception("")
 
-      assert exception.message == "Lua runtime error: "
+      assert Exception.message(exception) == "Lua runtime error: "
       assert exception.original == nil
       assert exception.state == nil
     end
@@ -225,7 +225,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error_message)
 
-      assert exception.message == "Lua runtime error: multi-line error\nwith details"
+      assert Exception.message(exception) == "Lua runtime error: multi-line error\nwith details"
       assert exception.original == nil
       assert exception.state == nil
     end
@@ -237,7 +237,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message == "Lua runtime error: invalid argument"
+      assert Exception.message(exception) == "Lua runtime error: invalid argument"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -247,7 +247,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message == "Lua runtime error: runtime failure"
+      assert Exception.message(exception) == "Lua runtime error: runtime failure"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -257,8 +257,8 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message =~ "Lua runtime error:"
-      assert exception.message =~ "key :missing not found"
+      assert Exception.message(exception) =~ "Lua runtime error:"
+      assert Exception.message(exception) =~ "key :missing not found"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -266,7 +266,7 @@ defmodule Lua.RuntimeExceptionTest do
     test "handles non-exception atom" do
       exception = RuntimeException.exception(:some_error)
 
-      assert exception.message == "Lua runtime error: :some_error"
+      assert Exception.message(exception) == "Lua runtime error: :some_error"
       assert exception.original == :some_error
       assert exception.state == nil
     end
@@ -274,7 +274,7 @@ defmodule Lua.RuntimeExceptionTest do
     test "handles non-exception integer" do
       exception = RuntimeException.exception(42)
 
-      assert exception.message == "Lua runtime error: 42"
+      assert Exception.message(exception) == "Lua runtime error: 42"
       assert exception.original == 42
       assert exception.state == nil
     end
@@ -284,7 +284,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message == "Lua runtime error: {:error, :not_found}"
+      assert Exception.message(exception) == "Lua runtime error: {:error, :not_found}"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -294,7 +294,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message == "Lua runtime error: %{code: 404, message: \"not found\"}"
+      assert Exception.message(exception) == "Lua runtime error: %{code: 404, message: \"not found\"}"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -312,8 +312,8 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(error)
 
-      assert exception.message =~ "Lua runtime error:"
-      assert exception.message =~ "MyModule.my_func/2"
+      assert Exception.message(exception) =~ "Lua runtime error:"
+      assert Exception.message(exception) =~ "MyModule.my_func/2"
       assert exception.original == error
       assert exception.state == nil
     end
@@ -328,7 +328,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "error"
         )
 
-      assert exception.message =~ "test() failed"
+      assert Exception.message(exception) =~ "test() failed"
     end
 
     test "formats function with single element scope" do
@@ -339,7 +339,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "error"
         )
 
-      assert exception.message =~ "module.func() failed"
+      assert Exception.message(exception) =~ "module.func() failed"
     end
 
     test "formats function with nested scope" do
@@ -350,7 +350,7 @@ defmodule Lua.RuntimeExceptionTest do
           message: "error"
         )
 
-      assert exception.message =~ "a.b.c.method() failed"
+      assert Exception.message(exception) =~ "a.b.c.method() failed"
     end
   end
 
@@ -440,34 +440,32 @@ defmodule Lua.RuntimeExceptionTest do
     test "binary clause does not double-prefix" do
       exception = RuntimeException.exception("Lua runtime error: already prefixed")
 
-      assert exception.message == "Lua runtime error: already prefixed"
+      assert Exception.message(exception) == "Lua runtime error: already prefixed"
     end
 
     test "binary clause trims then guards" do
       exception = RuntimeException.exception("  Lua runtime error: trimmed  \n")
 
-      assert exception.message == "Lua runtime error: trimmed"
+      assert Exception.message(exception) == "Lua runtime error: trimmed"
     end
 
     test "lua_error tuple clause does not double-prefix" do
       exception =
         RuntimeException.exception({:lua_error, "Lua runtime error: from inner error", State.new()})
 
-      assert exception.message == "Lua runtime error: from inner error"
+      assert Exception.message(exception) == "Lua runtime error: from inner error"
     end
 
-    test "catch-all clause does not double-prefix when wrapping a VM exception" do
-      inner =
-        Lua.VM.RuntimeError.exception(
-          value: "boom",
-          source: "t.lua",
-          line: 3,
-          message: "Lua runtime error: boom"
-        )
+    test "catch-all clause prefixes a wrapped VM exception exactly once" do
+      inner = Lua.VM.RuntimeError.exception(value: "boom", source: "t.lua", line: 3)
 
-      exception = RuntimeException.exception(inner)
+      message = Exception.message(RuntimeException.exception(inner))
 
-      assert exception.message == "Lua runtime error: boom"
+      # A VM exception's rendered message never starts with the runtime prefix,
+      # so wrapping it adds exactly one — never a doubled chain.
+      assert String.starts_with?(message, "Lua runtime error: ")
+      refute message =~ "Lua runtime error: Lua runtime error:"
+      assert message =~ "runtime error: boom"
     end
 
     test "catch-all clause does not double-prefix when wrapping a built-in exception" do
@@ -475,7 +473,7 @@ defmodule Lua.RuntimeExceptionTest do
 
       exception = RuntimeException.exception(inner)
 
-      assert exception.message == "Lua runtime error: already wrapped"
+      assert Exception.message(exception) == "Lua runtime error: already wrapped"
     end
 
     test "keyword list clause still prefixes (inner never starts with prefix)" do
@@ -486,13 +484,13 @@ defmodule Lua.RuntimeExceptionTest do
           message: "boom"
         )
 
-      assert exception.message == "Lua runtime error: m.f() failed, boom"
+      assert Exception.message(exception) == "Lua runtime error: m.f() failed, boom"
     end
 
     test "binary clause still prefixes plain messages" do
       exception = RuntimeException.exception("plain message")
 
-      assert exception.message == "Lua runtime error: plain message"
+      assert Exception.message(exception) == "Lua runtime error: plain message"
     end
   end
 


### PR DESCRIPTION
## Problem

Closes #384. Follow-up to #382 / #385 — same root cause, one level deeper.

Every Lua exception computed its fully-formatted, ANSI-colored message **eagerly in `exception/1`** and stored it. Construction happens during VM execution, where `IO.ANSI.enabled?/0` is true, so `ErrorFormatter.color/2` (and the parser formatter) emitted escape codes that got **frozen into the struct**. Later — in a log file, container stdout, or a Sentry/AppSignal title — the codes (and the multi-line render) survived, because the TTY gate fired at build time and never again at the point output is written.

```elixir
ex = Lua.VM.RuntimeError.exception(value: "kaboom", source: "demo", line: 1)
Application.put_env(:elixir, :ansi_enabled, false)
Exception.message(ex)
#=> before: "\e[2mat demo:1:\e[0m\n\n  runtime error: kaboom"   # ANSI survived the gate
#=> after:  "at demo:1:\n\n  runtime error: kaboom"             # gated at render time
```

## Fix

Render at `Exception.message/1` **call time** instead of construction, mirroring the pattern `Lua.VM.ArgumentError` already used.

- **`RuntimeError`, `TypeError`, `AssertionError`** — drop the memoized `:message` field; add a lazy `message/1` that formats from the stored fields.
- **`Lua.RuntimeException` wrapper** — stop memoizing the wrapped exception's render; the generic (VM-wrapping) clause defers to `message/1`. The terminal-independent clauses (`:lua_error`, `:api_error`, keyword-list, binary) still memoize their ANSI-free strings.
- **`CompilerException`** — store structured parse diagnostics + source and render colored lazily via `Parser.Error.format/2`. The `:errors` field now holds **bare, ANSI-free messages** (log-friendly). `parse_chunk/1` and `eval!` feed structured errors via `Parser.parse_structured/1`.

The rendered text is unchanged — only *when* it renders. Multi-line rich output is preserved (matches Elixir's own exceptions); structured/one-line logging remains available via `to_map/2` and the now-clean `:errors` field.

## Lua semantics unaffected

pcall/xpcall hand Lua code the `:value`/`:lua_value`/`raw_message` view via `ProtectedCall.error_value/1` — the rich `Exception.message/1` is host-facing only. Protected-call return values are byte-for-byte unchanged (guarded by `pcall_error_value_test.exs`, `pcall_test.exs`).

## Tests

- Tests that read the frozen `:message` struct field now call `Exception.message/1` (`error_messages_test.exs`, `runtime_exception_test.exs`). Removing the frozen field forces the correct accessor.
- Reconciles #385's `error_ansi_test.exs`: the color assertion moves from the `.errors` field to `Exception.message/1` (the field is now ANSI-free by design).
- New `exception_ansi_gating_test.exs` (`async: false`) covers each VM exception, the wrapper, and the parse path in both ANSI directions (off → no escapes, on → escapes) — proving a gate, not a strip.

Full suite: **2590 passed, 7 skipped, 30 excluded** (+10 new).

## Note — minor breaking change

The `:message` struct **field** is removed from `Lua.VM.RuntimeError`/`TypeError`/`AssertionError` and is `nil` on the `RuntimeException` wrapper when it wraps a VM exception. Consumers must use `Exception.message/1` (the idiomatic accessor) rather than reading `e.message` directly. This is the correction that makes the gate work; it lands before the 1.0 freeze.