### PR TITLE
lexer/parser: report non-ASCII unexpected chars as valid UTF-8

### DIFF
--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -268,9 +268,16 @@ defmodule Lua.Lexer do
     scan_identifier(<<c, rest::binary>>, "", acc, pos, pos)
   end
 
-  # Unexpected character
-  defp do_tokenize(<<c, _rest::binary>>, _acc, pos) do
-    {:error, {:unexpected_character, c, pos}}
+  # Unexpected character — carry the full codepoint so error messages stay
+  # valid UTF-8 even for multibyte characters (a byte-level match would keep
+  # only the UTF-8 lead byte).
+  defp do_tokenize(<<cp::utf8, _rest::binary>>, _acc, pos) do
+    {:error, {:unexpected_character, cp, pos}}
+  end
+
+  # Genuinely invalid UTF-8 lead byte (no valid codepoint here).
+  defp do_tokenize(<<byte, _rest::binary>>, _acc, pos) do
+    {:error, {:invalid_byte, byte, pos}}
   end
 
   # Scan single-line comment (collect text until newline)
@@ -300,6 +307,10 @@ defmodule Lua.Lexer do
   defp scan_single_line_comment_content(<<>>, text, acc, pos, start_pos) do
     token = {:comment, :single, text, start_pos}
     {:ok, Enum.reverse([{:eof, pos}, token | acc])}
+  end
+
+  defp scan_single_line_comment_content(<<cp::utf8, rest::binary>>, text, acc, pos, start_pos) when cp > 127 do
+    scan_single_line_comment_content(rest, text <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos)
   end
 
   defp scan_single_line_comment_content(<<c, rest::binary>>, text, acc, pos, start_pos) do
@@ -335,6 +346,17 @@ defmodule Lua.Lexer do
 
   defp scan_multiline_comment_text(<<>>, _text, _acc, pos, _start_pos, _level) do
     {:error, {:unclosed_comment, pos}}
+  end
+
+  defp scan_multiline_comment_text(<<cp::utf8, rest::binary>>, text, acc, pos, start_pos, level) when cp > 127 do
+    scan_multiline_comment_text(
+      rest,
+      text <> <<cp::utf8>>,
+      acc,
+      advance_utf8(pos, cp),
+      start_pos,
+      level
+    )
   end
 
   defp scan_multiline_comment_text(<<c, rest::binary>>, text, acc, pos, start_pos, level) do
@@ -433,6 +455,10 @@ defmodule Lua.Lexer do
 
   defp scan_string(<<>>, _str_acc, _acc, pos, _start_pos, _quote) do
     {:error, {:unclosed_string, pos}}
+  end
+
+  defp scan_string(<<cp::utf8, rest::binary>>, str_acc, acc, pos, start_pos, quote) when cp > 127 do
+    scan_string(rest, str_acc <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos, quote)
   end
 
   defp scan_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
@@ -619,6 +645,10 @@ defmodule Lua.Lexer do
 
   defp scan_long_string(<<>>, _str_acc, _acc, pos, _start_pos, _level) do
     {:error, {:unclosed_long_string, pos}}
+  end
+
+  defp scan_long_string(<<cp::utf8, rest::binary>>, str_acc, acc, pos, start_pos, level) when cp > 127 do
+    scan_long_string(rest, str_acc <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos, level)
   end
 
   defp scan_long_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, level) do
@@ -855,6 +885,13 @@ defmodule Lua.Lexer do
   # Position tracking helpers
   defp advance_column(pos, n) do
     %{pos | column: pos.column + n, byte_offset: pos.byte_offset + n}
+  end
+
+  # Advance one display column for a codepoint that occupies its full UTF-8
+  # byte width in the source, so `column` stays per-codepoint while
+  # `byte_offset` stays per-byte.
+  defp advance_utf8(pos, cp) do
+    %{pos | column: pos.column + 1, byte_offset: pos.byte_offset + byte_size(<<cp::utf8>>)}
   end
 
   # Advance one source line, consuming `n` raw bytes (the backslash plus the

--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -1501,11 +1501,20 @@ defmodule Lua.Parser do
        "To use this expression, return it or assign it to a name."}
   end
 
