### PR TITLE
docs: fix exception-handling examples and Lua.new option doctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ rescue
     e.line    # => 2
     e.source  # => "<eval>" (chunk name)
 
-    # Render the message with Exception.message/1. The :message struct field
-    # is nil when the exception wraps a VM error — the frame is built lazily
-    # so ANSI color is gated on the terminal at output time. It's a formatted,
-    # colorized frame (ANSI codes elided here):
     #
     #   Lua runtime error: at <eval>:2:
     #

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ rescue
     e.line    # => 2
     e.source  # => "<eval>" (chunk name)
 
-    # e.message is a formatted, colorized frame (ANSI codes elided here):
+    # Render the message with Exception.message/1. The :message struct field
+    # is nil when the exception wraps a VM error — the frame is built lazily
+    # so ANSI color is gated on the terminal at output time. It's a formatted,
+    # colorized frame (ANSI codes elided here):
     #
-    #   Lua runtime error: Runtime Error
-    #
-    #     at <eval>:2:
+    #   Lua runtime error: at <eval>:2:
     #
     #     runtime error: something went wrong
-    e.message
+    Exception.message(e)
 end
 ```
 

--- a/lib/lua.ex
+++ b/lib/lua.ex
@@ -96,10 +96,10 @@ defmodule Lua do
     bounds tail recursion too — including loops that PUC-Lua would run indefinitely. Leave the
     default `:infinity` if you rely on unbounded tail recursion.
 
-      iex> lua = Lua.new(max_call_depth: 10)
-      iex> {[false, message], _lua} = Lua.eval!(lua, "local function f() return f() end return pcall(f)")
-      iex> message =~ "stack overflow"
-      true
+        iex> lua = Lua.new(max_call_depth: 10)
+        iex> {[false, message], _lua} = Lua.eval!(lua, "local function f() return f() end return pcall(f)")
+        iex> message =~ "stack overflow"
+        true
 
   * `:max_string_bytes` - (default 256 MiB) ceiling for any single string the VM will build,
     whether via `..`, `string.rep`, or a `load` reader. An oversized result raises a catchable
@@ -112,10 +112,10 @@ defmodule Lua do
     heap cap mid-allocation, where the kill depends on garbage-collection timing rather than
     a deterministic refusal.
 
-      iex> lua = Lua.new(max_string_bytes: 1024)
-      iex> {[false, message], _lua} = Lua.eval!(lua, "return pcall(string.rep, \\"x\\", 2048)")
-      iex> message =~ "resulting string too large"
-      true
+        iex> lua = Lua.new(max_string_bytes: 1024)
+        iex> {[false, message], _lua} = Lua.eval!(lua, "return pcall(string.rep, 'x', 2048)")
+        iex> message =~ "resulting string too large"
+        true
 
   * `:max_instructions` - (default `:infinity`) caps the number of VM instructions a single
     evaluation may execute. When a script exceeds this budget, a catchable
@@ -125,10 +125,10 @@ defmodule Lua do
     back-edges and call boundaries, so the default `:infinity` path carries no per-instruction
     cost. The budget is fresh per top-level evaluation and recoverable via `pcall`.
 
-      iex> lua = Lua.new(max_instructions: 1000)
-      iex> {[false, message], _lua} = Lua.eval!(lua, "return pcall(function() while true do end end)")
-      iex> message =~ "instruction budget exceeded"
-      true
+        iex> lua = Lua.new(max_instructions: 1000)
+        iex> {[false, message], _lua} = Lua.eval!(lua, "return pcall(function() while true do end end)")
+        iex> message =~ "instruction budget exceeded"
+        true
   """
   @spec new(keyword()) :: t()
   def new(opts \\ []) do

--- a/website/lib/website_web/snippets.ex
+++ b/website/lib/website_web/snippets.ex
@@ -54,10 +54,10 @@ defmodule DemoWeb.Snippets do
 
       lua = Lua.new()
 
-      {:error, err} =
-        Lua.eval(lua, "return os.execute('rm -rf /')")
-
-      # err.message =~ "attempted to call"
+      # Calling a sandboxed function raises.
+      Lua.eval!(lua, "return os.execute('rm -rf /')")
+      # ** (Lua.RuntimeException) Lua runtime error:
+      #    os.execute(_) is sandboxed
       """
     },
     %{
@@ -75,7 +75,7 @@ defmodule DemoWeb.Snippets do
       lua = Lua.new() |> Lua.load_api(Agent.Tools)
 
       # The model emits Lua. You run it. Done.
-      {:ok, {results, _}} = Lua.eval(lua, llm_script)
+      {results, _lua} = Lua.eval!(lua, llm_script)
       """
     }
   ]
@@ -179,7 +179,7 @@ defmodule DemoWeb.Snippets do
 
   # The agent emits Lua. You run it. It can only
   # do what you exposed -- nothing else.
-  {:ok, {result, _lua}} = Lua.eval(lua, agent_script)
+  {result, _lua} = Lua.eval!(lua, agent_script)
   """
 
   @tvlabs_remote_api """


### PR DESCRIPTION
## What

Fixes three classes of documentation mistake around exception handling and doctest rendering. All examples were verified by running them.

### 1. README: `e.message` returns `nil`

The "Error messages with source and line" tour rescued a `Lua.RuntimeException` from `error("...")` and read `e.message`. Since #384, that field is `nil` when the exception wraps a VM error — the message is rendered lazily via `Exception.message/1`. Switched the example to the accessor.

The illustrative comment was also wrong: it showed a `Runtime Error` title line the formatter never emits. Corrected to the actual (ANSI-elided) frame:

```
Lua runtime error: at <eval>:2:

  runtime error: something went wrong
```

`e.line`/`e.source` were already correct and are unchanged.

### 2. `Lua.new/1` option doctests rendered as plain text

The three `## Options` doctests (`:max_call_depth`, `:max_string_bytes`, `:max_instructions`) were indented 6 spaces. Nested under 2-space bullets, a code block needs **8 spaces** — so Markdown/ExDoc rendered them as lazy continuation paragraphs instead of highlighted code blocks. Re-indented all three (confirmed via `mix docs` that each now renders inside a `<pre>` block within its bullet).

Also replaced the double-escaped `\"x\"` in the `:max_string_bytes` example with a single-quoted Lua string (`'x'`) so it renders cleanly.

### 3. Marketing snippets used a function that doesn't exist

`website/.../snippets.ex` called `Lua.eval/2` (only `Lua.eval!/2` exists) in three places, and the sandbox snippet read the nil `.message` field with the wrong expected substring. Rewrote to idiomatic `Lua.eval!/2` (correct `{results, lua}` shape; the sandbox one now shows the raise, matching `os.execute(_) is sandboxed`).

## Verification

- `mix test --only doctest` — 49 pass (the three re-indented `Lua.new/1` doctests included).
- `mix docs` — the three option examples now render as code blocks; `\"x\"` escaping gone.
- `mix format --check-formatted lib/lua.ex` — clean.
- Website compiles.
