### PR TITLE
lexer: slice tokens from the source binary; drop per-char position maps

### DIFF
--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -3,6 +3,17 @@ defmodule Lua.Lexer do
   Hand-written lexer for Lua 5.3 using Elixir binary pattern matching.
 
   Tokenizes Lua source code into a list of tokens with position tracking.
+
+  Position is threaded as three bare integers instead of a map: the current
+  line, the byte offset the current line's columns are measured from, and the
+  current byte offset. A position map is materialized only when a token or an
+  error is emitted. `line_start` absorbs the continuation bytes of multibyte
+  codepoints, so `column` counts codepoints while `byte_offset` counts bytes.
+
+  Token text is sliced out of the source binary with `binary_part/3`. String
+  escapes and long-string end-of-line normalization are the only places where
+  a token's text differs from its source bytes; those fall back to collecting
+  chunks of iodata around the rewritten spans.
   """
 
   import Bitwise
@@ -18,10 +29,12 @@ defmodule Lua.Lexer do
           | {:comment, :single | :multi, String.t(), position()}
           | {:eof, position()}
 
-  @keywords ~w(
-    and break do else elseif end false for function goto if in
-    local nil not or repeat return then true until while
-  )
+  # Signed 64-bit wrap-around constants for integer literals.
+  @uint64_mask 0xFFFFFFFFFFFFFFFF
+  @uint64_modulus 0x10000000000000000
+  @sign_bit 0x8000000000000000
+
+  @compile {:inline, position: 3, utf8_width: 1, chunked_text: 4}
 
   @doc """
   Tokenizes Lua source code into a list of tokens.
@@ -40,9 +53,8 @@ defmodule Lua.Lexer do
   @spec tokenize(String.t()) :: {:ok, [token()]} | {:error, term()}
   def tokenize(code) when is_binary(code) do
     # Handle shebang on first line (Unix convention: #! means interpreter directive)
-    code = strip_shebang(code)
-    pos = %{line: 1, column: 1, byte_offset: 0}
-    do_tokenize(code, [], pos)
+    src = strip_shebang(code)
+    do_tokenize(src, [], src, 1, 0, 0)
   end
 
   # Strip the first line if it looks like a shebang/header directive. Lua's
@@ -62,409 +74,492 @@ defmodule Lua.Lexer do
     end
   end
 
+  # Build the public position map for the given cursor.
+  defp position(line, line_start, offset) do
+    %{line: line, column: offset - line_start + 1, byte_offset: offset}
+  end
+
+  # Byte width of a codepoint's UTF-8 encoding (only called for cp > 127).
+  defp utf8_width(cp) when cp < 0x800, do: 2
+  defp utf8_width(cp) when cp < 0x10000, do: 3
+  defp utf8_width(_cp), do: 4
+
+  # Assemble token text from the trailing raw span plus any earlier chunks.
+  defp chunked_text(src, start, offset, []), do: binary_part(src, start, offset - start)
+
+  defp chunked_text(src, start, offset, chunks) do
+    IO.iodata_to_binary(:lists.reverse([binary_part(src, start, offset - start) | chunks]))
+  end
+
   # End of input
-  defp do_tokenize(<<>>, acc, pos) do
-    {:ok, Enum.reverse([{:eof, pos} | acc])}
+  defp do_tokenize(<<>>, acc, _src, line, line_start, offset) do
+    {:ok, Enum.reverse([{:eof, position(line, line_start, offset)} | acc])}
   end
 
   # Whitespace (space, horizontal tab, vertical tab, form feed).
   # Per Lua 5.3 reference manual §3.1, whitespace is space, tab, newline,
   # carriage return, vertical tab, and form feed. Newline and CR advance
   # the line counter and are handled below.
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in [?\s, ?\t, ?\v, ?\f] do
-    new_pos = advance_column(pos, 1)
-    do_tokenize(rest, acc, new_pos)
+  defp do_tokenize(<<c, rest::binary>>, acc, src, line, line_start, offset) when c in [?\s, ?\t, ?\v, ?\f] do
+    do_tokenize(rest, acc, src, line, line_start, offset + 1)
   end
 
   # Newline (LF)
