### PR TITLE
compiler: key scope resolution by node id and dedupe upvalue descriptors

### DIFF
--- a/lib/lua/ast/block.ex
+++ b/lib/lua/ast/block.ex
@@ -25,7 +25,7 @@ defmodule Lua.AST.Block do
       %Lua.AST.Block{stmts: [], meta: nil}
 
       iex> Lua.AST.Block.new([], %Lua.AST.Meta{})
-      %Lua.AST.Block{stmts: [], meta: %Lua.AST.Meta{start: nil, end: nil, metadata: %{}}}
+      %Lua.AST.Block{stmts: [], meta: %Lua.AST.Meta{start: nil, end: nil, metadata: %{}, id: nil}}
   """
   @spec new([Statement.t()], Meta.t() | nil) :: t()
   def new(stmts \\ [], meta \\ nil) do

--- a/lib/lua/ast/ids.ex
+++ b/lib/lua/ast/ids.ex
@@ -1,0 +1,234 @@
+defmodule Lua.AST.Ids do
+  @moduledoc """
+  Stamps AST nodes with chunk-unique identifiers.
+
+  Compiler passes keep per-node tables — which registers a `local` claimed,
+  which upvalue a `Var` resolved to, the close-upvalue watermark of a block.
+  Keying those tables by the node term makes every read and write hash the
+  node's whole subtree, so the deepest nodes (function bodies, blocks) — the
+  ones that make the most useful keys — are also the most expensive ones.
+
+  `assign/1` walks a parsed chunk once and writes a distinct integer into
+  each node's `meta.id`, letting those tables key on a single word instead.
+  Ids are unique across the whole chunk, including the bodies of nested
+  functions.
+  """
+
+  alias Lua.AST.Block
+  alias Lua.AST.Chunk
+  alias Lua.AST.Expr
+  alias Lua.AST.Meta
+  alias Lua.AST.Statement
+
+  @doc """
+  Returns `chunk` with every reachable node stamped with a unique `meta.id`.
+
+  Nodes the parser built without metadata gain a `Lua.AST.Meta` carrying only
+  the id; nodes that already have one keep their positions and comments.
+  """
+  @spec assign(Chunk.t()) :: Chunk.t()
+  def assign(%Chunk{} = chunk) do
+    {chunk, _next_id} = number(chunk, 0)
+    chunk
+  end
+
+  # Children are numbered before their parent, so a node's id is always
+  # greater than every id inside it. Nothing relies on that ordering; it just
+  # falls out of numbering on the way back up.
+
+  defp number(%Chunk{block: block} = node, next) do
+    {block, next} = number(block, next)
+    {%{node | block: block, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Block{stmts: stmts} = node, next) do
+    {stmts, next} = number_list(stmts, next, [])
+    {%{node | stmts: stmts, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  # Expressions
+
+  defp number(%Expr.Nil{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Expr.Bool{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Expr.Number{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Expr.String{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Expr.Var{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Expr.Vararg{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+
+  defp number(%Expr.BinOp{left: left, right: right} = node, next) do
+    {left, next} = number(left, next)
+    {right, next} = number(right, next)
+    {%{node | left: left, right: right, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.UnOp{operand: operand} = node, next) do
+    {operand, next} = number(operand, next)
+    {%{node | operand: operand, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Table{fields: fields} = node, next) do
+    {fields, next} = number_table_fields(fields, next, [])
+    {%{node | fields: fields, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Call{func: func, args: args} = node, next) do
+    {func, next} = number(func, next)
+    {args, next} = number_list(args, next, [])
+    {%{node | func: func, args: args, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.MethodCall{object: object, args: args} = node, next) do
+    {object, next} = number(object, next)
+    {args, next} = number_list(args, next, [])
+    {%{node | object: object, args: args, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Index{table: table, key: key} = node, next) do
+    {table, next} = number(table, next)
+    {key, next} = number(key, next)
+    {%{node | table: table, key: key, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Property{table: table} = node, next) do
+    {table, next} = number(table, next)
+    {%{node | table: table, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Function{body: body} = node, next) do
+    {body, next} = number(body, next)
+    {%{node | body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Expr.Paren{inner: inner} = node, next) do
+    {inner, next} = number(inner, next)
+    {%{node | inner: inner, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  # Statements
+
+  defp number(%Statement.Break{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Statement.Goto{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+  defp number(%Statement.Label{} = node, next), do: {%{node | meta: with_id(node.meta, next)}, next + 1}
+
+  defp number(%Statement.Assign{targets: targets, values: values} = node, next) do
+    {targets, next} = number_list(targets, next, [])
+    {values, next} = number_list(values, next, [])
+    {%{node | targets: targets, values: values, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.Local{values: values} = node, next) do
+    {values, next} = number_list(values, next, [])
+    {%{node | values: values, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.LocalFunc{body: body} = node, next) do
+    {body, next} = number(body, next)
+    {%{node | body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.FuncDecl{body: body} = node, next) do
+    {body, next} = number(body, next)
+    {%{node | body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.CallStmt{call: call} = node, next) do
+    {call, next} = number(call, next)
+    {%{node | call: call, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.If{} = node, next) do
+    %Statement.If{condition: condition, then_block: then_block, elseifs: elseifs, else_block: else_block} = node
+
+    {condition, next} = number(condition, next)
+    {then_block, next} = number(then_block, next)
+    {elseifs, next} = number_elseifs(elseifs, next, [])
+    {else_block, next} = number_optional(else_block, next)
+
+    {%{
+       node
+       | condition: condition,
+         then_block: then_block,
+         elseifs: elseifs,
+         else_block: else_block,
+         meta: with_id(node.meta, next)
+     }, next + 1}
+  end
+
+  defp number(%Statement.While{condition: condition, body: body} = node, next) do
+    {condition, next} = number(condition, next)
+    {body, next} = number(body, next)
+    {%{node | condition: condition, body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.Repeat{body: body, condition: condition} = node, next) do
+    {body, next} = number(body, next)
+    {condition, next} = number(condition, next)
+    {%{node | body: body, condition: condition, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.ForNum{} = node, next) do
+    %Statement.ForNum{start: start, limit: limit, step: step, body: body} = node
+
+    {start, next} = number(start, next)
+    {limit, next} = number(limit, next)
+    {step, next} = number_optional(step, next)
+    {body, next} = number(body, next)
+
+    {%{node | start: start, limit: limit, step: step, body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.ForIn{iterators: iterators, body: body} = node, next) do
+    {iterators, next} = number_list(iterators, next, [])
+    {body, next} = number(body, next)
+    {%{node | iterators: iterators, body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.Do{body: body} = node, next) do
+    {body, next} = number(body, next)
+    {%{node | body: body, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  defp number(%Statement.Return{values: values} = node, next) do
+    {values, next} = number_list(values, next, [])
+    {%{node | values: values, meta: with_id(node.meta, next)}, next + 1}
+  end
+
+  # Any node shape not listed above keeps its metadata untouched. It then has
+  # no id, and the compiler falls back to keying by the node term — slower,
+  # but still correct.
+  defp number(node, next), do: {node, next}
+
+  defp number_optional(nil, next), do: {nil, next}
+  defp number_optional(node, next), do: number(node, next)
+
+  defp number_list([], next, acc), do: {Enum.reverse(acc), next}
+
+  defp number_list([node | rest], next, acc) do
+    {node, next} = number(node, next)
+    number_list(rest, next, [node | acc])
+  end
+
+  defp number_table_fields([], next, acc), do: {Enum.reverse(acc), next}
+
+  defp number_table_fields([{:list, value} | rest], next, acc) do
+    {value, next} = number(value, next)
+    number_table_fields(rest, next, [{:list, value} | acc])
+  end
+
+  defp number_table_fields([{:record, key, value} | rest], next, acc) do
+    {key, next} = number(key, next)
+    {value, next} = number(value, next)
+    number_table_fields(rest, next, [{:record, key, value} | acc])
+  end
+
+  defp number_elseifs([], next, acc), do: {Enum.reverse(acc), next}
+
+  defp number_elseifs([{condition, block} | rest], next, acc) do
+    {condition, next} = number(condition, next)
+    {block, next} = number(block, next)
+    number_elseifs(rest, next, [{condition, block} | acc])
+  end
+
+  defp with_id(nil, id), do: %Meta{id: id}
+  defp with_id(meta, id), do: %{meta | id: id}
+end

--- a/lib/lua/ast/ids.ex
+++ b/lib/lua/ast/ids.ex
@@ -193,10 +193,14 @@ defmodule Lua.AST.Ids do
     {%{node | values: values, meta: with_id(node.meta, next)}, next + 1}
   end
 
-  # Any node shape not listed above keeps its metadata untouched. It then has
-  # no id, and the compiler falls back to keying by the node term — slower,
-  # but still correct.
-  defp number(node, next), do: {node, next}
+  # Every node shape must have a clause above. Silently skipping one would
+  # leave its whole subtree unnumbered, and the compiler's raw-term fallback
+  # key collides for structurally identical subtrees — a miscompile, not a
+  # slowdown — so an unrecognized node fails loudly instead.
+  defp number(node, _next) do
+    raise ArgumentError,
+          "Lua.AST.Ids has no number/2 clause for node: #{inspect(node, limit: 5)}"
+  end
 
   defp number_optional(nil, next), do: {nil, next}
   defp number_optional(node, next), do: number(node, next)

--- a/lib/lua/ast/meta.ex
+++ b/lib/lua/ast/meta.ex
@@ -25,10 +25,21 @@ defmodule Lua.AST.Meta do
   @type t :: %__MODULE__{
           start: position() | nil,
           end: position() | nil,
-          metadata: map()
+          metadata: map(),
+          id: non_neg_integer() | nil
         }
 
-  defstruct start: nil, end: nil, metadata: %{}
+  @typedoc """
+  Chunk-unique identifier for the node carrying this metadata.
+
+  `Lua.AST.Ids.assign/1` stamps every node of a parsed chunk, including the
+  bodies of nested functions. Compiler passes that need a per-node table key
+  it by this integer instead of by the node term, so a lookup hashes one word
+  rather than a whole subtree. It is `nil` on hand-built AST nodes.
+  """
+  @type id :: non_neg_integer() | nil
+
+  defstruct start: nil, end: nil, metadata: %{}, id: nil
 
   @doc """
   Creates a new Meta struct with start and end positions.