-  defp convert_lexer_error({:unexpected_character, char, pos}, _code) do
-    Error.new(:invalid_syntax, "Unexpected character: #{<<char>>}", pos,
+  defp convert_lexer_error({:unexpected_character, cp, pos}, _code) do
+    Error.new(:invalid_syntax, "Unexpected character: #{<<cp::utf8>>} (U+#{codepoint_hex(cp)})", pos,
       suggestion: """
       This character is not valid in Lua syntax.
       Check for typos or invisible characters.
+      """
+    )
+  end
+
+  defp convert_lexer_error({:invalid_byte, byte, pos}, _code) do
+    Error.new(:invalid_syntax, "Invalid byte 0x#{byte_hex(byte)}", pos,
+      suggestion: """
+      The source contains a byte that is not valid UTF-8.
+      Check the file encoding.
       """
     )
   end
@@ -1533,6 +1542,14 @@ defmodule Lua.Parser do
 
   defp convert_lexer_error(other, _code) do
     Error.new(:lexer_error, "Lexer error: #{inspect(other)}", nil)
+  end
+
+  defp codepoint_hex(cp) do
+    cp |> Integer.to_string(16) |> String.upcase() |> String.pad_leading(4, "0")
+  end
+
+  defp byte_hex(byte) do
+    byte |> Integer.to_string(16) |> String.upcase() |> String.pad_leading(2, "0")
   end
 
   defp suggest_for_token_error(type, message) do

--- a/lib/lua/parser/error.ex
+++ b/lib/lua/parser/error.ex
@@ -155,7 +155,9 @@ defmodule Lua.Parser.Error do
   The shape is identical to the map produced for runtime errors, so runtime
   and parse errors can flow through a single renderer (HTML, JSON, structured
   logs). No ANSI escapes appear in any string field, and leading/trailing
-  whitespace from the internal message/suggestion templates is trimmed.
+  whitespace from the internal message/suggestion templates is trimmed. Every
+  string field is valid UTF-8 and safe to `Jason.encode!/1` — even when the
+  offending source token is a non-ASCII or malformed byte.
 
       %{
         type: atom(),
@@ -200,7 +202,7 @@ defmodule Lua.Parser.Error do
   end
 
   defp clean(nil), do: nil
-  defp clean(text) when is_binary(text), do: String.trim(text)
+  defp clean(text) when is_binary(text), do: text |> String.replace_invalid() |> String.trim()
 
   # Deliberately mirrors `Lua.VM.ErrorFormatter`'s private source-context
   # windowing (same 2-before/2-after math) to keep the wire shapes in lockstep.
@@ -222,7 +224,9 @@ defmodule Lua.Parser.Error do
         |> Enum.slice((start_line - 1)..(end_line - 1))
         |> Enum.with_index(start_line)
         |> Enum.map(fn {text, num} ->
-          %{number: num, text: text, highlight?: num == line}
+          # Source may contain malformed bytes; scrub so the wire map stays
+          # valid UTF-8 and JSON-encodable.
+          %{number: num, text: String.replace_invalid(text), highlight?: num == line}
         end)
 
       %{lines: rendered_lines, pointer_column: position.column}

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -714,6 +714,40 @@ defmodule Lua.LexerTest do
       assert {:error, {:unexpected_character, ?`, _}} = Lexer.tokenize("`")
     end
 
+    test "carries the full codepoint for a multibyte unexpected character" do
+      # A box-drawing char (U+2502, bytes E2 94 82) must be reported by its
+      # whole codepoint, not just the UTF-8 lead byte.
+      assert {:error, {:unexpected_character, 0x2502, _}} = Lexer.tokenize("│")
+    end
+
+    test "reports a genuinely invalid UTF-8 byte separately" do
+      assert {:error, {:invalid_byte, 0xFF, _}} = Lexer.tokenize(<<0xFF>>)
+    end
+
+    test "counts a multibyte character as one column inside a string" do
+      # `column` advances per codepoint while `byte_offset` stays per byte, so
+      # a 2-byte `é` in the string body must not overcount the column of the
+      # following unexpected `@`.
+      {:error, {:unexpected_character, ?@, ascii_pos}} = Lexer.tokenize(~s("cafe" @))
+      {:error, {:unexpected_character, ?@, utf8_pos}} = Lexer.tokenize(~s("café" @))
+      assert ascii_pos.column == utf8_pos.column
+      assert utf8_pos.byte_offset == ascii_pos.byte_offset + 1
+    end
+
+    test "counts a multibyte character as one column inside a comment" do
+      {:error, {:unexpected_character, ?@, ascii_pos}} = Lexer.tokenize("--[[a]]@")
+      {:error, {:unexpected_character, ?@, utf8_pos}} = Lexer.tokenize("--[[é]]@")
+      assert ascii_pos.column == utf8_pos.column
+      assert utf8_pos.byte_offset == ascii_pos.byte_offset + 1
+    end
+
+    test "counts a multibyte character as one column inside a long string" do
+      {:error, {:unexpected_character, ?@, ascii_pos}} = Lexer.tokenize("[[a]]@")
+      {:error, {:unexpected_character, ?@, utf8_pos}} = Lexer.tokenize("[[é]]@")
+      assert ascii_pos.column == utf8_pos.column
+      assert utf8_pos.byte_offset == ascii_pos.byte_offset + 1
+    end
+
     test "handles consecutive operators" do
       assert {:ok, tokens} = Lexer.tokenize("+-*/")
 

--- a/test/lua/parser/error_to_map_test.exs
+++ b/test/lua/parser/error_to_map_test.exs
@@ -130,8 +130,38 @@ defmodule Lua.Parser.ErrorToMapTest do
     end
   end
 
+  describe "UTF-8 wire safety" do
+    # Valid UTF-8 in every string field is what makes the map JSON-encodable;
+    # the library carries no JSON dependency, so we assert the invariant directly.
+    test "a multibyte unexpected character produces a valid, wire-safe message" do
+      code = "local x = │"
+      map = code |> error!() |> Error.to_map(code)
+
+      assert String.valid?(map.message)
+      assert map.message =~ "U+2502"
+      assert_all_strings_valid(map)
+    end
+
+    test "every string field stays valid UTF-8 when the source has malformed bytes" do
+      code = <<"local x = ", 0xFF>>
+      map = code |> error!() |> Error.to_map(code)
+
+      assert map.message == "Invalid byte 0xFF"
+      assert_all_strings_valid(map)
+    end
+  end
+
+  defp assert_all_strings_valid(map) do
+    assert String.valid?(map.message)
+    assert String.valid?(map.suggestion || "")
+
+    for line <- map.source_context.lines do
+      assert String.valid?(line.text)
+    end
+  end
+
   defp error!(code) do
-    {:error, [error]} = Parser.parse_structured(code)
+    {:error, [error | _]} = Parser.parse_structured(code)
     error
   end
 end


### PR DESCRIPTION
## Summary

Fixes #394. A non-ASCII "unexpected character" made the parser emit an error whose message was not valid UTF-8, crashing any consumer that JSON-encodes it (e.g. a Sauron LiveView that bricked when a box-drawing character was pasted in).

The lexer matched a single **byte** for an unexpected character, so a multibyte UTF-8 char (`│`, `E2 94 82`) was reported by its lone lead byte `0xE2`. The parser spliced that raw byte into `"Unexpected character: #{<<char>>}"`, and `Lua.Parser.Error.to_map/2`'s `message` — despite its "wire-safe" contract — ended in a lone `0xE2`, so `Jason.encode!` raised `invalid byte 0xE2`.

## Changes

All three linked defects from the issue:

1. **Lexer (`lib/lua/lexer.ex`)** — the unexpected-character clause matches `<<cp::utf8, _>>` and carries the full codepoint; a new `{:invalid_byte, byte, pos}` fallback handles genuinely-malformed bytes.
2. **Parser (`lib/lua/parser.ex`)** — renders the codepoint safely via `<<cp::utf8>>` and names it `U+XXXX` (e.g. `Unexpected character: │ (U+2502)`); adds an `:invalid_byte` → `Invalid byte 0xFF` message.
3. **Column counting (`lib/lua/lexer.ex`)** — `advance_utf8/2` advances `column` per codepoint while keeping `byte_offset` per byte, applied to the string, comment, and long-string scanner loops so positions after a multibyte char are correct.

Plus making the **wire-safe guarantee real**: when the *source itself* contains malformed bytes, `to_map/2` previously embedded them in `source_context.lines[].text`. `clean/1` and the source-context builder now scrub with `String.replace_invalid/1`, and the docstring states that every string field is valid UTF-8.

## Tests

- `test/lua/lexer_test.exs` — multibyte unexpected char → `{:unexpected_character, 0x2502, _}`; invalid byte → `{:invalid_byte, 0xFF, _}`; multibyte char counts as one column inside strings/comments/long strings (with `byte_offset` +1).
- `test/lua/parser/error_to_map_test.exs` — regression: the issue repro and a malformed-byte source both yield maps where every string field is valid UTF-8 (the invariant that makes the map JSON-encodable — the library carries no JSON dependency).

## Verification

- `mix test` — full suite green (2618 passed, 7 skipped); `mix format` clean.
- Differential check against `luac -p`: line numbers agree; the rendered message is strictly friendlier than PUC-Lua's own byte-oriented `<\226>`.