-  defp do_tokenize(<<?\n, rest::binary>>, acc, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    do_tokenize(rest, acc, new_pos)
+  defp do_tokenize(<<?\n, rest::binary>>, acc, src, line, _line_start, offset) do
+    do_tokenize(rest, acc, src, line + 1, offset + 1, offset + 1)
   end
 
   # Carriage return (CR, or CRLF)
-  defp do_tokenize(<<?\r, ?\n, rest::binary>>, acc, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
-    do_tokenize(rest, acc, new_pos)
+  defp do_tokenize(<<?\r, ?\n, rest::binary>>, acc, src, line, _line_start, offset) do
+    do_tokenize(rest, acc, src, line + 1, offset + 2, offset + 2)
   end
 
-  defp do_tokenize(<<?\r, rest::binary>>, acc, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    do_tokenize(rest, acc, new_pos)
+  defp do_tokenize(<<?\r, rest::binary>>, acc, src, line, _line_start, offset) do
+    do_tokenize(rest, acc, src, line + 1, offset + 1, offset + 1)
   end
 
   # Comments: single-line (--) or multi-line (--[[ ... ]] or --[=[ ... ]=] etc.)
-  defp do_tokenize(<<"--[", rest::binary>>, acc, pos) do
+  defp do_tokenize(<<"--[", rest::binary>>, acc, src, line, line_start, offset) do
     # scan_long_bracket eats `=` characters then requires a closing `[`,
     # so it correctly detects --[[ (level 0), --[=[ (level 1), --[==[ (level 2), etc.
     case scan_long_bracket(rest, 0) do
       {:ok, equals, after_bracket} ->
-        # Multi-line comment of the given level. The opener spans `--[`, the
+        # Multi-line comment of the given level. The opener is `--[`, the
         # level's `=` signs, and the second `[`.
-        scan_multiline_comment_text(
+        body = offset + 4 + equals
+
+        scan_multiline_comment(
           after_bracket,
-          "",
           acc,
-          advance_column(pos, 4 + equals),
-          pos,
+          src,
+          line,
+          line_start,
+          body,
+          body,
+          position(line, line_start, offset),
           equals
         )
 
       :error ->
         # Single-line comment starting with --[
-        scan_single_line_comment(rest, acc, advance_column(pos, 3), pos)
+        scan_single_line_comment(rest, acc, src, line, line_start, offset + 3, offset + 3, offset)
     end
   end
 
-  defp do_tokenize(<<"--", rest::binary>>, acc, pos) do
-    scan_single_line_comment(rest, acc, advance_column(pos, 2), pos)
+  defp do_tokenize(<<"--", rest::binary>>, acc, src, line, line_start, offset) do
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 2, offset + 2, offset)
   end
 
   # Strings: double-quoted
-  defp do_tokenize(<<?", rest::binary>>, acc, pos) do
-    scan_string(rest, "", acc, advance_column(pos, 1), pos, ?")
+  defp do_tokenize(<<?", rest::binary>>, acc, src, line, line_start, offset) do
+    scan_string(rest, acc, src, line, line_start, offset + 1, offset + 1, [], position(line, line_start, offset), ?")
   end
 
   # Strings: single-quoted
-  defp do_tokenize(<<?', rest::binary>>, acc, pos) do
-    scan_string(rest, "", acc, advance_column(pos, 1), pos, ?')
+  defp do_tokenize(<<?', rest::binary>>, acc, src, line, line_start, offset) do
+    scan_string(rest, acc, src, line, line_start, offset + 1, offset + 1, [], position(line, line_start, offset), ?')
   end
 
   # Strings: multi-line [[ ... ]] or [=[ ... ]=]
-  defp do_tokenize(<<"[", rest::binary>>, acc, pos) do
+  defp do_tokenize(<<"[", rest::binary>>, acc, src, line, line_start, offset) do
     case scan_long_bracket(rest, 0) do
       {:ok, equals, after_bracket} ->
-        start_pos = pos
-        open_pos = advance_column(pos, 2 + equals)
-        {body_rest, body_pos} = drop_leading_newline(after_bracket, open_pos)
-        scan_long_string(body_rest, "", acc, body_pos, start_pos, equals)
+        start_pos = position(line, line_start, offset)
+
+        {body, body_line, body_line_start, body_offset} =
+          drop_leading_newline(after_bracket, line, line_start, offset + 2 + equals)
+
+        scan_long_string(
+          body,
+          acc,
+          src,
+          body_line,
+          body_line_start,
+          body_offset,
+          body_offset,
+          [],
+          start_pos,
+          equals
+        )
 
       :error ->
         # Not a long string, treat as delimiter
-        token = {:delimiter, :lbracket, pos}
-        do_tokenize(rest, [token | acc], advance_column(pos, 1))
+        token = {:delimiter, :lbracket, position(line, line_start, offset)}
+        do_tokenize(rest, [token | acc], src, line, line_start, offset + 1)
     end
   end
 
   # Numbers: hex (0x, 0X)
-  defp do_tokenize(<<"0", x, rest::binary>>, acc, pos) when x in [?x, ?X] do
-    scan_hex_number(rest, "", acc, advance_column(pos, 2), pos)
+  defp do_tokenize(<<"0", x, rest::binary>>, acc, src, line, line_start, offset) when x in [?x, ?X] do
+    scan_hex_int(rest, acc, src, line, line_start, offset + 2, offset + 2, offset)
   end
 
   # Numbers: decimal or float
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in ?0..?9 do
-    scan_number(<<c, rest::binary>>, "", acc, pos, pos)
+  defp do_tokenize(<<c, _rest::binary>> = bin, acc, src, line, line_start, offset) when c in ?0..?9 do
+    scan_int_digits(bin, acc, src, line, line_start, offset, offset)
   end
 
   # Float starting with dot: .0, .5e3, etc.
-  defp do_tokenize(<<".", c, rest::binary>>, acc, pos) when c in ?0..?9 do
-    scan_float(rest, "0." <> <<c>>, acc, advance_column(pos, 2), pos)
+  defp do_tokenize(<<".", c, _rest::binary>> = bin, acc, src, line, line_start, offset) when c in ?0..?9 do
+    scan_int_digits(bin, acc, src, line, line_start, offset, offset)
   end
 
   # Three-character operators
-  defp do_tokenize(<<"...", rest::binary>>, acc, pos) do
-    token = {:operator, :vararg, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 3))
+  defp do_tokenize(<<"...", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :vararg, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 3)
   end
 
   # Two-character operators
-  defp do_tokenize(<<"==", rest::binary>>, acc, pos) do
-    token = {:operator, :eq, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"==", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :eq, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<"~=", rest::binary>>, acc, pos) do
-    token = {:operator, :ne, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"~=", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :ne, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<"<=", rest::binary>>, acc, pos) do
-    token = {:operator, :le, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"<=", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :le, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<">=", rest::binary>>, acc, pos) do
-    token = {:operator, :ge, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<">=", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :ge, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<"..", rest::binary>>, acc, pos) do
-    token = {:operator, :concat, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"..", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :concat, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<"::", rest::binary>>, acc, pos) do
-    token = {:delimiter, :double_colon, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"::", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:delimiter, :double_colon, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<"//", rest::binary>>, acc, pos) do
-    token = {:operator, :floordiv, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"//", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :floordiv, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
   # Bitwise shift operators (must come before single < and >)
-  defp do_tokenize(<<"<<", rest::binary>>, acc, pos) do
-    token = {:operator, :shl, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<"<<", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :shl, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
-  defp do_tokenize(<<">>", rest::binary>>, acc, pos) do
-    token = {:operator, :shr, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 2))
+  defp do_tokenize(<<">>", rest::binary>>, acc, src, line, line_start, offset) do
+    token = {:operator, :shr, position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 2)
   end
 
   # Single-character operators and delimiters
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in [?+, ?-, ?*, ?/, ?%, ?^, ?#, ?&, ?|, ?~] do
-    op =
-      case c do
-        ?+ -> :add
-        ?- -> :sub
-        ?* -> :mul
-        ?/ -> :div
-        ?% -> :mod
-        ?^ -> :pow
-        ?# -> :len
-        ?& -> :band
-        ?| -> :bor
-        ?~ -> :bxor
-      end
-
-    token = {:operator, op, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 1))
+  defp do_tokenize(<<c, rest::binary>>, acc, src, line, line_start, offset)
+       when c in [?+, ?-, ?*, ?/, ?%, ?^, ?#, ?&, ?|, ?~] do
+    token = {:operator, single_operator(c), position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 1)
   end
 
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in [?<, ?>, ?=] do
-    op =
-      case c do
-        ?< -> :lt
-        ?> -> :gt
-        ?= -> :assign
-      end
-
-    token = {:operator, op, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 1))
+  defp do_tokenize(<<c, rest::binary>>, acc, src, line, line_start, offset) when c in [?<, ?>, ?=] do
+    token = {:operator, single_operator(c), position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 1)
   end
 
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in [?(, ?), ?{, ?}, ?], ?;, ?,, ?., ?:] do
-    delim =
-      case c do
-        ?( -> :lparen
-        ?) -> :rparen
-        ?{ -> :lbrace
-        ?} -> :rbrace
-        ?] -> :rbracket
-        ?; -> :semicolon
-        ?, -> :comma
-        ?. -> :dot
-        ?: -> :colon
-      end
-
-    token = {:delimiter, delim, pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 1))
+  defp do_tokenize(<<c, rest::binary>>, acc, src, line, line_start, offset)
+       when c in [?(, ?), ?{, ?}, ?], ?;, ?,, ?., ?:] do
+    token = {:delimiter, single_delimiter(c), position(line, line_start, offset)}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 1)
   end
 
   # Identifiers and keywords
-  defp do_tokenize(<<c, rest::binary>>, acc, pos) when c in ?a..?z or c in ?A..?Z or c == ?_ do
-    scan_identifier(<<c, rest::binary>>, "", acc, pos, pos)
+  defp do_tokenize(<<c, rest::binary>>, acc, src, line, line_start, offset) when c in ?a..?z or c in ?A..?Z or c == ?_ do
+    {after_id, len} = scan_identifier(rest, 1)
+    text = binary_part(src, offset, len)
+    start_pos = position(line, line_start, offset)
+
+    token =
+      case keyword_atom(text) do
+        {:ok, keyword} -> {:keyword, keyword, start_pos}
+        :error -> {:identifier, text, start_pos}
+      end
+
+    do_tokenize(after_id, [token | acc], src, line, line_start, offset + len)
   end
 
   # Unexpected character — carry the full codepoint so error messages stay
   # valid UTF-8 even for multibyte characters (a byte-level match would keep
   # only the UTF-8 lead byte).
-  defp do_tokenize(<<cp::utf8, _rest::binary>>, _acc, pos) do
-    {:error, {:unexpected_character, cp, pos}}
+  defp do_tokenize(<<cp::utf8, _rest::binary>>, _acc, _src, line, line_start, offset) do
+    {:error, {:unexpected_character, cp, position(line, line_start, offset)}}
   end
 
   # Genuinely invalid UTF-8 lead byte (no valid codepoint here).
-  defp do_tokenize(<<byte, _rest::binary>>, _acc, pos) do
-    {:error, {:invalid_byte, byte, pos}}
+  defp do_tokenize(<<byte, _rest::binary>>, _acc, _src, line, line_start, offset) do
+    {:error, {:invalid_byte, byte, position(line, line_start, offset)}}
   end
 
-  # Scan single-line comment (collect text until newline)
-  # pos is the current scanning position (after --), token_pos is where the comment started
-  defp scan_single_line_comment(rest, acc, pos, token_pos) do
-    scan_single_line_comment_content(rest, "", acc, pos, token_pos)
+  defp single_operator(?+), do: :add
+  defp single_operator(?-), do: :sub
+  defp single_operator(?*), do: :mul
+  defp single_operator(?/), do: :div
+  defp single_operator(?%), do: :mod
+  defp single_operator(?^), do: :pow
+  defp single_operator(?#), do: :len
+  defp single_operator(?&), do: :band
+  defp single_operator(?|), do: :bor
+  defp single_operator(?~), do: :bxor
+  defp single_operator(?<), do: :lt
+  defp single_operator(?>), do: :gt
+  defp single_operator(?=), do: :assign
+
+  defp single_delimiter(?(), do: :lparen
+  defp single_delimiter(?)), do: :rparen
+  defp single_delimiter(?{), do: :lbrace
+  defp single_delimiter(?}), do: :rbrace
+  defp single_delimiter(?]), do: :rbracket
+  defp single_delimiter(?;), do: :semicolon
+  defp single_delimiter(?,), do: :comma
+  defp single_delimiter(?.), do: :dot
+  defp single_delimiter(?:), do: :colon
+
+  # Scan single-line comment: the text runs from `text_start` to the newline
+  # (or end of input) and is always a verbatim slice of the source.
+  defp scan_single_line_comment(<<?\n, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
+    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+    do_tokenize(rest, [token | acc], src, line + 1, offset + 1, offset + 1)
   end
 
-  defp scan_single_line_comment_content(<<?\n, rest::binary>>, text, acc, pos, start_pos) do
-    token = {:comment, :single, text, start_pos}
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    do_tokenize(rest, [token | acc], new_pos)
+  defp scan_single_line_comment(<<?\r, ?\n, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
+    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+    do_tokenize(rest, [token | acc], src, line + 1, offset + 2, offset + 2)
   end
 
-  defp scan_single_line_comment_content(<<?\r, ?\n, rest::binary>>, text, acc, pos, start_pos) do
-    token = {:comment, :single, text, start_pos}
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
-    do_tokenize(rest, [token | acc], new_pos)
+  defp scan_single_line_comment(<<?\r, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
+    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+    do_tokenize(rest, [token | acc], src, line + 1, offset + 1, offset + 1)
   end
 
-  defp scan_single_line_comment_content(<<?\r, rest::binary>>, text, acc, pos, start_pos) do
-    token = {:comment, :single, text, start_pos}
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    do_tokenize(rest, [token | acc], new_pos)
+  defp scan_single_line_comment(<<>>, acc, src, line, line_start, offset, text_start, token_start) do
+    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+    {:ok, Enum.reverse([{:eof, position(line, line_start, offset)}, token | acc])}
   end
 
-  defp scan_single_line_comment_content(<<>>, text, acc, pos, start_pos) do
-    token = {:comment, :single, text, start_pos}
-    {:ok, Enum.reverse([{:eof, pos}, token | acc])}
+  defp scan_single_line_comment(<<c, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start)
+       when c < 128 do
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, token_start)
   end
 
-  defp scan_single_line_comment_content(<<cp::utf8, rest::binary>>, text, acc, pos, start_pos) when cp > 127 do
-    scan_single_line_comment_content(rest, text <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos)
+  defp scan_single_line_comment(<<cp::utf8, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start)
+       when cp > 127 do
+    width = utf8_width(cp)
+
+    scan_single_line_comment(
+      rest,
+      acc,
+      src,
+      line,
+      line_start + width - 1,
+      offset + width,
+      text_start,
+      token_start
+    )
   end
 
-  defp scan_single_line_comment_content(<<c, rest::binary>>, text, acc, pos, start_pos) do
-    scan_single_line_comment_content(rest, text <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  defp scan_single_line_comment(<<_c, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, token_start)
+  end
+
+  defp single_comment(src, text_start, offset, start_pos) do
+    {:comment, :single, binary_part(src, text_start, offset - text_start), start_pos}
   end
 
   # Scan multi-line comment body. The opening bracket level was determined by
-  # scan_long_bracket in do_tokenize/3. `pos` is the current scanning position
-  # (right after the opener), `start_pos` is where the comment started.
-  defp scan_multiline_comment_text(<<"]", rest::binary>>, text, acc, pos, start_pos, level) do
+  # scan_long_bracket in do_tokenize/6. The body is a verbatim slice of the
+  # source: no end-of-line normalization applies to comments.
+  defp scan_multiline_comment(<<"]", rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos, level) do
     case try_close_long_bracket(rest, level, 0) do
       {:ok, after_bracket} ->
+        text = binary_part(src, text_start, offset - text_start)
         token = {:comment, :multi, text, start_pos}
-        new_pos = advance_column(pos, 2 + level)
-        do_tokenize(after_bracket, [token | acc], new_pos)
+        do_tokenize(after_bracket, [token | acc], src, line, line_start, offset + 2 + level)
 
       :error ->
-        scan_multiline_comment_text(
-          rest,
-          text <> "]",
-          acc,
-          advance_column(pos, 1),
-          start_pos,
-          level
-        )
+        scan_multiline_comment(rest, acc, src, line, line_start, offset + 1, text_start, start_pos, level)
     end
   end
 
-  defp scan_multiline_comment_text(<<?\n, rest::binary>>, text, acc, pos, start_pos, level) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    scan_multiline_comment_text(rest, text <> "\n", acc, new_pos, start_pos, level)
+  defp scan_multiline_comment(<<?\n, rest::binary>>, acc, src, line, _line_start, offset, text_start, start_pos, level) do
+    scan_multiline_comment(rest, acc, src, line + 1, offset + 1, offset + 1, text_start, start_pos, level)
   end
 
-  defp scan_multiline_comment_text(<<>>, _text, _acc, pos, _start_pos, _level) do
-    {:error, {:unclosed_comment, pos}}
+  defp scan_multiline_comment(<<>>, _acc, _src, line, line_start, offset, _text_start, _start_pos, _level) do
+    {:error, {:unclosed_comment, position(line, line_start, offset)}}
   end
 
-  defp scan_multiline_comment_text(<<cp::utf8, rest::binary>>, text, acc, pos, start_pos, level) when cp > 127 do
-    scan_multiline_comment_text(
+  defp scan_multiline_comment(<<c, rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos, level)
+       when c < 128 do
+    scan_multiline_comment(rest, acc, src, line, line_start, offset + 1, text_start, start_pos, level)
+  end
+
+  defp scan_multiline_comment(
+         <<cp::utf8, rest::binary>>,
+         acc,
+         src,
+         line,
+         line_start,
+         offset,
+         text_start,
+         start_pos,
+         level
+       )
+       when cp > 127 do
+    width = utf8_width(cp)
+
+    scan_multiline_comment(
       rest,
-      text <> <<cp::utf8>>,
       acc,
-      advance_utf8(pos, cp),
+      src,
+      line,
+      line_start + width - 1,
+      offset + width,
+      text_start,
       start_pos,
       level
     )
   end
 
-  defp scan_multiline_comment_text(<<c, rest::binary>>, text, acc, pos, start_pos, level) do
-    scan_multiline_comment_text(
-      rest,
-      text <> <<c>>,
-      acc,
-      advance_column(pos, 1),
-      start_pos,
-      level
-    )
+  defp scan_multiline_comment(<<_c, rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos, level) do
+    scan_multiline_comment(rest, acc, src, line, line_start, offset + 1, text_start, start_pos, level)
   end
 
-  # Scan quoted string
-  defp scan_string(<<quote, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
+  # Scan quoted string. `chunk` is the offset where the current verbatim span
+  # of the string body starts; `chunks` holds the already-rewritten prefix in
+  # reverse order and stays empty for the common escape-free string.
+  defp scan_string(<<quote, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote) do
     # Closing quote
-    token = {:string, str_acc, start_pos}
-    do_tokenize(rest, [token | acc], advance_column(pos, 1))
+    token = {:string, chunked_text(src, chunk, offset, chunks), start_pos}
+    do_tokenize(rest, [token | acc], src, line, line_start, offset + 1)
   end
 
   # \z escape: skip all following whitespace
-  defp scan_string(<<?\\, ?z, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
-    {remaining, new_pos} = skip_whitespace_in_string(rest, advance_column(pos, 2))
-    scan_string(remaining, str_acc, acc, new_pos, start_pos, quote)
+  defp scan_string(<<?\\, ?z, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote) do
+    chunks = flush_chunk(src, chunk, offset, chunks)
+    {remaining, line, line_start, offset} = skip_string_whitespace(rest, line, line_start, offset + 2)
+    scan_string(remaining, acc, src, line, line_start, offset, offset, chunks, start_pos, quote)
   end
 
   # \xXX hex escape: exactly two hex digits
-  defp scan_string(<<?\\, ?x, h1, h2, rest::binary>>, str_acc, acc, pos, start_pos, quote)
+  defp scan_string(<<?\\, ?x, h1, h2, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote)
        when h1 in ?0..?9 or h1 in ?a..?f or h1 in ?A..?F do
     if hex?(h2) do
       byte = hex_value(h1) * 16 + hex_value(h2)
-      scan_string(rest, str_acc <> <<byte>>, acc, advance_column(pos, 4), start_pos, quote)
+      chunks = [<<byte>> | flush_chunk(src, chunk, offset, chunks)]
+      scan_string(rest, acc, src, line, line_start, offset + 4, offset + 4, chunks, start_pos, quote)
     else
-      {:error, {:invalid_escape, pos}}
+      {:error, {:invalid_escape, position(line, line_start, offset)}}
     end
   end
 
-  defp scan_string(<<?\\, ?x, _rest::binary>>, _str_acc, _acc, pos, _start_pos, _quote) do
-    {:error, {:invalid_escape, pos}}
+  defp scan_string(<<?\\, ?x, _rest::binary>>, _acc, _src, line, line_start, offset, _chunk, _chunks, _start_pos, _quote) do
+    {:error, {:invalid_escape, position(line, line_start, offset)}}
   end
 
   # \u{XXX} unicode escape (UTF-8 encoded codepoint)
-  defp scan_string(<<?\\, ?u, ?{, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
+  defp scan_string(<<?\\, ?u, ?{, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote) do
     case scan_unicode_escape(rest, 0, 0) do
-      {:ok, codepoint, digits, after_brace} when codepoint <= 0x7FFFFFFF ->
-        utf8 = encode_lua_utf8(codepoint)
-        # consumed: `\u{` plus `digits`, which already counts the closing `}`
-        scan_string(after_brace, str_acc <> utf8, acc, advance_column(pos, 3 + digits), start_pos, quote)
+      {:ok, codepoint, inner_len, after_brace} when codepoint <= 0x7FFFFFFF ->
+        chunks = [encode_lua_utf8(codepoint) | flush_chunk(src, chunk, offset, chunks)]
+        # consumed: `\u{` plus the digits and the closing `}`
+        offset = offset + 3 + inner_len
+        scan_string(after_brace, acc, src, line, line_start, offset, offset, chunks, start_pos, quote)
 
       _ ->
-        {:error, {:invalid_escape, pos}}
+        {:error, {:invalid_escape, position(line, line_start, offset)}}
     end
   end
 
   # \ddd decimal escape: 1-3 decimal digits, value must fit in a byte
-  defp scan_string(<<?\\, d1, rest::binary>>, str_acc, acc, pos, start_pos, quote) when d1 in ?0..?9 do
+  defp scan_string(<<?\\, d1, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote)
+       when d1 in ?0..?9 do
     {value, digits, remaining} = read_decimal_escape(d1 - ?0, 1, rest)
 
     if value > 255 do
-      {:error, {:invalid_escape, pos}}
+      {:error, {:invalid_escape, position(line, line_start, offset)}}
     else
-      scan_string(remaining, str_acc <> <<value>>, acc, advance_column(pos, 1 + digits), start_pos, quote)
+      chunks = [<<value>> | flush_chunk(src, chunk, offset, chunks)]
+      offset = offset + 1 + digits
+      scan_string(remaining, acc, src, line, line_start, offset, offset, chunks, start_pos, quote)
     end
   end
 
   # \<newline> line continuation: a backslash before a real end-of-line yields a
   # single \n byte and advances one line. All four line endings (\n, \r, \r\n,
   # \n\r) collapse to one newline, matching PUC-Lua's `read_string`.
-  defp scan_string(<<?\\, ?\r, ?\n, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
-    scan_string(rest, str_acc <> "\n", acc, advance_string_line(pos, 3), start_pos, quote)
+  defp scan_string(<<?\\, ?\r, ?\n, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, quote) do
+    continue_string_line(rest, acc, src, line, offset, 3, chunk, chunks, start_pos, quote)
   end
 
-  defp scan_string(<<?\\, ?\n, ?\r, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
-    scan_string(rest, str_acc <> "\n", acc, advance_string_line(pos, 3), start_pos, quote)
+  defp scan_string(<<?\\, ?\n, ?\r, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, quote) do
+    continue_string_line(rest, acc, src, line, offset, 3, chunk, chunks, start_pos, quote)
   end
 
-  defp scan_string(<<?\\, nl, rest::binary>>, str_acc, acc, pos, start_pos, quote) when nl in [?\n, ?\r] do
-    scan_string(rest, str_acc <> "\n", acc, advance_string_line(pos, 2), start_pos, quote)
+  defp scan_string(<<?\\, nl, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, quote)
+       when nl in [?\n, ?\r] do
+    continue_string_line(rest, acc, src, line, offset, 2, chunk, chunks, start_pos, quote)
   end
 
-  defp scan_string(<<?\\, esc, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
+  defp scan_string(<<?\\, esc, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote) do
     # Escape sequence
     case escape_char(esc) do
       {:ok, char} ->
-        scan_string(rest, str_acc <> <<char>>, acc, advance_column(pos, 2), start_pos, quote)
+        chunks = [<<char>> | flush_chunk(src, chunk, offset, chunks)]
+        scan_string(rest, acc, src, line, line_start, offset + 2, offset + 2, chunks, start_pos, quote)
 
       :error ->
-        # Invalid escape, but continue scanning
-        scan_string(rest, str_acc <> <<?\\, esc>>, acc, advance_column(pos, 2), start_pos, quote)
+        # Invalid escape, but continue scanning — the backslash and the
+        # following byte are kept verbatim, so the span needs no rewriting.
+        scan_string(rest, acc, src, line, line_start, offset + 2, chunk, chunks, start_pos, quote)
     end
   end
 
-  defp scan_string(<<?\n, _rest::binary>>, _str_acc, _acc, pos, _start_pos, _quote) do
-    {:error, {:unclosed_string, pos}}
+  defp scan_string(<<?\n, _rest::binary>>, _acc, _src, line, line_start, offset, _chunk, _chunks, _start_pos, _quote) do
+    {:error, {:unclosed_string, position(line, line_start, offset)}}
   end
 
-  defp scan_string(<<>>, _str_acc, _acc, pos, _start_pos, _quote) do
-    {:error, {:unclosed_string, pos}}
+  defp scan_string(<<>>, _acc, _src, line, line_start, offset, _chunk, _chunks, _start_pos, _quote) do
+    {:error, {:unclosed_string, position(line, line_start, offset)}}
   end
 
-  defp scan_string(<<cp::utf8, rest::binary>>, str_acc, acc, pos, start_pos, quote) when cp > 127 do
-    scan_string(rest, str_acc <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos, quote)
+  defp scan_string(<<c, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote)
+       when c < 128 do
+    scan_string(rest, acc, src, line, line_start, offset + 1, chunk, chunks, start_pos, quote)
   end
 
-  defp scan_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
-    scan_string(rest, str_acc <> <<c>>, acc, advance_column(pos, 1), start_pos, quote)
+  defp scan_string(<<cp::utf8, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote)
+       when cp > 127 do
+    width = utf8_width(cp)
+    scan_string(rest, acc, src, line, line_start + width - 1, offset + width, chunk, chunks, start_pos, quote)
   end
+
+  defp scan_string(<<_c, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote) do
+    scan_string(rest, acc, src, line, line_start, offset + 1, chunk, chunks, start_pos, quote)
+  end
+
+  # A \<newline> continuation contributes one "\n" byte and starts a new line
+  # after `consumed` raw source bytes.
+  defp continue_string_line(rest, acc, src, line, offset, consumed, chunk, chunks, start_pos, quote) do
+    chunks = ["\n" | flush_chunk(src, chunk, offset, chunks)]
+    offset = offset + consumed
+    scan_string(rest, acc, src, line + 1, offset, offset, offset, chunks, start_pos, quote)
+  end
+
+  # Close the current verbatim span before a rewritten one is appended.
+  defp flush_chunk(_src, chunk, offset, chunks) when chunk == offset, do: chunks
+  defp flush_chunk(src, chunk, offset, chunks), do: [binary_part(src, chunk, offset - chunk) | chunks]
 
   # Read up to two more decimal digits for a \ddd escape
   defp read_decimal_escape(value, digits, <<d, rest::binary>>) when d in ?0..?9 and digits < 3 do
@@ -479,7 +574,8 @@ defmodule Lua.Lexer do
 
   defp read_decimal_escape(value, digits, rest), do: {value, digits, rest}
 
-  # Read hex digits inside \u{...}
+  # Read hex digits inside \u{...}. The reported length covers the digits and
+  # the closing brace, i.e. everything after the opening `\u{`.
   defp scan_unicode_escape(<<?}, rest::binary>>, value, digits) when digits > 0 do
     {:ok, value, digits + 1, rest}
   end
@@ -544,39 +640,20 @@ defmodule Lua.Lexer do
   defp escape_char(_), do: :error
 
   # Helper for \z escape: skip all whitespace characters
-  defp skip_whitespace_in_string(<<?\s, rest::binary>>, pos) do
-    skip_whitespace_in_string(rest, advance_column(pos, 1))
+  defp skip_string_whitespace(<<c, rest::binary>>, line, line_start, offset) when c in [?\s, ?\t, ?\v, ?\f] do
+    skip_string_whitespace(rest, line, line_start, offset + 1)
   end
 
-  defp skip_whitespace_in_string(<<?\t, rest::binary>>, pos) do
-    skip_whitespace_in_string(rest, advance_column(pos, 1))
+  defp skip_string_whitespace(<<?\r, ?\n, rest::binary>>, line, _line_start, offset) do
+    skip_string_whitespace(rest, line + 1, offset + 2, offset + 2)
   end
 
-  defp skip_whitespace_in_string(<<?\v, rest::binary>>, pos) do
-    skip_whitespace_in_string(rest, advance_column(pos, 1))
+  defp skip_string_whitespace(<<c, rest::binary>>, line, _line_start, offset) when c in [?\n, ?\r] do
+    skip_string_whitespace(rest, line + 1, offset + 1, offset + 1)
   end
 
-  defp skip_whitespace_in_string(<<?\f, rest::binary>>, pos) do
-    skip_whitespace_in_string(rest, advance_column(pos, 1))
-  end
-
-  defp skip_whitespace_in_string(<<?\n, rest::binary>>, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    skip_whitespace_in_string(rest, new_pos)
-  end
-
-  defp skip_whitespace_in_string(<<?\r, ?\n, rest::binary>>, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
-    skip_whitespace_in_string(rest, new_pos)
-  end
-
-  defp skip_whitespace_in_string(<<?\r, rest::binary>>, pos) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    skip_whitespace_in_string(rest, new_pos)
-  end
-
-  defp skip_whitespace_in_string(rest, pos) do
-    {rest, pos}
+  defp skip_string_whitespace(rest, line, line_start, offset) do
+    {rest, line, line_start, offset}
   end
 
   # Scan long bracket for level: [[ or [=[ or [==[ etc.
@@ -615,289 +692,335 @@ defmodule Lua.Lexer do
   end
 
   # Scan long string [[ ... ]] or [=[ ... ]=]
-  defp scan_long_string(<<"]", rest::binary>>, str_acc, acc, pos, start_pos, level) do
+  defp scan_long_string(<<"]", rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, level) do
     case try_close_long_bracket(rest, level, 0) do
       {:ok, after_bracket} ->
-        token = {:string, str_acc, start_pos}
-        new_pos = advance_column(pos, 2 + level)
-        do_tokenize(after_bracket, [token | acc], new_pos)
+        token = {:string, chunked_text(src, chunk, offset, chunks), start_pos}
+        do_tokenize(after_bracket, [token | acc], src, line, line_start, offset + 2 + level)
 
       :error ->
-        scan_long_string(rest, str_acc <> "]", acc, advance_column(pos, 1), start_pos, level)
+        scan_long_string(rest, acc, src, line, line_start, offset + 1, chunk, chunks, start_pos, level)
     end
   end
 
   # Per Lua 5.3 §3.1, long strings normalize end-of-line sequences (`\r`,
-  # `\n`, `\r\n`, `\n\r`) to a single `\n`.
-  defp scan_long_string(<<?\r, ?\n, rest::binary>>, str_acc, acc, pos, start_pos, level) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
-    scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
+  # `\n`, `\r\n`, `\n\r`) to a single `\n`. A bare `\n` already is that
+  # normal form, so only the other three break the verbatim span.
+  defp scan_long_string(<<?\r, ?\n, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, level) do
+    long_string_newline(rest, acc, src, line, offset, 2, chunk, chunks, start_pos, level)
   end
 
-  defp scan_long_string(<<?\n, ?\r, rest::binary>>, str_acc, acc, pos, start_pos, level) do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}
-    scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
+  defp scan_long_string(<<?\n, ?\r, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, level) do
+    long_string_newline(rest, acc, src, line, offset, 2, chunk, chunks, start_pos, level)
   end
 
-  defp scan_long_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, level) when c == ?\n or c == ?\r do
-    new_pos = %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}
-    scan_long_string(rest, str_acc <> "\n", acc, new_pos, start_pos, level)
+  defp scan_long_string(<<?\n, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, level) do
+    scan_long_string(rest, acc, src, line + 1, offset + 1, offset + 1, chunk, chunks, start_pos, level)
   end
 
-  defp scan_long_string(<<>>, _str_acc, _acc, pos, _start_pos, _level) do
-    {:error, {:unclosed_long_string, pos}}
+  defp scan_long_string(<<?\r, rest::binary>>, acc, src, line, _line_start, offset, chunk, chunks, start_pos, level) do
+    long_string_newline(rest, acc, src, line, offset, 1, chunk, chunks, start_pos, level)
   end
 
-  defp scan_long_string(<<cp::utf8, rest::binary>>, str_acc, acc, pos, start_pos, level) when cp > 127 do
-    scan_long_string(rest, str_acc <> <<cp::utf8>>, acc, advance_utf8(pos, cp), start_pos, level)
+  defp scan_long_string(<<>>, _acc, _src, line, line_start, offset, _chunk, _chunks, _start_pos, _level) do
+    {:error, {:unclosed_long_string, position(line, line_start, offset)}}
   end
 
-  defp scan_long_string(<<c, rest::binary>>, str_acc, acc, pos, start_pos, level) do
-    scan_long_string(rest, str_acc <> <<c>>, acc, advance_column(pos, 1), start_pos, level)
+  defp scan_long_string(<<c, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, level)
+       when c < 128 do
+    scan_long_string(rest, acc, src, line, line_start, offset + 1, chunk, chunks, start_pos, level)
+  end
+
+  defp scan_long_string(<<cp::utf8, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, level)
+       when cp > 127 do
+    width = utf8_width(cp)
+    scan_long_string(rest, acc, src, line, line_start + width - 1, offset + width, chunk, chunks, start_pos, level)
+  end
+
+  defp scan_long_string(<<_c, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, level) do
+    scan_long_string(rest, acc, src, line, line_start, offset + 1, chunk, chunks, start_pos, level)
+  end
+
+  # An end-of-line sequence other than a bare `\n` becomes a single "\n".
+  defp long_string_newline(rest, acc, src, line, offset, consumed, chunk, chunks, start_pos, level) do
+    chunks = ["\n" | flush_chunk(src, chunk, offset, chunks)]
+    offset = offset + consumed
+    scan_long_string(rest, acc, src, line + 1, offset, offset, offset, chunks, start_pos, level)
   end
 
   # Per Lua 5.3 §3.1: "when the opening long bracket is immediately followed
   # by a newline, the newline is not included in the string." Applies to any
   # line-break sequence (`\n`, `\r`, `\r\n`, `\n\r`).
-  defp drop_leading_newline(<<?\r, ?\n, rest::binary>>, pos),
-    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}}
+  defp drop_leading_newline(<<?\r, ?\n, rest::binary>>, line, _line_start, offset),
+    do: {rest, line + 1, offset + 2, offset + 2}
 
-  defp drop_leading_newline(<<?\n, ?\r, rest::binary>>, pos),
-    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 2}}
+  defp drop_leading_newline(<<?\n, ?\r, rest::binary>>, line, _line_start, offset),
+    do: {rest, line + 1, offset + 2, offset + 2}
 
-  defp drop_leading_newline(<<c, rest::binary>>, pos) when c == ?\n or c == ?\r,
-    do: {rest, %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + 1}}
+  defp drop_leading_newline(<<c, rest::binary>>, line, _line_start, offset) when c == ?\n or c == ?\r,
+    do: {rest, line + 1, offset + 1, offset + 1}
 
-  defp drop_leading_newline(rest, pos), do: {rest, pos}
+  defp drop_leading_newline(rest, line, line_start, offset), do: {rest, line, line_start, offset}
 
-  # Scan identifier or keyword
-  defp scan_identifier(<<c, rest::binary>>, id_acc, acc, pos, start_pos)
-       when c in ?a..?z or c in ?A..?Z or c in ?0..?9 or c == ?_ do
-    scan_identifier(rest, id_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  # Scan identifier or keyword — only the length is collected, the text is
+  # then sliced out of the source binary in one go.
+  defp scan_identifier(<<c, rest::binary>>, len) when c in ?a..?z or c in ?A..?Z or c in ?0..?9 or c == ?_ do
+    scan_identifier(rest, len + 1)
   end
 
-  defp scan_identifier(rest, id_acc, acc, pos, start_pos) do
-    # Check if it's a keyword
-    token =
-      if id_acc in @keywords do
-        {:keyword, String.to_atom(id_acc), start_pos}
-      else
-        {:identifier, id_acc, start_pos}
-      end
+  defp scan_identifier(rest, len), do: {rest, len}
 
-    do_tokenize(rest, [token | acc], pos)
+  # Reserved words. Compiled into a binary decision tree, so a non-keyword
+  # identifier falls through without any sequential comparison or atom
+  # conversion. The results are wrapped because `nil` and `false` are
+  # themselves keyword atoms.
+  defp keyword_atom("and"), do: {:ok, :and}
+  defp keyword_atom("break"), do: {:ok, :break}
+  defp keyword_atom("do"), do: {:ok, :do}
+  defp keyword_atom("else"), do: {:ok, :else}
+  defp keyword_atom("elseif"), do: {:ok, :elseif}
+  defp keyword_atom("end"), do: {:ok, :end}
+  defp keyword_atom("false"), do: {:ok, false}
+  defp keyword_atom("for"), do: {:ok, :for}
+  defp keyword_atom("function"), do: {:ok, :function}
+  defp keyword_atom("goto"), do: {:ok, :goto}
+  defp keyword_atom("if"), do: {:ok, :if}
+  defp keyword_atom("in"), do: {:ok, :in}
+  defp keyword_atom("local"), do: {:ok, :local}
+  defp keyword_atom("nil"), do: {:ok, nil}
+  defp keyword_atom("not"), do: {:ok, :not}
+  defp keyword_atom("or"), do: {:ok, :or}
+  defp keyword_atom("repeat"), do: {:ok, :repeat}
+  defp keyword_atom("return"), do: {:ok, :return}
+  defp keyword_atom("then"), do: {:ok, :then}
+  defp keyword_atom("true"), do: {:ok, true}
+  defp keyword_atom("until"), do: {:ok, :until}
+  defp keyword_atom("while"), do: {:ok, :while}
+  defp keyword_atom(_), do: :error
+
+  # Scan decimal number. `token_start` is the byte offset of the first
+  # character of the literal; the digit runs are measured against it and the
+  # value is converted straight from the source bytes.
+  defp scan_int_digits(<<c, rest::binary>>, acc, src, line, line_start, offset, token_start) when c in ?0..?9 do
+    scan_int_digits(rest, acc, src, line, line_start, offset + 1, token_start)
   end
 
-  # Scan decimal number
-  defp scan_number(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in ?0..?9 do
-    scan_number(rest, num_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  # ".." is the concat operator, not a decimal point: 0..5 → 0 .. 5
+  defp scan_int_digits(<<"..", _rest::binary>> = bin, acc, src, line, line_start, offset, token_start) do
+    emit_integer(bin, acc, src, line, line_start, offset, token_start)
   end
 
-  defp scan_number(<<".", c, rest::binary>>, num_acc, acc, pos, start_pos) when c in ?0..?9 do
-    # Decimal point with digit following: 0.5
-    scan_float(rest, num_acc <> "." <> <<c>>, acc, advance_column(pos, 2), start_pos)
+  defp scan_int_digits(<<".", rest::binary>>, acc, src, line, line_start, offset, token_start) do
+    scan_frac_digits(rest, acc, src, line, line_start, offset + 1, token_start, offset - token_start, offset + 1)
   end
 
-  defp scan_number(<<"..", _rest::binary>> = rest, num_acc, acc, pos, start_pos) do
-    # ".." is concat operator, not a decimal point: 0..5 → 0 .. 5
-    finalize_number(num_acc, rest, acc, pos, start_pos)
+  # Scientific notation without a decimal point: 1e5
+  defp scan_int_digits(<<c, rest::binary>>, acc, src, line, line_start, offset, token_start) when c in [?e, ?E] do
+    mantissa = binary_part(src, token_start, offset - token_start) <> ".0"
+    scan_exponent(rest, acc, src, line, line_start, offset + 1, token_start, mantissa)
   end
 
-  defp scan_number(<<".", c, rest::binary>>, num_acc, acc, pos, start_pos) when c in [?e, ?E] do
-    # "0.e5" → float with exponent
-    scan_float(<<c, rest::binary>>, num_acc <> ".", acc, advance_column(pos, 1), start_pos)
+  defp scan_int_digits(bin, acc, src, line, line_start, offset, token_start) do
+    emit_integer(bin, acc, src, line, line_start, offset, token_start)
   end
 
-  defp scan_number(<<".", rest::binary>>, num_acc, acc, pos, start_pos) do
-    # Trailing dot makes it a float: 0. → 0.0
-    scan_float(rest, num_acc <> ".", acc, advance_column(pos, 1), start_pos)
+  # Scan the fractional digits after a decimal point.
+  defp scan_frac_digits(<<c, rest::binary>>, acc, src, line, line_start, offset, token_start, int_len, frac_start)
+       when c in ?0..?9 do
+    scan_frac_digits(rest, acc, src, line, line_start, offset + 1, token_start, int_len, frac_start)
   end
 
-  defp scan_number(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in [?e, ?E] do
-    # Scientific notation
-    scan_exponent(<<c, rest::binary>>, num_acc, acc, pos, start_pos)
+  defp scan_frac_digits(<<c, rest::binary>>, acc, src, line, line_start, offset, token_start, int_len, frac_start)
+       when c in [?e, ?E] do
+    mantissa = mantissa_binary(src, token_start, int_len, frac_start, offset - frac_start)
+    scan_exponent(rest, acc, src, line, line_start, offset + 1, token_start, mantissa)
   end
 
-  defp scan_number(rest, num_acc, acc, pos, start_pos) do
-    finalize_number(num_acc, rest, acc, pos, start_pos)
+  defp scan_frac_digits(bin, acc, src, line, line_start, offset, token_start, int_len, frac_start) do
+    mantissa = mantissa_binary(src, token_start, int_len, frac_start, offset - frac_start)
+    emit_float(bin, acc, src, line, line_start, offset, token_start, mantissa)
   end
 
-  # Scan float part (after decimal point)
-  defp scan_float(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in ?0..?9 do
-    scan_float(rest, num_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  # Scan the exponent of a decimal float. `mantissa` is already normalized to
+  # a form Erlang's binary_to_float/1 accepts (digits on both sides of a dot).
+  defp scan_exponent(<<sign, rest::binary>>, acc, src, line, line_start, offset, token_start, mantissa)
+       when sign in [?+, ?-] do
+    scan_exponent_digits(rest, acc, src, line, line_start, offset + 1, token_start, mantissa <> <<?e, sign>>, offset + 1)
   end
 
-  defp scan_float(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in [?e, ?E] do
-    scan_exponent(<<c, rest::binary>>, num_acc, acc, pos, start_pos)
+  defp scan_exponent(bin, acc, src, line, line_start, offset, token_start, mantissa) do
+    scan_exponent_digits(bin, acc, src, line, line_start, offset, token_start, mantissa <> "e", offset)
   end
 
-  defp scan_float(rest, num_acc, acc, pos, start_pos) do
-    finalize_number(num_acc, rest, acc, pos, start_pos)
+  defp scan_exponent_digits(<<c, rest::binary>>, acc, src, line, line_start, offset, token_start, mantissa, digit_start)
+       when c in ?0..?9 do
+    scan_exponent_digits(rest, acc, src, line, line_start, offset + 1, token_start, mantissa, digit_start)
   end
 
-  # Scan scientific notation exponent
-  defp scan_exponent(<<c, sign, rest::binary>>, num_acc, acc, pos, start_pos) when c in [?e, ?E] and sign in [?+, ?-] do
-    scan_exponent_digits(rest, num_acc <> <<c, sign>>, acc, advance_column(pos, 2), start_pos)
+  # An exponent marker with no digits after it is a malformed number.
+  defp scan_exponent_digits(_bin, _acc, _src, line, line_start, offset, token_start, _mantissa, digit_start)
+       when offset == digit_start do
+    {:error, {:invalid_number, position(line, line_start, token_start)}}
   end
 
-  defp scan_exponent(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in [?e, ?E] do
-    scan_exponent_digits(rest, num_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  defp scan_exponent_digits(bin, acc, src, line, line_start, offset, token_start, mantissa, digit_start) do
+    literal = mantissa <> binary_part(src, digit_start, offset - digit_start)
+    emit_float(bin, acc, src, line, line_start, offset, token_start, literal)
   end
 
-  defp scan_exponent_digits(<<c, rest::binary>>, num_acc, acc, pos, start_pos) when c in ?0..?9 do
-    scan_exponent_digits(rest, num_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  # Normalize the mantissa so Erlang's strict float syntax accepts it: digits
+  # are required on both sides of the decimal point.
+  defp mantissa_binary(src, token_start, int_len, _frac_start, 0) when int_len > 0 do
+    binary_part(src, token_start, int_len) <> ".0"
   end
 
-  defp scan_exponent_digits(rest, num_acc, acc, pos, start_pos) do
-    finalize_number(num_acc, rest, acc, pos, start_pos)
+  defp mantissa_binary(src, _token_start, 0, frac_start, frac_len) when frac_len > 0 do
+    "0." <> binary_part(src, frac_start, frac_len)
+  end
+
+  defp mantissa_binary(src, token_start, int_len, _frac_start, frac_len) when int_len > 0 and frac_len > 0 do
+    binary_part(src, token_start, int_len + 1 + frac_len)
+  end
+
+  defp mantissa_binary(_src, _token_start, _int_len, _frac_start, _frac_len), do: "0.0"
+
+  defp emit_integer(bin, acc, src, line, line_start, offset, token_start) do
+    value = :erlang.binary_to_integer(binary_part(src, token_start, offset - token_start))
+
+    # Lua 5.3.3 §3.1: a decimal integer literal that overflows the signed
+    # 64-bit range converts to a float (a leading sign is a separate token,
+    # so `value` here is always the non-negative magnitude). Hex integer
+    # literals instead wrap via wrap_int64; this branch is decimal only.
+    # @sign_bit is 2^63, i.e. max_int + 1, so `>= @sign_bit` means overflow.
+    number = if value >= @sign_bit, do: value * 1.0, else: value
+    token = {:number, number, position(line, line_start, token_start)}
+    do_tokenize(bin, [token | acc], src, line, line_start, offset)
+  end
+
+  defp emit_float(bin, acc, src, line, line_start, offset, token_start, literal) do
+    case parse_float(literal) do
+      {:ok, value} ->
+        token = {:number, value, position(line, line_start, token_start)}
+        do_tokenize(bin, [token | acc], src, line, line_start, offset)
+
+      :error ->
+        {:error, {:invalid_number, position(line, line_start, token_start)}}
+    end
+  end
+
+  # The literal is always well-formed by construction; the only way this can
+  # fail is a magnitude outside the double range, e.g. `1e400`.
+  defp parse_float(literal) do
+    {:ok, :erlang.binary_to_float(literal)}
+  rescue
+    ArgumentError -> :error
   end
 
   # Scan hexadecimal number (0x...) — supports integers, hex floats (0xF0.0), and exponents (0xABCp-3)
-  defp scan_hex_number(<<c, rest::binary>>, hex_acc, acc, pos, start_pos)
+  defp scan_hex_int(<<c, rest::binary>>, acc, src, line, line_start, offset, digit_start, token_start)
        when c in ?0..?9 or c in ?a..?f or c in ?A..?F do
-    scan_hex_number(rest, hex_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+    scan_hex_int(rest, acc, src, line, line_start, offset + 1, digit_start, token_start)
   end
 
   # Hex float: dot followed by hex digits
-  defp scan_hex_number(<<".", rest::binary>>, hex_acc, acc, pos, start_pos) do
-    scan_hex_frac(rest, hex_acc, "", acc, advance_column(pos, 1), start_pos)
+  defp scan_hex_int(<<".", rest::binary>>, acc, src, line, line_start, offset, digit_start, token_start) do
+    int_hex = binary_part(src, digit_start, offset - digit_start)
+    scan_hex_frac(rest, acc, src, line, line_start, offset + 1, offset + 1, int_hex, token_start)
   end
 
   # Hex float: binary exponent (p/P)
-  defp scan_hex_number(<<p, rest::binary>>, hex_acc, acc, pos, start_pos) when p in [?p, ?P] do
-    scan_hex_exp(rest, hex_acc, "", acc, advance_column(pos, 1), start_pos)
+  defp scan_hex_int(<<p, rest::binary>>, acc, src, line, line_start, offset, digit_start, token_start)
+       when p in [?p, ?P] do
+    int_hex = binary_part(src, digit_start, offset - digit_start)
+    scan_hex_exponent(rest, acc, src, line, line_start, offset + 1, int_hex, "", token_start)
   end
 
-  defp scan_hex_number(rest, hex_acc, acc, pos, start_pos) do
-    case Integer.parse(hex_acc, 16) do
-      {num, ""} ->
-        # Per Lua 5.3 §3.1: hex integer literals overflow-wrap into the
-        # signed 64-bit range. e.g. 0xFFFFFFFFFFFFFFFF == -1.
-        token = {:number, wrap_int64(num), start_pos}
-        do_tokenize(rest, [token | acc], pos)
+  defp scan_hex_int(bin, acc, src, line, line_start, offset, digit_start, token_start) when offset > digit_start do
+    # Per Lua 5.3 §3.1: hex integer literals overflow-wrap into the
+    # signed 64-bit range. e.g. 0xFFFFFFFFFFFFFFFF == -1.
+    value = wrap_int64(:erlang.binary_to_integer(binary_part(src, digit_start, offset - digit_start), 16))
+    token = {:number, value, position(line, line_start, token_start)}
+    do_tokenize(bin, [token | acc], src, line, line_start, offset)
+  end
 
-      _ ->
-        {:error, {:invalid_hex_number, start_pos}}
-    end
+  defp scan_hex_int(_bin, _acc, _src, line, line_start, _offset, _digit_start, token_start) do
+    {:error, {:invalid_hex_number, position(line, line_start, token_start)}}
   end
 
   # Wrap an unsigned hex integer to the signed 64-bit range. Inlined here so
   # the lexer doesn't depend on Lua.VM.Numeric (kept VM-internal).
-  @uint64_mask 0xFFFFFFFFFFFFFFFF
-  @uint64_modulus 0x10000000000000000
-  @sign_bit 0x8000000000000000
-
   defp wrap_int64(n) when is_integer(n) do
     masked = band(n, @uint64_mask)
     if masked >= @sign_bit, do: masked - @uint64_modulus, else: masked
   end
 
   # Scan hex fractional digits after the dot
-  defp scan_hex_frac(<<c, rest::binary>>, int_acc, frac_acc, acc, pos, start_pos)
+  defp scan_hex_frac(<<c, rest::binary>>, acc, src, line, line_start, offset, frac_start, int_hex, token_start)
        when c in ?0..?9 or c in ?a..?f or c in ?A..?F do
-    scan_hex_frac(rest, int_acc, frac_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+    scan_hex_frac(rest, acc, src, line, line_start, offset + 1, frac_start, int_hex, token_start)
   end
 
   # Hex float fractional part followed by exponent
-  defp scan_hex_frac(<<p, rest::binary>>, int_acc, frac_acc, acc, pos, start_pos) when p in [?p, ?P] do
-    scan_hex_exp(rest, int_acc, frac_acc, acc, advance_column(pos, 1), start_pos)
+  defp scan_hex_frac(<<p, rest::binary>>, acc, src, line, line_start, offset, frac_start, int_hex, token_start)
+       when p in [?p, ?P] do
+    frac_hex = binary_part(src, frac_start, offset - frac_start)
+    scan_hex_exponent(rest, acc, src, line, line_start, offset + 1, int_hex, frac_hex, token_start)
   end
 
   # Hex float fractional part without exponent
-  defp scan_hex_frac(rest, int_acc, frac_acc, acc, pos, start_pos) do
-    num = build_hex_float(int_acc, frac_acc, 0)
-    token = {:number, num, start_pos}
-    do_tokenize(rest, [token | acc], pos)
+  defp scan_hex_frac(bin, acc, src, line, line_start, offset, frac_start, int_hex, token_start) do
+    frac_hex = binary_part(src, frac_start, offset - frac_start)
+    token = {:number, build_hex_float(int_hex, frac_hex, 0), position(line, line_start, token_start)}
+    do_tokenize(bin, [token | acc], src, line, line_start, offset)
   end
 
   # Scan binary exponent (p/P followed by optional sign and decimal digits)
-  defp scan_hex_exp(<<sign, rest::binary>>, int_acc, frac_acc, acc, pos, start_pos) when sign in [?+, ?-] do
-    scan_hex_exp_digits(rest, int_acc, frac_acc, <<sign>>, acc, advance_column(pos, 1), start_pos)
+  defp scan_hex_exponent(<<sign, rest::binary>>, acc, src, line, line_start, offset, int_hex, frac_hex, token_start)
+       when sign in [?+, ?-] do
+    scan_hex_exponent_digits(rest, acc, src, line, line_start, offset + 1, offset, int_hex, frac_hex, token_start)
   end
 
-  defp scan_hex_exp(rest, int_acc, frac_acc, acc, pos, start_pos) do
-    scan_hex_exp_digits(rest, int_acc, frac_acc, "", acc, pos, start_pos)
+  defp scan_hex_exponent(bin, acc, src, line, line_start, offset, int_hex, frac_hex, token_start) do
+    scan_hex_exponent_digits(bin, acc, src, line, line_start, offset, offset, int_hex, frac_hex, token_start)
   end
 
-  defp scan_hex_exp_digits(<<c, rest::binary>>, int_acc, frac_acc, exp_acc, acc, pos, start_pos) when c in ?0..?9 do
-    scan_hex_exp_digits(rest, int_acc, frac_acc, exp_acc <> <<c>>, acc, advance_column(pos, 1), start_pos)
+  defp scan_hex_exponent_digits(
+         <<c, rest::binary>>,
+         acc,
+         src,
+         line,
+         line_start,
+         offset,
+         exp_start,
+         int_hex,
+         frac_hex,
+         token_start
+       )
+       when c in ?0..?9 do
+    scan_hex_exponent_digits(rest, acc, src, line, line_start, offset + 1, exp_start, int_hex, frac_hex, token_start)
   end
 
-  defp scan_hex_exp_digits(rest, int_acc, frac_acc, exp_acc, acc, pos, start_pos) do
-    exp = if exp_acc == "" or exp_acc == "+" or exp_acc == "-", do: 0, else: String.to_integer(exp_acc)
-    num = build_hex_float(int_acc, frac_acc, exp)
-    token = {:number, num, start_pos}
-    do_tokenize(rest, [token | acc], pos)
+  defp scan_hex_exponent_digits(bin, acc, src, line, line_start, offset, exp_start, int_hex, frac_hex, token_start) do
+    exp = hex_exponent_value(binary_part(src, exp_start, offset - exp_start))
+    token = {:number, build_hex_float(int_hex, frac_hex, exp), position(line, line_start, token_start)}
+    do_tokenize(bin, [token | acc], src, line, line_start, offset)
   end
+
+  defp hex_exponent_value(digits) when digits in ["", "+", "-"], do: 0
+  defp hex_exponent_value(digits), do: :erlang.binary_to_integer(digits)
 
   # Build a hex float value from integer hex digits, fractional hex digits, and binary exponent
   defp build_hex_float(int_hex, frac_hex, exp) do
-    int_val = if int_hex == "", do: 0, else: String.to_integer(int_hex, 16)
+    int_val = if int_hex == "", do: 0, else: :erlang.binary_to_integer(int_hex, 16)
 
     frac_val =
       if frac_hex == "" do
         0.0
       else
-        frac_int = String.to_integer(frac_hex, 16)
-        frac_int / :math.pow(16, String.length(frac_hex))
+        frac_int = :erlang.binary_to_integer(frac_hex, 16)
+        frac_int / :math.pow(16, byte_size(frac_hex))
       end
 
     (int_val + frac_val) * :math.pow(2, exp)
-  end
-
-  # Finalize number token
-  defp finalize_number(num_str, rest, acc, pos, start_pos) do
-    case parse_number(num_str) do
-      {:ok, num} ->
-        token = {:number, num, start_pos}
-        do_tokenize(rest, [token | acc], pos)
-
-      {:error, reason} ->
-        {:error, {reason, start_pos}}
-    end
-  end
-
-  # Parse number string to integer or float
-  defp parse_number(num_str) do
-    if String.contains?(num_str, ".") or String.contains?(num_str, "e") or
-         String.contains?(num_str, "E") do
-      # Normalize for Elixir's Float.parse which requires digits after dot
-      normalized = num_str
-      # "0." → "0.0"
-      normalized = if String.ends_with?(normalized, "."), do: normalized <> "0", else: normalized
-      # "2.E-1" → "2.0E-1"
-      normalized = String.replace(normalized, ~r/\.([eE])/, ".0\\1")
-
-      case Float.parse(normalized) do
-        {num, ""} -> {:ok, num}
-        _ -> {:error, :invalid_number}
-      end
-    else
-      {num, ""} = Integer.parse(num_str)
-      # Lua 5.3.3 §3.1: a decimal integer literal that overflows the signed
-      # 64-bit range converts to a float (a leading sign is a separate token,
-      # so `num` here is always the non-negative magnitude). Hex integer
-      # literals instead wrap via wrap_int64; this branch is decimal only.
-      # @sign_bit is 2^63, i.e. max_int + 1, so `>= @sign_bit` means overflow.
-      if num >= @sign_bit, do: {:ok, num * 1.0}, else: {:ok, num}
-    end
-  end
-
-  # Position tracking helpers
-  defp advance_column(pos, n) do
-    %{pos | column: pos.column + n, byte_offset: pos.byte_offset + n}
-  end
-
-  # Advance one display column for a codepoint that occupies its full UTF-8
-  # byte width in the source, so `column` stays per-codepoint while
-  # `byte_offset` stays per-byte.
-  defp advance_utf8(pos, cp) do
-    %{pos | column: pos.column + 1, byte_offset: pos.byte_offset + byte_size(<<cp::utf8>>)}
-  end
-
-  # Advance one source line, consuming `n` raw bytes (the backslash plus the
-  # one- or two-byte line ending of a \<newline> continuation).
-  defp advance_string_line(pos, n) do
-    %{line: pos.line + 1, column: 1, byte_offset: pos.byte_offset + n}
   end
 end

--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -99,12 +99,13 @@ defmodule Lua.Lexer do
     # so it correctly detects --[[ (level 0), --[=[ (level 1), --[==[ (level 2), etc.
     case scan_long_bracket(rest, 0) do
       {:ok, equals, after_bracket} ->
-        # Multi-line comment of the given level
+        # Multi-line comment of the given level. The opener spans `--[`, the
+        # level's `=` signs, and the second `[`.
         scan_multiline_comment_text(
           after_bracket,
           "",
           acc,
-          advance_column(pos, 3 + equals),
+          advance_column(pos, 4 + equals),
           pos,
           equals
         )
@@ -374,7 +375,7 @@ defmodule Lua.Lexer do
   defp scan_string(<<quote, rest::binary>>, str_acc, acc, pos, start_pos, quote) do
     # Closing quote
     token = {:string, str_acc, start_pos}
-    do_tokenize(rest, [token | acc], pos)
+    do_tokenize(rest, [token | acc], advance_column(pos, 1))
   end
 
   # \z escape: skip all following whitespace
@@ -403,8 +404,8 @@ defmodule Lua.Lexer do
     case scan_unicode_escape(rest, 0, 0) do
       {:ok, codepoint, digits, after_brace} when codepoint <= 0x7FFFFFFF ->
         utf8 = encode_lua_utf8(codepoint)
-        # consumed: \u{ + digits + }
-        scan_string(after_brace, str_acc <> utf8, acc, advance_column(pos, 4 + digits), start_pos, quote)
+        # consumed: `\u{` plus `digits`, which already counts the closing `}`
+        scan_string(after_brace, str_acc <> utf8, acc, advance_column(pos, 3 + digits), start_pos, quote)
 
       _ ->
         {:error, {:invalid_escape, pos}}

--- a/lib/lua/lexer.ex
+++ b/lib/lua/lexer.ex
@@ -10,10 +10,12 @@ defmodule Lua.Lexer do
   error is emitted. `line_start` absorbs the continuation bytes of multibyte
   codepoints, so `column` counts codepoints while `byte_offset` counts bytes.
 
-  Token text is sliced out of the source binary with `binary_part/3`. String
-  escapes and long-string end-of-line normalization are the only places where
-  a token's text differs from its source bytes; those fall back to collecting
-  chunks of iodata around the rewritten spans.
+  Token text is sliced out of the source binary with `binary_part/3` and then
+  copied with `:binary.copy/1`, so a retained token never keeps the whole
+  source binary alive. String escapes and long-string end-of-line
+  normalization are the only places where a token's text differs from its
+  source bytes; those fall back to collecting chunks of iodata around the
+  rewritten spans.
   """
 
   import Bitwise
@@ -85,7 +87,9 @@ defmodule Lua.Lexer do
   defp utf8_width(_cp), do: 4
 
   # Assemble token text from the trailing raw span plus any earlier chunks.
-  defp chunked_text(src, start, offset, []), do: binary_part(src, start, offset - start)
+  # The single-slice path copies the sub-binary so a token doesn't keep the
+  # whole source binary alive; the chunked path copies via iodata already.
+  defp chunked_text(src, start, offset, []), do: :binary.copy(binary_part(src, start, offset - start))
 
   defp chunked_text(src, start, offset, chunks) do
     IO.iodata_to_binary(:lists.reverse([binary_part(src, start, offset - start) | chunks]))
@@ -142,12 +146,14 @@ defmodule Lua.Lexer do
 
       :error ->
         # Single-line comment starting with --[
-        scan_single_line_comment(rest, acc, src, line, line_start, offset + 3, offset + 3, offset)
+        start_pos = position(line, line_start, offset)
+        scan_single_line_comment(rest, acc, src, line, line_start, offset + 3, offset + 3, start_pos)
     end
   end
 
   defp do_tokenize(<<"--", rest::binary>>, acc, src, line, line_start, offset) do
-    scan_single_line_comment(rest, acc, src, line, line_start, offset + 2, offset + 2, offset)
+    start_pos = position(line, line_start, offset)
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 2, offset + 2, start_pos)
   end
 
   # Strings: double-quoted
@@ -284,7 +290,8 @@ defmodule Lua.Lexer do
     token =
       case keyword_atom(text) do
         {:ok, keyword} -> {:keyword, keyword, start_pos}
-        :error -> {:identifier, text, start_pos}
+        # Copy the slice so the identifier doesn't keep the source alive.
+        :error -> {:identifier, :binary.copy(text), start_pos}
       end
 
     do_tokenize(after_id, [token | acc], src, line, line_start, offset + len)
@@ -327,33 +334,35 @@ defmodule Lua.Lexer do
   defp single_delimiter(?:), do: :colon
 
   # Scan single-line comment: the text runs from `text_start` to the newline
-  # (or end of input) and is always a verbatim slice of the source.
-  defp scan_single_line_comment(<<?\n, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
-    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+  # (or end of input) and is always a verbatim slice of the source. The start
+  # position is built eagerly by the caller — multibyte codepoints in the body
+  # shift `line_start`, so it can't be reconstructed after scanning.
+  defp scan_single_line_comment(<<?\n, rest::binary>>, acc, src, line, _line_start, offset, text_start, start_pos) do
+    token = single_comment(src, text_start, offset, start_pos)
     do_tokenize(rest, [token | acc], src, line + 1, offset + 1, offset + 1)
   end
 
-  defp scan_single_line_comment(<<?\r, ?\n, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
-    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+  defp scan_single_line_comment(<<?\r, ?\n, rest::binary>>, acc, src, line, _line_start, offset, text_start, start_pos) do
+    token = single_comment(src, text_start, offset, start_pos)
     do_tokenize(rest, [token | acc], src, line + 1, offset + 2, offset + 2)
   end
 
-  defp scan_single_line_comment(<<?\r, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
-    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+  defp scan_single_line_comment(<<?\r, rest::binary>>, acc, src, line, _line_start, offset, text_start, start_pos) do
+    token = single_comment(src, text_start, offset, start_pos)
     do_tokenize(rest, [token | acc], src, line + 1, offset + 1, offset + 1)
   end
 
-  defp scan_single_line_comment(<<>>, acc, src, line, line_start, offset, text_start, token_start) do
-    token = single_comment(src, text_start, offset, position(line, line_start, token_start))
+  defp scan_single_line_comment(<<>>, acc, src, line, line_start, offset, text_start, start_pos) do
+    token = single_comment(src, text_start, offset, start_pos)
     {:ok, Enum.reverse([{:eof, position(line, line_start, offset)}, token | acc])}
   end
 
-  defp scan_single_line_comment(<<c, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start)
+  defp scan_single_line_comment(<<c, rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos)
        when c < 128 do
-    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, token_start)
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, start_pos)
   end
 
-  defp scan_single_line_comment(<<cp::utf8, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start)
+  defp scan_single_line_comment(<<cp::utf8, rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos)
        when cp > 127 do
     width = utf8_width(cp)
 
@@ -365,16 +374,16 @@ defmodule Lua.Lexer do
       line_start + width - 1,
       offset + width,
       text_start,
-      token_start
+      start_pos
     )
   end
 
-  defp scan_single_line_comment(<<_c, rest::binary>>, acc, src, line, line_start, offset, text_start, token_start) do
-    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, token_start)
+  defp scan_single_line_comment(<<_c, rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos) do
+    scan_single_line_comment(rest, acc, src, line, line_start, offset + 1, text_start, start_pos)
   end
 
   defp single_comment(src, text_start, offset, start_pos) do
-    {:comment, :single, binary_part(src, text_start, offset - text_start), start_pos}
+    {:comment, :single, :binary.copy(binary_part(src, text_start, offset - text_start)), start_pos}
   end
 
   # Scan multi-line comment body. The opening bracket level was determined by
@@ -383,7 +392,7 @@ defmodule Lua.Lexer do
   defp scan_multiline_comment(<<"]", rest::binary>>, acc, src, line, line_start, offset, text_start, start_pos, level) do
     case try_close_long_bracket(rest, level, 0) do
       {:ok, after_bracket} ->
-        text = binary_part(src, text_start, offset - text_start)
+        text = :binary.copy(binary_part(src, text_start, offset - text_start))
         token = {:comment, :multi, text, start_pos}
         do_tokenize(after_bracket, [token | acc], src, line, line_start, offset + 2 + level)
 
@@ -482,18 +491,14 @@ defmodule Lua.Lexer do
     end
   end
 
-  # \ddd decimal escape: 1-3 decimal digits, value must fit in a byte
+  # \ddd decimal escape: 1-3 decimal digits. read_decimal_escape/3 stops
+  # before a digit would push the value past 255, so it always fits in a byte.
   defp scan_string(<<?\\, d1, rest::binary>>, acc, src, line, line_start, offset, chunk, chunks, start_pos, quote)
        when d1 in ?0..?9 do
     {value, digits, remaining} = read_decimal_escape(d1 - ?0, 1, rest)
-
-    if value > 255 do
-      {:error, {:invalid_escape, position(line, line_start, offset)}}
-    else
-      chunks = [<<value>> | flush_chunk(src, chunk, offset, chunks)]
-      offset = offset + 1 + digits
-      scan_string(remaining, acc, src, line, line_start, offset, offset, chunks, start_pos, quote)
-    end
+    chunks = [<<value>> | flush_chunk(src, chunk, offset, chunks)]
+    offset = offset + 1 + digits
+    scan_string(remaining, acc, src, line, line_start, offset, offset, chunks, start_pos, quote)
   end
 
   # \<newline> line continuation: a backslash before a real end-of-line yields a

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -789,6 +789,18 @@ defmodule Lua.LexerTest do
       assert utf8_pos.byte_offset == ascii_pos.byte_offset + 1
     end
 
+    test "a multibyte character inside a single-line comment does not shift its start column" do
+      # The comment's start position must reflect where the `--` opener sits,
+      # not be skewed by multibyte codepoints scanned later in the body.
+      assert {:ok, [{:comment, :single, " é", pos} | _]} = Lexer.tokenize("-- é\nx")
+      assert pos == %{line: 1, column: 1, byte_offset: 0}
+
+      assert {:ok, tokens} = Lexer.tokenize("local y = 1 -- é\n")
+
+      assert {:comment, :single, " é", %{line: 1, column: 13, byte_offset: 12}} =
+               Enum.find(tokens, &match?({:comment, _, _, _}, &1))
+    end
+
     test "handles consecutive operators" do
       assert {:ok, tokens} = Lexer.tokenize("+-*/")
 
@@ -1033,6 +1045,52 @@ defmodule Lua.LexerTest do
       code = "{1, 2, x = 3, [\"key\"] = 4}"
       assert {:ok, tokens} = Lexer.tokenize(code)
       assert length(tokens) > 10
+    end
+  end
+
+  describe "token invariants" do
+    test "every token position has line >= 1 and column >= 1 across the Lua 5.3 suite files" do
+      fixtures = Path.wildcard(Path.join(__DIR__, "../lua53_tests/*.lua"))
+      assert fixtures != []
+
+      for file <- fixtures do
+        assert {:ok, tokens} = Lexer.tokenize(File.read!(file))
+
+        for token <- tokens do
+          pos = elem(token, tuple_size(token) - 1)
+
+          assert pos.line >= 1 and pos.column >= 1,
+                 "#{Path.basename(file)}: token #{inspect(token)} has an out-of-range position"
+        end
+      end
+    end
+
+    test "token text does not retain the source binary" do
+      # Sub-binaries over 64 bytes are references into the original binary;
+      # token text must be copied out so retained tokens don't keep a large
+      # source alive. Build a >4KB source with a >64-byte escape-free string
+      # literal and a >64-byte comment, and check each token's text is
+      # backed by exactly its own bytes.
+      long = String.duplicate("a", 100)
+      padding = String.duplicate("local x = 1\n", 400)
+      src = ~s(local s = "#{long}" -- #{long}\n) <> padding
+
+      assert byte_size(src) > 4096
+      assert {:ok, tokens} = Lexer.tokenize(src)
+
+      assert {:string, string_text, _} = Enum.find(tokens, &match?({:string, _, _}, &1))
+      assert byte_size(string_text) > 64
+      assert :binary.referenced_byte_size(string_text) == byte_size(string_text)
+
+      assert {:comment, :single, comment_text, _} =
+               Enum.find(tokens, &match?({:comment, :single, _, _}, &1))
+
+      assert byte_size(comment_text) > 64
+      assert :binary.referenced_byte_size(comment_text) == byte_size(comment_text)
+
+      for {:identifier, text, _} <- tokens do
+        assert :binary.referenced_byte_size(text) == byte_size(text)
+      end
     end
   end
 end

--- a/test/lua/lexer_test.exs
+++ b/test/lua/lexer_test.exs
@@ -616,6 +616,47 @@ defmodule Lua.LexerTest do
 
       assert [{:string, "hello", %{line: 1, column: 1, byte_offset: 0}}, {:eof, _}] = tokens
     end
+
+    test "counts the closing quote of a short string" do
+      code = ~s(local x = "ab" ])
+
+      assert {:ok, tokens} = Lexer.tokenize(code)
+
+      assert [
+               {:keyword, :local, %{column: 1, byte_offset: 0}},
+               {:identifier, "x", %{column: 7, byte_offset: 6}},
+               {:operator, :assign, %{column: 9, byte_offset: 8}},
+               {:string, "ab", %{column: 11, byte_offset: 10}},
+               {:delimiter, :rbracket, %{column: 16, byte_offset: 15}},
+               {:eof, %{column: 17, byte_offset: 16}}
+             ] = tokens
+    end
+
+    test "the eof offset is the size of the source, whatever precedes it" do
+      for code <- [
+            ~s(local x = "ab"),
+            ~s(local x = 'a' .. 'b'),
+            ~s(x = "\\u{41}"),
+            "--[[ comment ]]",
+            "--[==[ comment ]==]",
+            "x = [[long]]"
+          ] do
+        assert {:ok, tokens} = Lexer.tokenize(code)
+        assert {:eof, pos} = List.last(tokens)
+        assert pos.byte_offset == byte_size(code), "wrong eof offset for #{inspect(code)}"
+        assert pos.column == byte_size(code) + 1, "wrong eof column for #{inspect(code)}"
+      end
+    end
+
+    test "counts the whole opener and body of a multi-line comment" do
+      assert {:ok, tokens} = Lexer.tokenize("--[==[ c ]==] x")
+
+      assert [
+               {:comment, :multi, " c ", %{column: 1, byte_offset: 0}},
+               {:identifier, "x", %{column: 15, byte_offset: 14}},
+               {:eof, %{column: 16, byte_offset: 15}}
+             ] = tokens
+    end
   end
 
   describe "complex expressions" do


### PR DESCRIPTION
Rewrites the hot paths of `lib/lua/lexer.ex`. Two commits: the first is a
behavioral fix to position tracking, the second is a pure-performance
rewrite on top of it.

## Why

The lexer allocated far more than it scanned. Per source *character* it
rebuilt a three-key position map (`advance_column/2`, plus sixteen inline
`%{line: ..., column: 1, byte_offset: ...}` literals), and it grew every
token's text one byte at a time with `acc <> <<c>>`. On top of that, each
identifier was compared against the 22 reserved words in sequence and then
run through `String.to_atom/1`, and each number was classified with three
`String.contains?/2` scans and a regex before parsing.

## What changed

**Position** is threaded as three bare integers — line, the byte offset the
current line's columns are measured from, and the current byte offset — and
a position map is materialized only when a token or an error is emitted
(~140 maps instead of ~800 for a 370-byte input). The column base absorbs
the continuation bytes of multibyte codepoints, so `column` still counts
codepoints while `byte_offset` counts bytes; the "multibyte character as one
column" tests are unchanged.

**Token text** is `binary_part/3` out of the source binary. String escapes
and long-string end-of-line normalization are the only cases where a token's
text differs from its source bytes, so those collect iodata chunks around
just the rewritten spans — an escape-free string, an identifier, a number,
and a comment are each a single slice. A bare `\n` inside a long string is
already the normal form, so it does not even break the span.

**Keywords** are pattern-matched function heads, which the compiler turns
into a binary decision tree; a non-keyword identifier now falls through with
no sequential comparison and no atom conversion.

**Numbers** carry their shape (integer / fraction / exponent) out of the
scanner and go straight to `:erlang.binary_to_integer/1` and
`:erlang.binary_to_float/1`. The mantissa is normalized in the scanner,
where the shape is known, rather than by regex afterwards. The
`>= 2^63 → float` decimal rule and `wrap_int64` for hex literals are
unchanged, as is the `{:invalid_number, pos}` error for `1e`, `1e+`, and
out-of-range magnitudes such as `1e400`.

## The bug (first commit)

Three scanners emitted a token and resumed without accounting for bytes they
had just consumed:

* a short string did not advance past its closing quote, so every later
  token on the line was one byte short per preceding string — `local x = "ab" ]`
  reported `]` at column 15 instead of 16;
* a multi-line comment's body was assumed to start after `--[` plus the
  level's `=` signs, forgetting the second `[`;
* a `\u{...}` escape charged `4 + digits` columns, but `digits` already
  counts the closing brace, so it over-advanced by one.

The net effect was that `{:eof, pos}` did not report `byte_size(source)` and
anything slicing the source by `byte_offset` picked up shifted text. **Line
numbers were never affected**, so the luac line-number differential
convention is untouched. No existing test pinned the wrong values;
regression tests are added for all three.

## Verification

* `mix format` clean; full suite green including `--include slow
  --include differential --include lua53` (2642 passing).
* **Behavior preservation.** A scratch harness tokenized every `.lua` file
  in the repo (68 files: fixtures, the integration corpus, the Lua 5.3
  official suite) plus 24 hand-written edge cases — escapes, `\z`, mixed
  `\r`/`\n`/`\r\n`/`\n\r`, hex floats, malformed numbers, unterminated
  tokens, invalid UTF-8, shebangs — with the rewrite and with the *previous*
  lexer carrying only the three position fixes. Every token stream is
  byte-for-byte identical (68/68 files, 24/24 cases).
* **Position correctness.** An independent checker re-derives each token's
  line, column, and byte offset from the source and confirms identifiers and
  keywords slice back to their own text and that `eof.byte_offset ==
  byte_size(source)`. The rewrite passes 65/65 checkable files; the lexer on
  `main` fails 59 of them.

## Numbers

Prod build, median of 20 batched runs, on the playground snippets and two
real files. Absolute times move a few percent between runs with machine
load; the ratios were stable across repeated runs.

| input | bytes | before | after | speedup |
| --- | ---: | ---: | ---: | ---: |
| metatables | 370 | 29.10us | 5.46us | 5.3x |
| fib | 180 | 13.77us | 2.50us | 5.5x |
| tables | 256 | 21.02us | 4.15us | 5.1x |
| literals.lua | 10,339 | 509.33us | 84.53us | 6.0x |
| assertions.lua | 14,361 | 1189.4us | 151.40us | 7.9x |

The metatables snippet's lexer stage goes from ~29us to ~5.5us, against a
target of 7us.

Scope is `lexer.ex` and its tests only; parser and compiler are untouched.