@@ -42,7 +53,8 @@ defmodule Lua.AST.Meta do
       %Lua.AST.Meta{
         start: %{line: 1, column: 1, byte_offset: 0},
         end: %{line: 1, column: 5, byte_offset: 4},
-        metadata: %{}
+        metadata: %{},
+        id: nil
       }
   """
   @spec new(position() | nil, position() | nil, map()) :: t()
@@ -63,7 +75,8 @@ defmodule Lua.AST.Meta do
       %Lua.AST.Meta{
         start: %{line: 1, column: 1, byte_offset: 0},
         end: %{line: 1, column: 10, byte_offset: 9},
-        metadata: %{}
+        metadata: %{},
+        id: nil
       }
   """
   @spec merge(t(), t()) :: t()

--- a/lib/lua/ast/meta.ex
+++ b/lib/lua/ast/meta.ex
@@ -35,7 +35,8 @@ defmodule Lua.AST.Meta do
   `Lua.AST.Ids.assign/1` stamps every node of a parsed chunk, including the
   bodies of nested functions. Compiler passes that need a per-node table key
   it by this integer instead of by the node term, so a lookup hashes one word
-  rather than a whole subtree. It is `nil` on hand-built AST nodes.
+  rather than a whole subtree. Hand-built AST nodes carry `nil` until
+  `Lua.Compiler.compile/2` stamps the chunk they belong to.
   """
   @type id :: non_neg_integer() | nil
 
@@ -65,7 +66,9 @@ defmodule Lua.AST.Meta do
   @doc """
   Merges two Meta structs, taking the earliest start and latest end.
 
-  Useful when combining multiple nodes into a single parent node.
+  Useful when combining multiple nodes into a single parent node. The
+  `metadata` (comments) and `id` of the left operand are kept, so merging a
+  wider span into a node never silently drops what was already attached to it.
 
   ## Examples
 
@@ -80,10 +83,12 @@ defmodule Lua.AST.Meta do
       }
   """
   @spec merge(t(), t()) :: t()
-  def merge(%__MODULE__{start: start1, end: end1}, %__MODULE__{start: start2, end: end2}) do
-    new_start = earliest_position(start1, start2)
-    new_end = latest_position(end1, end2)
-    new(new_start, new_end)
+  def merge(%__MODULE__{} = left, %__MODULE__{} = right) do
+    %{
+      left
+      | start: earliest_position(left.start, right.start),
+        end: latest_position(left.end, right.end)
+    }
   end
 
   @doc """

--- a/lib/lua/compiler.ex
+++ b/lib/lua/compiler.ex
@@ -6,6 +6,7 @@ defmodule Lua.Compiler do
   """
 
   alias Lua.AST.Chunk
+  alias Lua.AST.Ids
   alias Lua.Compiler.Bytecode
   alias Lua.Compiler.Codegen
   alias Lua.Compiler.GotoResolution
@@ -29,6 +30,14 @@ defmodule Lua.Compiler do
   """
   @spec compile(Chunk.t(), compile_opts()) :: {:ok, Prototype.t()} | {:error, term()}
   def compile(%Chunk{} = chunk, opts \\ []) do
+    # Scope resolution and codegen key per-node tables by `meta.id` (see
+    # `Lua.AST.Ids`); without ids, structurally identical nodes (e.g. two
+    # empty loop bodies) would share one table entry and miscompile. Stamping
+    # here covers chunks that never went through the parser, such as those
+    # built with `Lua.AST.Builder`. Assignment is deterministic, so a parsed
+    # chunk (already stamped by `Lua.Parser`) re-stamps to the same ids.
+    chunk = Ids.assign(chunk)
+
     with :ok <- GotoValidation.validate(chunk),
          {:ok, scope_state} <- Scope.resolve(chunk, opts),
          {:ok, prototype} <- Codegen.generate(chunk, scope_state, opts) do

--- a/lib/lua/compiler/codegen.ex
+++ b/lib/lua/compiler/codegen.ex
@@ -450,7 +450,7 @@ defmodule Lua.Compiler.Codegen do
 
   defp gen_statement(%Statement.Local{names: names, values: values} = local_stmt, ctx) do
     # Get per-statement register assignments from var_map
-    reg_list = Map.get(ctx.scope.var_map, local_stmt, [])
+    reg_list = Map.get(ctx.scope.var_map, Scope.node_key(local_stmt), [])
     num_names = length(names)
     num_values = length(values)
 
@@ -604,7 +604,7 @@ defmodule Lua.Compiler.Codegen do
     # captured during scope resolution so consecutive `for` loops with the
     # same variable name use distinct registers (issue #146).
     loop_var_reg =
-      Map.get(ctx.scope.var_map, {:for_num_var_reg, for_stmt}, ctx.scope.locals[var])
+      Map.get(ctx.scope.var_map, {:for_num_var_reg, Scope.node_key(for_stmt)}, ctx.scope.locals[var])
 
     # Allocate 3 internal registers for: counter, limit, step
     base = ctx.next_reg
@@ -654,7 +654,11 @@ defmodule Lua.Compiler.Codegen do
     # bindings captured during scope resolution so consecutive `for` loops
     # with the same variable names use distinct registers (issue #146).
     var_regs =
-      Map.get(ctx.scope.var_map, {:for_in_var_regs, for_stmt}, Enum.map(vars, fn name -> ctx.scope.locals[name] end))
+      Map.get(
+        ctx.scope.var_map,
+        {:for_in_var_regs, Scope.node_key(for_stmt)},
+        Enum.map(vars, fn name -> ctx.scope.locals[name] end)
+      )
 
     # Allocate 3 internal registers for: iterator function, invariant state, control variable
     base = ctx.next_reg
@@ -757,7 +761,7 @@ defmodule Lua.Compiler.Codegen do
         # Per Lua 5.3: `function name(...) end` is sugar for `name = function(...) end`.
         # Use the var_map entry resolved by scope analysis.
         {store_instructions, ctx} =
-          case Map.get(ctx.scope.var_map, {:func_decl_target, decl}) do
+          case Map.get(ctx.scope.var_map, {:func_decl_target, Scope.node_key(decl)}) do
             {:register, local_reg} ->
               instrs = if local_reg == closure_reg, do: [], else: [Instruction.move(local_reg, closure_reg)]
               {instrs, ctx}
@@ -773,7 +777,7 @@ defmodule Lua.Compiler.Codegen do
 
             nil ->
               # Should never happen after scope analysis (single-name FuncDecl
-              # always populates {:func_decl_target, decl}).
+              # always populates the `{:func_decl_target, _}` entry).
               raise "codegen: missing var_map entry for FuncDecl target #{inspect(name)}"
           end
 
@@ -804,7 +808,7 @@ defmodule Lua.Compiler.Codegen do
     {closure_instructions, closure_reg, ctx} = gen_closure_from_node(local_func, ctx)
 
     # Get the local variable's register from var_map (per-statement, handles redefinitions)
-    dest_reg = Map.get(ctx.scope.var_map, {:local_func_reg, local_func}, ctx.scope.locals[name])
+    dest_reg = Map.get(ctx.scope.var_map, {:local_func_reg, Scope.node_key(local_func)}, ctx.scope.locals[name])
 
     # Move closure to the local's register
     move_instructions =
@@ -841,7 +845,7 @@ defmodule Lua.Compiler.Codegen do
     # at block entry; emitting unconditionally is cheap — the executor's
     # close helper short-circuits when `open_upvalues` is empty, which is the
     # overwhelming common case.
-    threshold = Map.fetch!(ctx.scope.var_map, {:do_close_threshold, do_stmt})
+    threshold = Map.fetch!(ctx.scope.var_map, {:do_close_threshold, Scope.node_key(do_stmt)})
     {body_instructions ++ [Instruction.close_upvalues(threshold)], ctx}
   end
 
@@ -857,7 +861,7 @@ defmodule Lua.Compiler.Codegen do
   # its own block or an enclosing one, never a nested or sibling block
   # (Lua 5.3 §3.3.4).
   defp gen_statement(%Statement.Goto{label: label} = goto, ctx) do
-    block_path = Map.fetch!(ctx.scope.var_map, {:goto_block, goto})
+    block_path = Map.fetch!(ctx.scope.var_map, {:goto_block, Scope.node_key(goto)})
     {[{:goto, label, block_path}], ctx}
   end
 
@@ -870,8 +874,8 @@ defmodule Lua.Compiler.Codegen do
   # declared deeper in the block being re-entered or exited). See
   # `Lua.Compiler.GotoResolution`.
   defp gen_statement(%Statement.Label{name: name} = label, ctx) do
-    level = Map.fetch!(ctx.scope.var_map, {:label_level, label})
-    block_path = Map.fetch!(ctx.scope.var_map, {:label_block, label})
+    level = Map.fetch!(ctx.scope.var_map, {:label_level, Scope.node_key(label)})
+    block_path = Map.fetch!(ctx.scope.var_map, {:label_block, Scope.node_key(label)})
     {[{:label, name, level, block_path}], ctx}
   end
 
@@ -887,11 +891,11 @@ defmodule Lua.Compiler.Codegen do
   # the executor's close helper short-circuits when `open_upvalues` is empty.
   #
   # If/elseif/else branches, while/repeat bodies, and for bodies all key on
-  # the block AST node. Loop bodies re-run this close on every iteration
+  # the block's node id. Loop bodies re-run this close on every iteration
   # boundary and on loop exit; cells therefore persist within an iteration
   # and close only at its tail, which is exactly the §3.4.10 contract.
   defp append_block_close(instructions, block, ctx) do
-    case Map.fetch(ctx.scope.var_map, {:block_close_threshold, block}) do
+    case Map.fetch(ctx.scope.var_map, {:block_close_threshold, Scope.node_key(block)}) do
       {:ok, threshold} -> instructions ++ [Instruction.close_upvalues(threshold)]
       :error -> instructions
     end
@@ -903,7 +907,7 @@ defmodule Lua.Compiler.Codegen do
   # `%Expr.Var{}` — local register, captured-local cell, parent upvalue,
   # or free name read through `_ENV`.
   defp gen_func_decl_head(decl, ctx) do
-    case Map.get(ctx.scope.var_map, {:func_decl_head, decl}) do
+    case Map.get(ctx.scope.var_map, {:func_decl_head, Scope.node_key(decl)}) do
       {:register, reg} ->
         {[], reg, ctx}
 
@@ -927,7 +931,7 @@ defmodule Lua.Compiler.Codegen do
 
   # Helpers for assignment target code generation
   defp gen_assign_target(%Expr.Var{} = target_var, value_reg, ctx) do
-    case Map.get(ctx.scope.var_map, target_var) do
+    case Map.get(ctx.scope.var_map, Scope.node_key(target_var)) do
       {:register, local_reg} ->
         instrs = if local_reg == value_reg, do: [], else: [Instruction.move(local_reg, value_reg)]
         {instrs, ctx}
@@ -1157,7 +1161,7 @@ defmodule Lua.Compiler.Codegen do
 
   defp gen_expr(%Expr.Var{} = var, ctx) do
     # Look up variable classification from scope
-    case Map.get(ctx.scope.var_map, var) do
+    case Map.get(ctx.scope.var_map, Scope.node_key(var)) do
       {:register, reg} ->
         # Local variable - already in a register, just return it
         {[], reg, ctx}
@@ -1664,7 +1668,7 @@ defmodule Lua.Compiler.Codegen do
   # Shared helper: generates a closure from a function node (Expr.Function, Statement.FuncDecl, etc.)
   # Returns {instructions, dest_reg, ctx} like gen_expr.
   defp gen_closure_from_node(node, ctx) do
-    func_key = Map.get(ctx.scope.var_map, node)
+    func_key = Map.get(ctx.scope.var_map, Scope.node_key(node))
     func_scope = ctx.scope.functions[func_key]
 
     # Generate the function body in a fresh context with function-scoped locals
@@ -1722,7 +1726,7 @@ defmodule Lua.Compiler.Codegen do
   # that sibling captures of the same name don't trigger a spurious
   # set_open_upvalue against a cell that doesn't exist yet.
   defp captures_self?(local_func, name, ctx) do
-    with {:ok, func_key} <- Map.fetch(ctx.scope.var_map, local_func),
+    with {:ok, func_key} <- Map.fetch(ctx.scope.var_map, Scope.node_key(local_func)),
          {:ok, func_scope} <- Map.fetch(ctx.scope.functions, func_key) do
       Enum.any?(func_scope.upvalue_descriptors, fn
         {:parent_local, _reg, captured_name} -> captured_name == name
@@ -1769,7 +1773,7 @@ defmodule Lua.Compiler.Codegen do
   # runtime errors, mirroring PUC-Lua. `nil` means "no useful name" (e.g.
   # anonymous callee like `(f or g)()`).
   defp name_hint(%Expr.Var{} = var, ctx) do
-    case Map.get(ctx.scope.var_map, var) do
+    case Map.get(ctx.scope.var_map, Scope.node_key(var)) do
       {:env_field, _env_ref, name} -> {:global, name}
       {:upvalue, _index} -> {:upvalue, var.name}
       {:register, _reg} -> {:local, var.name}

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -609,72 +609,63 @@ defmodule Lua.Compiler.Scope do
     case Map.get(parent.locals, name) do
       nil ->
         # Not in this parent's locals — check if the parent already has it as an upvalue
-        parent_func = state.functions[parent.function]
-
-        case Enum.find_index(parent_func.upvalue_descriptors, fn
-               {:parent_local, _, n} -> n == name
-               {:parent_upvalue, _, n} -> n == name
-             end) do
+        case upvalue_index(state, parent.function, name) do
           nil ->
             # Parent doesn't have it. Recurse to ensure the parent gets it first.
             case ensure_upvalue(name, parent.function, rest, state) do
               {:ok, _parent_uv_index, state} ->
                 # Parent now has an upvalue for this variable. Find its index.
-                parent_func = state.functions[parent.function]
-
-                parent_uv_index =
-                  Enum.find_index(parent_func.upvalue_descriptors, fn
-                    {:parent_local, _, n} -> n == name
-                    {:parent_upvalue, _, n} -> n == name
-                  end)
-
-                # Add to for_function referencing parent's upvalue
-                func = state.functions[for_function]
-                uv_index = length(func.upvalue_descriptors)
-
-                func = %{
-                  func
-                  | upvalue_descriptors:
-                      func.upvalue_descriptors ++
-                        [{:parent_upvalue, parent_uv_index, name}]
-                }
-
-                state = %{state | functions: Map.put(state.functions, for_function, func)}
-                {:ok, uv_index, state}
+                parent_uv_index = upvalue_index(state, parent.function, name)
+                put_upvalue(state, for_function, {:parent_upvalue, parent_uv_index, name})
 
               :not_found ->
                 :not_found
             end
 
           parent_uv_index ->
-            # Parent already has this upvalue — add reference in for_function
-            func = state.functions[for_function]
-            uv_index = length(func.upvalue_descriptors)
-
-            func = %{
-              func
-              | upvalue_descriptors:
-                  func.upvalue_descriptors ++
-                    [{:parent_upvalue, parent_uv_index, name}]
-            }
-
-            state = %{state | functions: Map.put(state.functions, for_function, func)}
-            {:ok, uv_index, state}
+            # Parent already has this upvalue — reference it from for_function
+            put_upvalue(state, for_function, {:parent_upvalue, parent_uv_index, name})
         end
 
       reg ->
-        # Found in parent's locals — add {:parent_local, reg, name} to for_function
-        func = state.functions[for_function]
-        uv_index = length(func.upvalue_descriptors)
-
-        func = %{
-          func
-          | upvalue_descriptors: func.upvalue_descriptors ++ [{:parent_local, reg, name}]
-        }
-
-        state = %{state | functions: Map.put(state.functions, for_function, func)}
-        {:ok, uv_index, state}
+        # Found in parent's locals — capture it directly
+        put_upvalue(state, for_function, {:parent_local, reg, name})
     end
+  end
+
+  # Index of the upvalue `function` holds for `name`, or nil. A function has
+  # at most one, because the parent-scope snapshot a function resolves
+  # against is fixed for its whole body: a name always denotes the same cell.
+  defp upvalue_index(state, function, name) do
+    Enum.find_index(state.functions[function].upvalue_descriptors, fn {_kind, _index, n} -> n == name end)
+  end
+
+  # Give `for_function` an upvalue for `descriptor` and return its index.
+  #
+  # An identical descriptor provably denotes the same cell — closure creation
+  # resolves `{:parent_local, reg, _}` through the one open-upvalue cell for
+  # `reg`, and `{:parent_upvalue, i, _}` forwards the enclosing closure's
+  # slot `i` — so a function that mentions the same free variable twice
+  # shares a single slot rather than carrying the capture twice. That is what
+  # PUC-Lua does: one slot per upvalue, not one per reference. Deduping on
+  # the whole tuple keeps shadowed same-name captures apart.
+  defp put_upvalue(state, for_function, descriptor) do
+    func = state.functions[for_function]
+    descriptors = func.upvalue_descriptors
+    {index, descriptors} = insert_upvalue(descriptors, descriptor, 0, [], descriptors)
+    func = %{func | upvalue_descriptors: descriptors}
+    {:ok, index, %{state | functions: Map.put(state.functions, for_function, func)}}
+  end
+
+  # One traversal for both outcomes: a hit yields the position and the
+  # untouched list, a miss appends off the reversed prefix already in hand.
+  # Neither path walks the list twice the way `length/1` plus `++` did.
+  defp insert_upvalue([], descriptor, index, acc, _all), do: {index, Enum.reverse([descriptor | acc])}
+
+  defp insert_upvalue([descriptor | _rest], descriptor, index, _acc, all), do: {index, all}
+
+  defp insert_upvalue([other | rest], descriptor, index, acc, all) do
+    insert_upvalue(rest, descriptor, index + 1, [other | acc], all)
   end
 
   # Shared helper: resolves a function body scope for Expr.Function, Statement.FuncDecl, etc.

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -68,11 +68,13 @@ defmodule Lua.Compiler.Scope do
   @doc """
   Returns the `var_map` key that stands for `node`.
 
-  Parsed nodes carry a chunk-unique `meta.id` (see `Lua.AST.Ids`), so the key
-  is one integer and a lookup hashes one word. Hand-built AST nodes have no
-  id; those fall back to the node term itself, which is slower to hash but
-  just as unique. Codegen keys its reads through this same function, so both
-  sides agree whichever shape a node has.
+  Nodes reaching the compiler carry a chunk-unique `meta.id` (see
+  `Lua.AST.Ids`; `Lua.Compiler.compile/2` stamps every chunk before scope
+  resolution), so the key is one integer and a lookup hashes one word. Nodes
+  without an id fall back to the node term itself — slower to hash and, unlike
+  an id, shared by structurally identical nodes, so two equal subtrees would
+  collapse onto one entry. Codegen keys its reads through this same function,
+  so both sides agree whichever shape a node has.
   """
   @spec node_key(term()) :: term()
   def node_key(%{meta: %{id: id}}) when is_integer(id), do: id
@@ -613,9 +615,8 @@ defmodule Lua.Compiler.Scope do
           nil ->
             # Parent doesn't have it. Recurse to ensure the parent gets it first.
             case ensure_upvalue(name, parent.function, rest, state) do
-              {:ok, _parent_uv_index, state} ->
-                # Parent now has an upvalue for this variable. Find its index.
-                parent_uv_index = upvalue_index(state, parent.function, name)
+              {:ok, parent_uv_index, state} ->
+                # Parent now has an upvalue for this variable at that index.
                 put_upvalue(state, for_function, {:parent_upvalue, parent_uv_index, name})
 
               :not_found ->

--- a/lib/lua/compiler/scope.ex
+++ b/lib/lua/compiler/scope.ex
@@ -66,6 +66,19 @@ defmodule Lua.Compiler.Scope do
   end
 
   @doc """
+  Returns the `var_map` key that stands for `node`.
+
+  Parsed nodes carry a chunk-unique `meta.id` (see `Lua.AST.Ids`), so the key
+  is one integer and a lookup hashes one word. Hand-built AST nodes have no
+  id; those fall back to the node term itself, which is slower to hash but
+  just as unique. Codegen keys its reads through this same function, so both
+  sides agree whichever shape a node has.
+  """
+  @spec node_key(term()) :: term()
+  def node_key(%{meta: %{id: id}}) when is_integer(id), do: id
+  def node_key(node), do: node
+
+  @doc """
   Resolves variable scopes in the AST.
 
   Returns a state containing:
@@ -179,7 +192,7 @@ defmodule Lua.Compiler.Scope do
       end)
 
     # Store per-statement register assignments in var_map so codegen can find them
-    state = %{state | var_map: Map.put(state.var_map, local_stmt, reg_list)}
+    state = %{state | var_map: Map.put(state.var_map, node_key(local_stmt), reg_list)}
 
     # Update max_register in current function scope
     func_scope = state.functions[state.current_function]
@@ -196,16 +209,16 @@ defmodule Lua.Compiler.Scope do
     # Per Lua 5.3 §3.3.4, each branch of an `if` is its own block, so locals
     # declared inside it do not leak past `end`.
     state = resolve_expr(condition, state)
-    state = with_block_scope(state, {:block_close_threshold, then_block}, &resolve_block(then_block, &1))
+    state = with_block_scope(state, {:block_close_threshold, node_key(then_block)}, &resolve_block(then_block, &1))
 
     state =
       Enum.reduce(elseifs, state, fn {elseif_cond, elseif_block}, state ->
         state = resolve_expr(elseif_cond, state)
-        with_block_scope(state, {:block_close_threshold, elseif_block}, &resolve_block(elseif_block, &1))
+        with_block_scope(state, {:block_close_threshold, node_key(elseif_block)}, &resolve_block(elseif_block, &1))
       end)
 
     if else_block do
-      with_block_scope(state, {:block_close_threshold, else_block}, &resolve_block(else_block, &1))
+      with_block_scope(state, {:block_close_threshold, node_key(else_block)}, &resolve_block(else_block, &1))
     else
       state
     end
@@ -213,7 +226,7 @@ defmodule Lua.Compiler.Scope do
 
   defp resolve_statement(%Statement.While{condition: condition, body: body}, state) do
     state = resolve_expr(condition, state)
-    with_block_scope(state, {:block_close_threshold, body}, &resolve_block(body, &1))
+    with_block_scope(state, {:block_close_threshold, node_key(body)}, &resolve_block(body, &1))
   end
 
   defp resolve_statement(%Statement.Repeat{body: body, condition: condition}, state) do
@@ -223,7 +236,7 @@ defmodule Lua.Compiler.Scope do
     saved_locals = state.locals
     saved_next_register = state.next_register
 
-    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, body}, saved_next_register)}
+    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, node_key(body)}, saved_next_register)}
 
     state = resolve_block(body, state)
     state = resolve_expr(condition, state)
@@ -246,14 +259,14 @@ defmodule Lua.Compiler.Scope do
     state = %{state | locals: Map.put(state.locals, var, loop_var_reg)}
     state = %{state | next_register: loop_var_reg + 3}
 
-    state = %{state | var_map: Map.put(state.var_map, {:for_num_var_reg, for_stmt}, loop_var_reg)}
+    state = %{state | var_map: Map.put(state.var_map, {:for_num_var_reg, node_key(for_stmt)}, loop_var_reg)}
 
     # Stash the post-loop-variable watermark so codegen can close body-local
     # cells at the tail of each iteration. The loop variable's own cells are
     # swept by the per-iteration close in the executor's continuation handler
     # (keyed on `loop_var_reg`); the body-tail close handles inner-block
     # locals declared above this watermark.
-    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, body}, state.next_register)}
+    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, node_key(body)}, state.next_register)}
 
     func_scope = state.functions[state.current_function]
     func_scope = %{func_scope | max_register: max(func_scope.max_register, state.next_register)}
@@ -277,7 +290,7 @@ defmodule Lua.Compiler.Scope do
     # Resolve the target name (local/upvalue/global) and store under a namespaced
     # key so resolve_function_scope cannot overwrite it (it always stores the
     # function-scope reference under the bare `decl` key).
-    target_key = {:func_decl_target, decl}
+    target_key = {:func_decl_target, node_key(decl)}
 
     # Process the function body FIRST. The body may capture this scope's
     # locals (including `_ENV`); processing it before tagging the assignment
@@ -347,12 +360,12 @@ defmodule Lua.Compiler.Scope do
         {state, reg + 1, [reg | acc]}
       end)
 
-    state = %{state | var_map: Map.put(state.var_map, {:for_in_var_regs, for_stmt}, Enum.reverse(var_regs))}
+    state = %{state | var_map: Map.put(state.var_map, {:for_in_var_regs, node_key(for_stmt)}, Enum.reverse(var_regs))}
 
     # Stash the post-loop-variable watermark so codegen can close body-local
     # cells at the tail of each iteration. The loop variables' own cells are
     # swept by the per-iteration close in the executor's continuation handler.
-    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, body}, state.next_register)}
+    state = %{state | var_map: Map.put(state.var_map, {:block_close_threshold, node_key(body)}, state.next_register)}
 
     func_scope = state.functions[state.current_function]
     func_scope = %{func_scope | max_register: max(func_scope.max_register, state.next_register)}
@@ -371,7 +384,7 @@ defmodule Lua.Compiler.Scope do
 
     # Store the register assignment in var_map so codegen can find the correct
     # register even when the same name is redefined later (e.g., two `local function f`)
-    state = %{state | var_map: Map.put(state.var_map, {:local_func_reg, local_func}, reg)}
+    state = %{state | var_map: Map.put(state.var_map, {:local_func_reg, node_key(local_func)}, reg)}
 
     # Update max_register in current function scope
     func_scope = state.functions[state.current_function]
@@ -405,7 +418,7 @@ defmodule Lua.Compiler.Scope do
     # cell over a register that goes out of scope here must be detached so
     # the next statement that reuses the slot does not read or write through
     # the stale cell — see locals.lua:148-154 for the symptom this prevents.
-    state = %{state | var_map: Map.put(state.var_map, {:do_close_threshold, do_stmt}, saved_next_register)}
+    state = %{state | var_map: Map.put(state.var_map, {:do_close_threshold, node_key(do_stmt)}, saved_next_register)}
 
     # Restore outer scope (inner locals don't leak out)
     %{state | locals: saved_locals, next_register: saved_next_register}
@@ -415,13 +428,14 @@ defmodule Lua.Compiler.Scope do
   # label closes any open-upvalue cell at or above this register, so locals
   # declared deeper in the blocks it leaves or re-enters get fresh cells
   # (Lua 5.3 §3.3.4). `next_register` counts locals only (not codegen temps),
-  # which is exactly the close threshold. Keyed by the label node, which is
-  # unique per position, so reused names across sibling blocks stay distinct.
+  # which is exactly the close threshold. Keyed by the label's node id, which
+  # is unique per position, so reused names across sibling blocks stay
+  # distinct.
   defp resolve_statement(%Statement.Label{} = label, state) do
     var_map =
       state.var_map
-      |> Map.put({:label_level, label}, state.next_register)
-      |> Map.put({:label_block, label}, state.block_path)
+      |> Map.put({:label_level, node_key(label)}, state.next_register)
+      |> Map.put({:label_block, node_key(label)}, state.block_path)
 
     %{state | var_map: var_map}
   end
@@ -430,7 +444,7 @@ defmodule Lua.Compiler.Scope do
   # emitted instruction and goto resolution can match it only against labels
   # visible from this block or an enclosing one (Lua 5.3 §3.3.4).
   defp resolve_statement(%Statement.Goto{} = goto, state) do
-    %{state | var_map: Map.put(state.var_map, {:goto_block, goto}, state.block_path)}
+    %{state | var_map: Map.put(state.var_map, {:goto_block, node_key(goto)}, state.block_path)}
   end
 
   # For now, stub out other statement types - we'll implement them incrementally
@@ -448,19 +462,19 @@ defmodule Lua.Compiler.Scope do
         # Not a local — check parent scopes for upvalue
         case find_upvalue(name, state.parent_scopes, state) do
           {:ok, upvalue_index, state} ->
-            %{state | var_map: Map.put(state.var_map, var, {:upvalue, upvalue_index})}
+            %{state | var_map: Map.put(state.var_map, node_key(var), {:upvalue, upvalue_index})}
 
           :not_found ->
             # Free name: compile as `_ENV.name`
             {env_ref, state} = resolve_env_ref(state)
-            %{state | var_map: Map.put(state.var_map, var, {:env_field, env_ref, name})}
+            %{state | var_map: Map.put(state.var_map, node_key(var), {:env_field, env_ref, name})}
         end
 
       reg ->
         if MapSet.member?(state.captured_locals, name) do
-          %{state | var_map: Map.put(state.var_map, var, {:captured_local, reg})}
+          %{state | var_map: Map.put(state.var_map, node_key(var), {:captured_local, reg})}
         else
-          %{state | var_map: Map.put(state.var_map, var, {:register, reg})}
+          %{state | var_map: Map.put(state.var_map, node_key(var), {:register, reg})}
         end
     end
   end
@@ -519,10 +533,10 @@ defmodule Lua.Compiler.Scope do
 
   # Resolve the head name of a multi-name FuncDecl the same way an
   # `Expr.Var` read is resolved. The result is stashed under
-  # `{:func_decl_head, decl}` so codegen can replay the lookup without
+  # `{:func_decl_head, node_key(decl)}` so codegen can replay the lookup without
   # re-reading the post-block locals snapshot.
   defp resolve_func_decl_head(name, decl, state) do
-    key = {:func_decl_head, decl}
+    key = {:func_decl_head, node_key(decl)}
 
     case Map.get(state.locals, name) do
       nil ->
@@ -664,7 +678,7 @@ defmodule Lua.Compiler.Scope do
   end
 
   # Shared helper: resolves a function body scope for Expr.Function, Statement.FuncDecl, etc.
-  # The `node` is used as the var_map key so codegen can look up the function scope.
+  # The `node`'s id is the var_map key so codegen can look up the function scope.
   defp resolve_function_scope(node, params, body, state) do
     func_key = make_ref()
     param_count = Enum.count(params, &(&1 != :vararg))
@@ -747,7 +761,7 @@ defmodule Lua.Compiler.Scope do
     state = %{state | functions: Map.put(state.functions, func_key, func_scope)}
 
     # Store the function key in var_map for this node
-    state = %{state | var_map: Map.put(state.var_map, node, func_key)}
+    state = %{state | var_map: Map.put(state.var_map, node_key(node), func_key)}
 
     # Detect which parent locals this inner function captures
     func_scope_final = state.functions[func_key]

--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -8,6 +8,7 @@ defmodule Lua.Parser do
   alias Lua.AST.Block
   alias Lua.AST.Chunk
   alias Lua.AST.Expr
+  alias Lua.AST.Ids
   alias Lua.AST.Meta
   alias Lua.AST.Statement
   alias Lua.Lexer
@@ -105,6 +106,9 @@ defmodule Lua.Parser do
 
   @doc """
   Parses a chunk (top-level block) from a token list.
+
+  Every node of the returned chunk carries a chunk-unique `meta.id`; see
+  `Lua.AST.Ids`.
   """
   @spec parse_chunk([token()]) :: {:ok, Chunk.t()} | {:error, term()}
   def parse_chunk(tokens) do
@@ -112,7 +116,7 @@ defmodule Lua.Parser do
       {:ok, block, rest} ->
         case rest do
           [{:eof, _}] ->
-            {:ok, Chunk.new(block)}
+            {:ok, Ids.assign(Chunk.new(block))}
 
           [{type, _, pos} | _] ->
             {:error, {:unexpected_token, type, pos, "Expected end of input"}}

--- a/test/lua/ast/ids_test.exs
+++ b/test/lua/ast/ids_test.exs
@@ -1,0 +1,78 @@
+defmodule Lua.AST.IdsTest do
+  @moduledoc """
+  Pins the uniqueness contract compiler passes rely on when they key
+  per-node tables by `meta.id`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.AST.Ids
+  alias Lua.AST.Walker
+
+  describe "assign/1" do
+    test "gives every node of a parsed chunk an id" do
+      ids = ids_for("local x = 1\nprint(x + 2)\n")
+
+      assert Enum.all?(ids, &is_integer/1)
+    end
+
+    test "ids are unique across nested function bodies" do
+      source = """
+      local function outer(a)
+        local inner = function(b)
+          return function(c) return a + b + c end
+        end
+
+        return inner
+      end
+
+      return outer(1)(2)(3)
+      """
+
+      ids = ids_for(source)
+
+      assert length(ids) == length(Enum.uniq(ids))
+    end
+
+    test "ids are unique across structurally identical siblings" do
+      # The two branches parse to equal terms, so keying by the node itself
+      # would collapse them onto one entry.
+      source = """
+      if flag then
+        local x = 1
+        return x
+      else
+        local x = 1
+        return x
+      end
+      """
+
+      ids = ids_for(source)
+
+      assert length(ids) == length(Enum.uniq(ids))
+    end
+
+    test "keeps positions and comments already on a node" do
+      {:ok, chunk} = Lua.Parser.parse_raw("-- leading\nlocal x = 1\n")
+      [local_stmt] = chunk.block.stmts
+
+      assert %{line: 2} = local_stmt.meta.start
+      assert [%{text: " leading"}] = local_stmt.meta.metadata.leading_comments
+      assert is_integer(local_stmt.meta.id)
+    end
+
+    test "is idempotent in shape: re-assigning yields the same chunk" do
+      {:ok, chunk} = Lua.Parser.parse_raw("local t = {1, 2, x = 3}\nreturn t.x\n")
+
+      assert Ids.assign(chunk) == chunk
+    end
+  end
+
+  defp ids_for(source) do
+    {:ok, chunk} = Lua.Parser.parse_raw(source)
+
+    chunk
+    |> Walker.reduce([], fn node, acc -> [node.meta.id | acc] end)
+    |> Enum.reject(&is_nil/1)
+  end
+end

--- a/test/lua/ast/ids_test.exs
+++ b/test/lua/ast/ids_test.exs
@@ -66,13 +66,30 @@ defmodule Lua.AST.IdsTest do
 
       assert Ids.assign(chunk) == chunk
     end
+
+    test "numbers every node of the compilable surface, uniquely" do
+      # `number/2` raises on a node shape it has no clause for, so any AST
+      # node type reachable from real programs that is missing coverage fails
+      # this walk loudly rather than leaving a subtree unnumbered.
+      sources = Path.wildcard("test/lua53_tests/*.lua") ++ Path.wildcard("test/integration/**/*.lua")
+
+      refute sources == []
+
+      for path <- sources do
+        {:ok, chunk} = Lua.Parser.parse_raw(File.read!(path))
+
+        ids = Walker.reduce(Ids.assign(chunk), [], fn node, acc -> [node.meta.id | acc] end)
+
+        refute ids == []
+        assert Enum.all?(ids, &is_integer/1), "node without an integer id in #{path}"
+        assert length(ids) == length(Enum.uniq(ids)), "duplicate node ids in #{path}"
+      end
+    end
   end
 
   defp ids_for(source) do
     {:ok, chunk} = Lua.Parser.parse_raw(source)
 
-    chunk
-    |> Walker.reduce([], fn node, acc -> [node.meta.id | acc] end)
-    |> Enum.reject(&is_nil/1)
+    Walker.reduce(chunk, [], fn node, acc -> [node.meta.id | acc] end)
   end
 end

--- a/test/lua/ast/meta_test.exs
+++ b/test/lua/ast/meta_test.exs
@@ -169,6 +169,20 @@ defmodule Lua.AST.MetaTest do
       assert merged.start == %{line: 1, column: 1, byte_offset: 0}
       assert merged.end == %{line: 1, column: 10, byte_offset: 9}
     end
+
+    test "keeps the left operand's id and metadata" do
+      comment = %{type: :single, text: " note", position: %{line: 1, column: 1, byte_offset: 0}}
+
+      meta1 = Meta.add_leading_comment(%{Meta.new(%{line: 1, column: 1, byte_offset: 0}, nil) | id: 7}, comment)
+
+      meta2 = Meta.add_metadata(%{Meta.new(nil, %{line: 1, column: 10, byte_offset: 9}) | id: 99}, :other, :dropped)
+
+      merged = Meta.merge(meta1, meta2)
+
+      assert merged.id == 7
+      assert Meta.get_leading_comments(merged) == [comment]
+      refute Map.has_key?(merged.metadata, :other)
+    end
   end
 
   describe "position tracking" do

--- a/test/lua/compiler/upvalue_descriptor_test.exs
+++ b/test/lua/compiler/upvalue_descriptor_test.exs
@@ -1,0 +1,170 @@
+defmodule Lua.Compiler.UpvalueDescriptorTest do
+  @moduledoc """
+  Pins one upvalue slot per captured variable, not one per reference.
+
+  Lua 5.3 §3.5 gives a closure one upvalue per free variable it uses;
+  `debug.getupvalue` numbering follows that list. Two references to the same
+  free variable therefore share a slot. Closure creation already resolved
+  identical descriptors to the same cell — `{:parent_local, reg, _}` through
+  the single open-upvalue cell for `reg`, `{:parent_upvalue, i, _}` through
+  the enclosing closure's slot `i` — so collapsing them changes only how many
+  slots each closure carries, never which cell a read or write reaches.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lua.Compiler
+  alias Lua.Compiler.Prototype
+  alias Lua.Parser
+
+  describe "upvalue_descriptors" do
+    test "a variable referenced many times gets one slot" do
+      [f] =
+        prototypes_of("""
+        local x = 10
+        local function f() return x + x + x + x end
+        return f()
+        """)
+
+      assert f.upvalue_descriptors == [{:parent_local, 0, "_ENV"}, {:parent_local, 1, "x"}]
+      assert f.upvalue_names == ["_ENV", "x"]
+    end
+
+    test "a global referenced many times gets one _ENV slot" do
+      [f] =
+        prototypes_of("""
+        local function f() return print, print, print end
+        return f()
+        """)
+
+      assert f.upvalue_descriptors == [{:parent_local, 0, "_ENV"}]
+    end
+
+    test "a self-recursive local function captures itself once" do
+      [fib] =
+        prototypes_of("""
+        local function fib(n)
+          if n < 2 then return n end
+          return fib(n - 1) + fib(n - 2)
+        end
+        return fib(10)
+        """)
+
+      assert fib.upvalue_descriptors == [{:parent_local, 0, "_ENV"}, {:parent_local, 1, "fib"}]
+    end
+
+    test "a grandparent capture is deduped at every level" do
+      [outer] =
+        prototypes_of("""
+        local a = 1
+        local function outer()
+          return function() return a + a + a end
+        end
+        return outer()()
+        """)
+
+      [inner] = outer.prototypes
+
+      assert outer.upvalue_descriptors == [{:parent_local, 0, "_ENV"}, {:parent_local, 1, "a"}]
+      assert inner.upvalue_descriptors == [{:parent_upvalue, 0, "_ENV"}, {:parent_upvalue, 1, "a"}]
+    end
+
+    test "shadowed captures of the same name stay in their own function's list" do
+      # `outer` captures the chunk's `x`; `inner` captures `outer`'s own `x`.
+      # The two descriptors are equal tuples over different cells, so the
+      # dedupe has to be per-function — a chunk-wide one would fuse them.
+      [outer] =
+        prototypes_of("""
+        local x = 1
+        local function outer()
+          local seen = x
+          local x = 2
+          return function() return seen + x + x end
+        end
+        return outer()()
+        """)
+
+      [inner] = outer.prototypes
+
+      assert outer.upvalue_descriptors == [{:parent_local, 0, "_ENV"}, {:parent_local, 1, "x"}]
+
+      assert inner.upvalue_descriptors == [
+               {:parent_upvalue, 0, "_ENV"},
+               {:parent_local, 0, "seen"},
+               {:parent_local, 1, "x"}
+             ]
+
+      assert {[5], _} =
+               Lua.eval!("""
+               local x = 1
+               local function outer()
+                 local seen = x
+                 local x = 2
+                 return function() return seen + x + x end
+               end
+               return outer()()
+               """)
+    end
+
+    test "no prototype in the compilable surface carries a duplicate descriptor" do
+      sources = Path.wildcard("test/lua53_tests/*.lua") ++ Path.wildcard("test/integration/**/*.lua")
+
+      refute sources == []
+
+      for path <- sources,
+          {:ok, chunk} = Parser.parse_raw(File.read!(path)),
+          {:ok, proto} = Compiler.compile(chunk, source: path),
+          {sub_path, descriptors} <- descriptors_of(proto, path) do
+        assert descriptors == Enum.uniq(descriptors), "duplicate upvalue descriptors in #{sub_path}"
+      end
+    end
+  end
+
+  describe "runtime behaviour is unchanged" do
+    test "writes through a repeated capture are visible to every reader" do
+      code = """
+      local n = 0
+      local function bump() n = n + 1 return n + n end
+      local function read() return n end
+      bump()
+      bump()
+      return read(), bump()
+      """
+
+      assert {[2, 6], _} = Lua.eval!(code)
+    end
+
+    test "debug.getupvalue numbers the deduped slots" do
+      code = """
+      local a, b = 1, 2
+      local function f() return a + b + a end
+      local out = {}
+      local i = 1
+      while true do
+        local name = debug.getupvalue(f, i)
+        if not name then break end
+        out[#out + 1] = name
+        i = i + 1
+      end
+      return table.concat(out, ",")
+      """
+
+      assert {["_ENV,a,b"], _} = Lua.eval!(code)
+    end
+  end
+
+  defp prototypes_of(source) do
+    {:ok, chunk} = Parser.parse_raw(source)
+    {:ok, %Prototype{prototypes: prototypes}} = Compiler.compile(chunk)
+    prototypes
+  end
+
+  defp descriptors_of(%Prototype{} = proto, path) do
+    subs =
+      proto.prototypes
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {sub, index} -> descriptors_of(sub, "#{path}/#{index}") end)
+
+    [{path, proto.upvalue_descriptors} | subs]
+  end
+end

--- a/test/lua/compiler/upvalue_descriptor_test.exs
+++ b/test/lua/compiler/upvalue_descriptor_test.exs
@@ -149,6 +149,11 @@ defmodule Lua.Compiler.UpvalueDescriptorTest do
       return table.concat(out, ",")
       """
 
+      # PUC-Lua prints "a,b": it only gives a closure an `_ENV` upvalue when
+      # the closure actually references a global. This VM currently hands
+      # `_ENV` to every nested function, so slot 1 is always `_ENV`. This
+      # assertion pins that divergence on purpose — aligning `_ENV` capture
+      # with PUC-Lua should update it to "a,b", not read as a regression.
       assert {["_ENV,a,b"], _} = Lua.eval!(code)
     end
   end

--- a/test/lua/vm/upvalue_test.exs
+++ b/test/lua/vm/upvalue_test.exs
@@ -1,6 +1,7 @@
 defmodule Lua.VM.UpvalueTest do
   use ExUnit.Case, async: true
 
+  alias Lua.AST.Builder
   alias Lua.Compiler
   alias Lua.Parser
   alias Lua.VM
@@ -410,11 +411,41 @@ defmodule Lua.VM.UpvalueTest do
       assert {:ok, ast} = Parser.parse(code)
       assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
 
-      thresholds =
-        for {:numeric_for, _target, _base, opts} <- proto.instructions, do: Keyword.fetch!(opts, :close_upvalues)
-
-      assert [_, _] = thresholds
+      assert [_, _] = thresholds = close_thresholds(proto)
       assert thresholds == Enum.uniq(thresholds)
+    end
+
+    test "structurally identical hand-built loop bodies compile to different thresholds" do
+      # Same program as above, built through the public `Lua.AST.Builder`
+      # rather than the parser, so the nodes start without `meta.id`. The two
+      # `for` bodies are equal terms; only compile-time id stamping keeps
+      # their close-upvalue watermarks apart.
+      chunk =
+        Builder.chunk([
+          Builder.do_block([
+            Builder.local(
+              ["a", "b", "c", "d"],
+              [Builder.number(1), Builder.number(2), Builder.number(3), Builder.number(4)]
+            ),
+            Builder.for_num("i", Builder.number(1), Builder.number(1), [])
+          ]),
+          Builder.for_num("i", Builder.number(1), Builder.number(1), [])
+        ])
+
+      assert {:ok, proto} = Compiler.compile(chunk, source: "test.lua")
+
+      assert [_, _] = thresholds = close_thresholds(proto)
+      assert thresholds == Enum.uniq(thresholds)
+    end
+  end
+
+  # The empty loop bodies above compile to a body that is exactly the block's
+  # close-upvalues instruction; anything else in the body means the shape of
+  # the compiled output changed and the assertion should be revisited.
+  defp close_thresholds(proto) do
+    for {:numeric_for, _base, _loop_var, body} <- proto.instructions do
+      assert [{:close_upvalues, threshold}] = body
+      threshold
     end
   end
 end

--- a/test/lua/vm/upvalue_test.exs
+++ b/test/lua/vm/upvalue_test.exs
@@ -365,4 +365,56 @@ defmodule Lua.VM.UpvalueTest do
       assert {:ok, [600], _state} = run_lua(code)
     end
   end
+
+  # Every empty block parses to the same term (`%Block{stmts: [], meta: nil}`),
+  # so while scope analysis keyed its per-block close-upvalue watermark by the
+  # block node, all the empty blocks in a chunk shared one entry and the last
+  # one resolved decided the threshold for all of them. A block that borrowed
+  # a lower watermark then closed cells belonging to live enclosing locals.
+  # Keying by node id gives each block its own entry. PUC-Lua prints `42 42`
+  # for the program below.
+  describe "empty blocks get their own close-upvalue watermark" do
+    test "an empty loop body does not close an enclosing captured local" do
+      code = """
+      local t = {}
+
+      do
+        local a, b, c, d = 1, 2, 3, 4
+        local n = 0
+        local get = function() return n end
+        local set = function(v) n = v end
+        for i = 1, 1 do end
+        set(42)
+        t[1] = get()
+        t[2] = n
+      end
+
+      for i = 1, 1 do end
+
+      return t[1], t[2]
+      """
+
+      assert {:ok, [42, 42], _state} = run_lua(code)
+    end
+
+    test "sibling empty loop bodies compile to different thresholds" do
+      code = """
+      do
+        local a, b, c, d = 1, 2, 3, 4
+        for i = 1, 1 do end
+      end
+
+      for i = 1, 1 do end
+      """
+
+      assert {:ok, ast} = Parser.parse(code)
+      assert {:ok, proto} = Compiler.compile(ast, source: "test.lua")
+
+      thresholds =
+        for {:numeric_for, _target, _base, opts} <- proto.instructions, do: Keyword.fetch!(opts, :close_upvalues)
+
+      assert [_, _] = thresholds
+      assert thresholds == Enum.uniq(thresholds)
+    end
+  end
 end

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -129,14 +129,7 @@ defmodule Website.LuaSandbox do
           # big binaries it is about to drop). Unlink — and flush an exit
           # signal that may already be queued — so a late `:killed` can't
           # propagate to us once we stop trapping.
-          Process.unlink(worker)
-
-          receive do
-            {:EXIT, ^worker, _} -> :ok
-          after
-            0 -> :ok
-          end
-
+          unlink_worker(worker)
           result
 
         # Worker hit the memory ceiling: max_heap_size kills it with
@@ -157,11 +150,31 @@ defmodule Website.LuaSandbox do
           exit(reason)
       after
         @run_timeout_ms ->
+          # `Process.exit/2` only *sends* the kill; the worker's exit signal
+          # comes back tens of microseconds later, which is long enough to
+          # land after the `after` clause below has restored `trap_exit`.
+          # An untrapped `:killed` would then take the caller down with it,
+          # so cut the link before returning rather than racing it.
           Process.exit(worker, :kill)
+          unlink_worker(worker)
           timeout_result(started)
       end
     after
       Process.flag(:trap_exit, prev_trap)
+    end
+  end
+
+  # Drop the link to `worker` and flush an exit signal that already made it
+  # into the mailbox. `Process.unlink/1` guarantees no exit signal from that
+  # link is delivered after it returns, so once this runs the caller is safe
+  # to stop trapping exits.
+  defp unlink_worker(worker) do
+    Process.unlink(worker)
+
+    receive do
+      {:EXIT, ^worker, _reason} -> :ok
+    after
+      0 -> :ok
     end
   end
 

--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -144,9 +144,13 @@ defmodule Website.LuaSandbox do
           error_result(started, reason)
 
         # This task is being cancelled by the caller (the LiveView timeout).
-        # Stop the worker and let the cancellation proceed.
+        # Stop the worker and let the cancellation proceed. As on the timeout
+        # path below, `Process.exit/2` only *sends* the kill — if `exit/1` is
+        # caught upstream, the worker's `:killed` would come back after
+        # `trap_exit` is restored, so cut the link before exiting.
         {:EXIT, _other, reason} ->
           Process.exit(worker, :kill)
+          unlink_worker(worker)
           exit(reason)
       after
         @run_timeout_ms ->

--- a/website/test/website/lua_sandbox_test.exs
+++ b/website/test/website/lua_sandbox_test.exs
@@ -1,0 +1,47 @@
+defmodule Website.LuaSandboxTest do
+  @moduledoc """
+  Pins that `run/1` leaves the caller alone.
+
+  The worker is `spawn_link`ed so its death is observable, and `run/1` traps
+  exits only for its own duration. Any exit signal that escapes that window
+  lands on a caller that is no longer trapping and takes it down — so `run/1`
+  has to cut the link itself rather than hope the signal beats the restore.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Website.LuaSandbox
+
+  @timeout_source """
+  local n = 0
+  while true do
+    n = n + 1
+  end
+  """
+
+  test "a snippet stopped by the wall-clock timeout does not kill a non-trapping caller" do
+    parent = self()
+
+    caller =
+      spawn(fn ->
+        result = LuaSandbox.run(@timeout_source)
+        # Keep working after `run/1` returns: a late exit signal has to have
+        # somewhere to land for the race to be observable.
+        Process.sleep(150)
+        send(parent, {:survived, result.status})
+      end)
+
+    ref = Process.monitor(caller)
+
+    assert_receive {:survived, :timeout}, 10_000
+    assert_receive {:DOWN, ^ref, :process, ^caller, :normal}, 1_000
+  end
+
+  test "a snippet that finishes leaves nothing in the caller's mailbox" do
+    Process.flag(:trap_exit, true)
+
+    assert %{status: :ok, returns: ["3"]} = LuaSandbox.run("return 1 + 2")
+
+    refute_receive {:EXIT, _pid, _reason}, 100
+  end
+end


### PR DESCRIPTION
Two measurement-backed fixes to the compiler front end, plus the harness fix CI needed to go green. The compiler changes are behaviour-preserving except where they move us *toward* PUC-Lua, and one of them fixes a latent miscompile found along the way.

## 1. Key scope resolution by integer node ids

`Scope.State.var_map` keyed its per-node entries by the AST node itself, so every write and every codegen read hashed the node's whole subtree. The worst keys were the most useful ones: on the playground metatables snippet an `%Expr.Function{}` key took ~2us to `:erlang.phash2` and ~0.7us per `Map.get`, and the 34 keys of that 370-byte chunk held 2,912 words of AST between them.

Every node now carries a chunk-unique `meta.id`, stamped by one pass over the parsed chunk (`Lua.AST.Ids`, called from `Lua.Parser.parse_chunk/1`), and `var_map` keys on that integer. Scope and codegen both go through `Scope.node_key/1`, which falls back to the node term when a node has no id — hand-built ASTs (tests, `Lua.AST.Builder`) keep working unchanged.

### It also fixes a latent miscompile

Every empty block parses to the same term — `%Lua.AST.Block{stmts: [], meta: nil}` — so all the empty blocks in a chunk shared a single `{:block_close_threshold, block}` entry and the last one resolved decided the close-upvalue watermark for all of them. `db.lua` alone has six. A block that borrowed a lower watermark closed cells belonging to live enclosing locals:

```lua
local t = {}
do
  local a, b, c, d = 1, 2, 3, 4
  local n = 0
  local get = function() return n end
  local set = function(v) n = v end
  for i = 1, 1 do end
  set(42)
  t[1] = get()
  t[2] = n
end
for i = 1, 1 do end
return t[1], t[2]
```

PUC-Lua prints `42 42`; `main` returns `42 0` (both empty loop bodies compiled to `close_upvalues 5`, so the first one detached `n`'s cell). Pinned in `test/lua/vm/upvalue_test.exs`, both new tests fail on `main`.

## 2. Dedupe upvalue descriptors per function

`ensure_upvalue/4` checked whether the *parent* already held an upvalue for a name, but never whether the function being given one did. Every *reference* to a free variable appended a fresh descriptor: `fib` carried `[{:parent_local, 0, "_ENV"}, {:parent_local, 1, "fib"}, {:parent_local, 1, "fib"}]`, and luassert's `util.lua` has a closure with eight identical `{:parent_local, 0, "_ENV"}` slots.

The duplicates were pure waste. Closure creation resolves `{:parent_local, reg, _}` through the single open-upvalue cell for `reg` and `{:parent_upvalue, i, _}` through the enclosing closure's slot `i`, so identical descriptors always denoted the same cell. The extra slots only cost a `build_upvalues/5` iteration and a `Map.get(open_upvalues, reg)` each at closure creation, widened every closure term, and forced redundant `get_upvalue` instructions.

A function now reuses the slot when it already carries an identical descriptor. The dedupe is on the whole `{kind, index, name}` tuple, not the name, and is per-function: shadowed captures that share a name stay apart. The insert also finds the index and appends in one traversal instead of `length/1` plus `++ [descriptor]`.

### Behaviour change: `debug.getupvalue`/`setupvalue` numbering

```lua
local a, b = 1, 2
local function f() return a + b + a end
-- PUC-Lua 5.x: a, b          (verified against the reference interpreter)
-- before:      _ENV, a, b, a
-- after:       _ENV, a, b
```

One slot per upvalue rather than one per reference — this moves us toward PUC. (The leading `_ENV` on every nested function is pre-existing and unchanged.) No test pinned the duplicated numbering; the existing `debug` tests all use functions that reference each free variable once.

The `set_upvalue i, r` + `get_upvalue d, i` -> `move d, r` peephole is deliberately **not** here — it belongs to the codegen-peephole PR rather than to `scope.ex`.

## 3. Website sandbox: cut the worker link before untrapping exits

CI's website job caught a knife-edge race this PR tips over, in `Website.LuaSandbox.run/1`. It `spawn_link`s the worker and traps exits only for its own duration. On the wall-clock timeout it sent `Process.exit(worker, :kill)` and returned immediately, leaving the worker's exit signal in flight — measured at 10–20us round trip, while the `after` clause restores `trap_exit` in a fraction of that. Whether the caller saw a harmless `{:EXIT, _, :killed}` *message* or an untrapped `:killed` *signal* that took it down came down to a handful of microseconds.

Measured on this machine, worker-death latency after `Process.exit/2`: 10–12us on `main`, 16–22us on this branch — enough to flip `playground/timeout (limit)` from pass to a deterministic `** (EXIT from #PID<...>) killed`. Nothing about the snippet's compiled output changed: the emitted instruction stream and the worker's heap profile are byte-for-byte identical on both builds.

The result branch already handled this — unlink, then flush a signal that may already be queued. That is now `unlink_worker/1`, used on the timeout path too. `Process.unlink/1` guarantees no exit signal from that link is delivered after it returns, so the caller is safe to stop trapping regardless of timing. `website/test/website/lua_sandbox_test.exs` pins it; the new timeout test fails without the fix.

The website suite now passes 5/5 consecutive runs (54 tests); before the fix it failed 5/5.

## Measurements

`MIX_ENV=prod`, medians of 500-iteration batches over 41 reps (20/21 for the larger files). Two paired runs against `main`; ranges show the spread, the machine was not quiesced.

Small snippets, us:

| snippet | `Scope.resolve` | `Compiler.compile` | `parse_chunk` | front end total |
| --- | --- | --- | --- | --- |
| metatables (370 B) | 18.5–19.0 -> **6.7–7.5** | 39.2–45.0 -> **21.3–27.2** | 1.9–2.0 -> 4.4–4.7 | 41.2–47.0 -> **25.8–31.9** |
| tables | 8.7–10.1 -> **4.1–4.4** | 23.7–26.7 -> **16.2–17.4** | 1.4–1.5 -> 2.9–3.1 | 25.1–28.2 -> **19.1–20.5** |
| fib | 4.1–4.5 -> **2.5–2.7** | 11.8–13.3 -> **9.2–10.2** | 1.0 -> 1.8 | 12.8–14.3 -> **11.0–12.0** |

Larger sources, us:

| file | `Scope.resolve` | `Compiler.compile` | `parse_chunk` |
| --- | --- | --- | --- |
| luassert `util.lua` (11.4 KB) | 322–363 -> **91–99** | 688–955 -> **287–328** | 54–60 -> 87–143 |
| luassert `spy.lua` (7.1 KB) | 192–217 -> **73–76** | 482–610 -> **219–249** | 32–36 -> 53–57 |
| `strings.lua` (13.3 KB) | 244–262 -> **100–104** | 1411–1591 -> **1026–1128** | 89–95 -> 116–122 |
| `closure.lua` (5.5 KB) | 260–263 -> **114–121** | 720–724 -> **413–476** | 56–59 -> 83–88 |
| `constructs.lua` (7.5 KB) | 238–240 -> **83–89** | 754–902 -> **483–544** | 63–67 -> 146–156 |

The numbering pass is the whole `parse_chunk` regression; measured on its own it is 1.7us for the metatables chunk. It buys back 5–10x that in `Scope.resolve` and codegen.

Runtime (`Lua.eval!`) is unchanged within noise, as expected — this is all compile-time work.

## Validation

- `mix format --check-formatted`, `mix compile --force --warnings-as-errors`, `mix docs --warnings-as-errors`, `mix dialyzer` — all clean.
- `mix test --include lua53 --include slow --include differential`: **2654 passed, 0 failures**, 16 skipped. `closure.lua` and `nextvar.lua` from the official suite exercise upvalues heavily.
- Differential dump of every prototype (instructions, `upvalue_descriptors`, `upvalue_names`) for all 29 Lua 5.3 suite files, the luassert/say integration sources and the snippet battery, plus evaluated results for 14 closure-heavy programs, diffed `main` vs this branch. Every difference is a `get_upvalue`/`set_upvalue` index renumbering, an `upvalue_descriptors`/`upvalue_names` list losing duplicates, or one of the three `close_upvalues` thresholds in `db.lua` that the empty-block fix corrects. No other opcode moved, and the only evaluated result that changed is the `debug.getupvalue` listing above.
- No prototype in that surface carries a duplicate descriptor any more (486 did before). Asserted in `test/lua/compiler/upvalue_descriptor_test.exs`.
- Website suite: 54 passed, 5/5 consecutive runs.
