### PR TITLE
vm: cut per-call and per-iteration overhead in the dispatcher

### DIFF
--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -241,7 +241,7 @@ defmodule Lua.VM.Dispatcher do
       {@op_load_env, dest} ->
         env =
           if tuple_size(upvalues) > 0 do
-            Map.get(state.upvalue_cells, :erlang.element(1, upvalues))
+            :maps.get(:erlang.element(1, upvalues), state.upvalue_cells, nil)
           else
             State.g_ref(state)
           end
@@ -251,12 +251,12 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_get_upvalue, dest, index} ->
         cell_ref = :erlang.element(index + 1, upvalues)
-        # Mirror the interpreter's `Map.get/2` (returns nil for a dangling
+        # Mirror the interpreter's defaulting read (nil for a dangling
         # cell) rather than `:erlang.map_get/2` (which raises `:badkey`).
         # Compiled closures should never carry stale cell refs, but the
         # invariant is the interpreter's, not ours, and the error shape
         # has to match where it does fire.
-        v = Map.get(state.upvalue_cells, cell_ref)
+        v = :maps.get(cell_ref, state.upvalue_cells, nil)
         regs = :erlang.setelement(dest + 1, regs, v)
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
 
@@ -679,17 +679,19 @@ defmodule Lua.VM.Dispatcher do
         case func_value do
           {:compiled_closure, callee_proto, callee_upvalues} ->
             callee_regs = init_callee_regs(callee_proto, regs, base + 1, arg_count)
-            # B5c-v2: compiled callees may now be vararg functions. The
-            # `is_vararg` check in `setup_vararg_proto/4` short-circuits for
-            # the common non-vararg case at one tuple-field read.
-            callee_proto = setup_vararg_proto(callee_proto, regs, base + 1, arg_count)
+            # Compiled callees may be vararg functions. Testing `is_vararg`
+            # here keeps the common non-vararg call to one field read.
+            callee_proto =
+              if callee_proto.is_vararg,
+                do: setup_vararg_proto(callee_proto, regs, base + 1, arg_count),
+                else: callee_proto
 
             frame =
               {code, pc + 1, regs, upvalues, proto, cont, :discard, state.open_upvalues}
 
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -712,9 +714,9 @@ defmodule Lua.VM.Dispatcher do
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -747,7 +749,11 @@ defmodule Lua.VM.Dispatcher do
         case func_value do
           {:compiled_closure, callee_proto, callee_upvalues} ->
             callee_regs = init_callee_regs(callee_proto, regs, base + 1, arg_count)
-            callee_proto = setup_vararg_proto(callee_proto, regs, base + 1, arg_count)
+
+            callee_proto =
+              if callee_proto.is_vararg,
+                do: setup_vararg_proto(callee_proto, regs, base + 1, arg_count),
+                else: callee_proto
 
             # Frame is a tuple, not a map: pattern-matching a tuple in
             # `return_one/3` skips Map.fetch! lookups and lets the BEAM
@@ -755,9 +761,9 @@ defmodule Lua.VM.Dispatcher do
             frame =
               {code, pc + 1, regs, upvalues, proto, cont, base, state.open_upvalues}
 
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -780,9 +786,9 @@ defmodule Lua.VM.Dispatcher do
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -918,11 +924,34 @@ defmodule Lua.VM.Dispatcher do
         state = Executor.dispatcher_set_table(table_val, key, value, state, proto, name_hint)
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
 
+      # Mirrors `@op_get_field`'s shape: a tref whose table has no metatable
+      # has no `__newindex` to consult, so the write is a direct
+      # `Table.put/3` into `state.tables`. Anything else — a non-tref, or a
+      # table carrying a metatable — bridges so the `__newindex` chain and
+      # the index type errors stay the interpreter's.
       {@op_set_field, table_reg, name, value_reg, name_hint} ->
         table_val = :erlang.element(table_reg + 1, regs)
         value = :erlang.element(value_reg + 1, regs)
-        state = Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+
+        case table_val do
+          {:tref, id} ->
+            table = :erlang.map_get(id, state.tables)
+
+            state =
+              case :erlang.map_get(:metatable, table) do
+                nil ->
+                  %{state | tables: :maps.put(id, Table.put(table, name, value), state.tables)}
+
+                _ ->
+                  Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
+              end
+
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+
+          # Indexing a non-table always raises; the bridge owns the wording.
+          _ ->
+            Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
+        end
 
       # `:set_list` with a positive integer count is the table-constructor
       # form. The `count == 0` sentinel was filtered upstream and never
@@ -1009,7 +1038,7 @@ defmodule Lua.VM.Dispatcher do
 
         if should_continue do
           regs = :erlang.setelement(loop_var + 1, regs, counter)
-          state = Executor.dispatcher_close_open_upvalues_at_or_above(state, loop_var)
+          state = close_upv(state, loop_var)
           marker = {:cps_for, base, loop_var, body_bc, code, pc + 1}
           loop_exit = {:loop_exit, code, pc + 1}
           dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | cont], frames, instruction_count)
@@ -1063,7 +1092,7 @@ defmodule Lua.VM.Dispatcher do
             regs = :erlang.setelement(base + 3, regs, first)
             regs = assign_iter_results(regs, var_regs, results, 0)
             first_var_reg = :erlang.element(1, var_regs)
-            state = Executor.dispatcher_close_open_upvalues_at_or_above(state, first_var_reg)
+            state = close_upv(state, first_var_reg)
             marker = {:cps_generic_for, base, var_regs, body_bc, line, code, pc + 1}
             loop_exit = {:loop_exit, code, pc + 1}
             dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | cont], frames, instruction_count)
@@ -1092,11 +1121,11 @@ defmodule Lua.VM.Dispatcher do
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
 
       {@op_goto, 0, target_pc, level} ->
-        state = Executor.dispatcher_close_open_upvalues_at_or_above(state, level)
+        state = close_upv(state, level)
         dispatch(code, target_pc, regs, upvalues, proto, state, cont, frames, instruction_count)
 
       {@op_goto, depth, target_pc, level} ->
-        state = Executor.dispatcher_close_open_upvalues_at_or_above(state, level)
+        state = close_upv(state, level)
         {dest_code, rest_cont} = unwind_goto(cont, depth)
         dispatch(dest_code, target_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
 
@@ -1143,9 +1172,9 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_get_open_upvalue, dest, reg} ->
         value =
-          case Map.get(state.open_upvalues, reg) do
+          case :maps.get(reg, state.open_upvalues, nil) do
             nil -> :erlang.element(reg + 1, regs)
-            cell_ref -> Map.get(state.upvalue_cells, cell_ref)
+            cell_ref -> :maps.get(cell_ref, state.upvalue_cells, nil)
           end
 
         regs = :erlang.setelement(dest + 1, regs, value)
@@ -1153,7 +1182,7 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_set_open_upvalue, reg, source} ->
         state =
-          case Map.get(state.open_upvalues, reg) do
+          case :maps.get(reg, state.open_upvalues, nil) do
             nil ->
               state
 
@@ -1165,7 +1194,7 @@ defmodule Lua.VM.Dispatcher do
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
 
       {@op_close_upvalues, threshold} ->
-        state = Executor.dispatcher_close_open_upvalues_at_or_above(state, threshold)
+        state = close_upv(state, threshold)
         dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
 
       # ── Vararg ────────────────────────────────────────────────────
@@ -1227,7 +1256,12 @@ defmodule Lua.VM.Dispatcher do
         case func_value do
           {:compiled_closure, callee_proto, callee_upvalues} ->
             callee_regs = init_callee_regs(callee_proto, regs, base + 1, total_args)
-            callee_proto = setup_vararg_proto(callee_proto, regs, base + 1, total_args)
+
+            callee_proto =
+              if callee_proto.is_vararg,
+                do: setup_vararg_proto(callee_proto, regs, base + 1, total_args),
+                else: callee_proto
+
             # Reuse the fast-path frame shapes when result_count is 0
             # (discard) or 1 (single integer base). Only the genuine
             # multi-return shapes (-1, -2, n > 1) need the tagged
@@ -1240,9 +1274,9 @@ defmodule Lua.VM.Dispatcher do
               end
 
             frame = {code, pc + 1, regs, upvalues, proto, cont, dest, state.open_upvalues}
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -1265,9 +1299,9 @@ defmodule Lua.VM.Dispatcher do
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, total_args)
-            call_info = Executor.dispatcher_call_info(proto, name_hint, 0)
-            instruction_count = State.tick!(state, instruction_count)
-            State.check_call_depth!(state)
+            call_info = {proto.source, 0, name_hint}
+            instruction_count = tick(state, instruction_count)
+            ckdepth(state)
 
             state = %{
               state
@@ -1391,9 +1425,9 @@ defmodule Lua.VM.Dispatcher do
     should_continue = if step > 0, do: new_counter <= limit, else: new_counter >= limit
 
     if should_continue do
-      instruction_count = State.tick!(state, instruction_count)
+      instruction_count = tick(state, instruction_count)
       regs = :erlang.setelement(loop_var + 1, regs, new_counter)
-      state = Executor.dispatcher_close_open_upvalues_at_or_above(state, loop_var)
+      state = close_upv(state, loop_var)
       dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | rest_cont], frames, instruction_count)
     else
       dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
@@ -1438,7 +1472,7 @@ defmodule Lua.VM.Dispatcher do
          frames,
          instruction_count
        ) do
-    instruction_count = State.tick!(state, instruction_count)
+    instruction_count = tick(state, instruction_count)
     cps = {:cps_while_test, test_reg, cond_bc, body_bc, outer_code, outer_pc}
     dispatch(cond_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
   end
@@ -1476,7 +1510,7 @@ defmodule Lua.VM.Dispatcher do
        ) do
     case :erlang.element(test_reg + 1, regs) do
       v when v === nil or v === false ->
-        instruction_count = State.tick!(state, instruction_count)
+        instruction_count = tick(state, instruction_count)
         cps = {:cps_repeat_body, test_reg, body_bc, cond_bc, outer_code, outer_pc}
         dispatch(body_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
 
@@ -1517,11 +1551,11 @@ defmodule Lua.VM.Dispatcher do
         dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
 
       [first | _] ->
-        instruction_count = State.tick!(state, instruction_count)
+        instruction_count = tick(state, instruction_count)
         regs = :erlang.setelement(base + 3, regs, first)
         regs = assign_iter_results(regs, var_regs, results, 0)
         first_var_reg = :erlang.element(1, var_regs)
-        state = Executor.dispatcher_close_open_upvalues_at_or_above(state, first_var_reg)
+        state = close_upv(state, first_var_reg)
         dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | rest_cont], frames, instruction_count)
     end
   end
@@ -1643,6 +1677,26 @@ defmodule Lua.VM.Dispatcher do
 
   # ── Helpers ─────────────────────────────────────────────────────────────
 
+  # Hot-path guards. Each of these fires on every call or loop iteration
+  # only to discover it has nothing to do under the default configuration.
+  # Inlining the guard here keeps the no-op case to a single function-head
+  # match instead of a cross-module call into `Executor`/`State`; the
+  # non-trivial case still routes to the canonical implementation so the
+  # behaviour (and its error shapes) live in one place.
+  @compile {:inline, close_upv: 2, tick: 2, ckdepth: 1}
+
+  defp close_upv(%{open_upvalues: ou} = state, _threshold) when map_size(ou) == 0, do: state
+
+  defp close_upv(state, threshold) do
+    Executor.dispatcher_close_open_upvalues_at_or_above(state, threshold)
+  end
+
+  defp tick(%{max_instructions: :infinity}, instruction_count), do: instruction_count
+  defp tick(state, instruction_count), do: State.tick!(state, instruction_count)
+
+  defp ckdepth(%{max_call_depth: :infinity}), do: :ok
+  defp ckdepth(state), do: State.check_call_depth!(state)
+
   defp clear_nils(regs, _dest, 0), do: regs
 
   defp clear_nils(regs, dest, n) do
@@ -1735,15 +1789,16 @@ defmodule Lua.VM.Dispatcher do
   # Vararg setup at the call boundary. Mirrors the executor's per-call
   # behaviour: when calling a vararg function, regs[param_count..total_args)
   # become the varargs list carried on `%{proto | varargs: ...}`.
+  #
+  # Only reached when the callee is actually vararg — call sites test
+  # `callee_proto.is_vararg` inline so a non-vararg call pays one field
+  # read rather than a call into a function that rebuilds nothing. The
+  # vararg case still copies the whole `%Prototype{}`.
   defp setup_vararg_proto(callee_proto, src_regs, src_off, total_args) do
-    if callee_proto.is_vararg do
-      param_count = callee_proto.param_count
-      vararg_count = max(total_args - param_count, 0)
-      varargs = collect_args(src_regs, src_off + param_count, vararg_count)
-      %{callee_proto | varargs: varargs}
-    else
-      callee_proto
-    end
+    param_count = callee_proto.param_count
+    vararg_count = max(total_args - param_count, 0)
+    varargs = collect_args(src_regs, src_off + param_count, vararg_count)
+    %{callee_proto | varargs: varargs}
   end
 
   # Closure upvalue capture. `:parent_local` allocates (or reuses) an
@@ -1753,7 +1808,7 @@ defmodule Lua.VM.Dispatcher do
 
   defp build_upvalues([{:parent_local, reg, _name} | rest], regs, upvalues, state, acc) do
     {cell_ref, state} =
-      case Map.get(state.open_upvalues, reg) do
+      case :maps.get(reg, state.open_upvalues, nil) do
         nil ->
           new_ref = make_ref()
           value = :erlang.element(reg + 1, regs)

--- a/lib/lua/vm/dispatcher.ex
+++ b/lib/lua/vm/dispatcher.ex
@@ -154,18 +154,28 @@ defmodule Lua.VM.Dispatcher do
         proto
       end
 
-    saved_open = state.open_upvalues
-
     try do
-      state = %{state | open_upvalues: %{}}
+      # Seed the loop-carried control parameters — instruction tally, call
+      # stack, call depth, open upvalues — from the state crossing the
+      # boundary. `open_upvalues` starts empty: cells are keyed by register
+      # index, so a nested evaluation must not see the caller's. The
+      # terminals stamp all four back into the struct on the way out.
+      {results, state} =
+        dispatch(
+          proto.bytecode,
+          1,
+          regs,
+          upvalues,
+          proto,
+          state,
+          [],
+          [],
+          state.instruction_count,
+          state.call_stack,
+          state.call_depth,
+          %{}
+        )
 
-      # Seed the dispatcher tally from the budget carried across the boundary
-      # so an alternating-engine call chain accumulates against one budget
-      # instead of resetting here; the terminals stamp the final tally back
-      # into `state.instruction_count`.
-      {results, state} = dispatch(proto.bytecode, 1, regs, upvalues, proto, state, [], [], state.instruction_count)
-
-      state = %{state | open_upvalues: saved_open}
       {results, state}
     rescue
       # Backstop net: any raise site missed by the per-site state
@@ -215,28 +225,29 @@ defmodule Lua.VM.Dispatcher do
   # `Executor.call_function/3` instead, paying one Erlang stack frame
   # at the boundary.
 
-  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count) when pc > tuple_size(code) do
-    finish_body(regs, upvalues, proto, state, cont, frames, instruction_count)
+  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
+       when pc > tuple_size(code) do
+    finish_body(regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
   end
 
-  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count) do
+  defp dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou) do
     case :erlang.element(pc, code) do
       {@op_load_constant, dest, value} ->
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_load_boolean, dest, value} ->
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_load_nil, dest, count} ->
         regs = clear_nils(regs, dest, count + 1)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_move, dest, src} ->
         v = :erlang.element(src + 1, regs)
         regs = :erlang.setelement(dest + 1, regs, v)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_load_env, dest} ->
         env =
@@ -247,7 +258,7 @@ defmodule Lua.VM.Dispatcher do
           end
 
         regs = :erlang.setelement(dest + 1, regs, env)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_get_upvalue, dest, index} ->
         cell_ref = :erlang.element(index + 1, upvalues)
@@ -258,12 +269,12 @@ defmodule Lua.VM.Dispatcher do
         # has to match where it does fire.
         v = :maps.get(cell_ref, state.upvalue_cells, nil)
         regs = :erlang.setelement(dest + 1, regs, v)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_get_global, dest, name} ->
         v = State.get_global(state, name)
         regs = :erlang.setelement(dest + 1, regs, v)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_get_field, dest, table_reg, name, name_hint} ->
         table_val = :erlang.element(table_reg + 1, regs)
@@ -279,29 +290,29 @@ defmodule Lua.VM.Dispatcher do
             case data do
               %{^name => value} ->
                 regs = :erlang.setelement(dest + 1, regs, value)
-                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
               _ ->
                 case :erlang.map_get(:metatable, table) do
                   nil ->
                     regs = :erlang.setelement(dest + 1, regs, nil)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
                   _ ->
                     {value, state} =
-                      Executor.dispatcher_get_field(table_val, name, state, proto, name_hint)
+                      Executor.dispatcher_get_field(table_val, name, sync(state, cs, cd), proto, name_hint)
 
                     regs = :erlang.setelement(dest + 1, regs, value)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
                 end
             end
 
           _ ->
             {value, state} =
-              Executor.dispatcher_get_field(table_val, name, state, proto, name_hint)
+              Executor.dispatcher_get_field(table_val, name, sync(state, cs, cd), proto, name_hint)
 
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       # ── Arithmetic ──────────────────────────────────────────────────
@@ -320,16 +331,16 @@ defmodule Lua.VM.Dispatcher do
             sum = va + vb
             wrapped = if sum >= @min_int and sum <= @max_int, do: sum, else: Numeric.to_signed_int64(sum)
             regs = :erlang.setelement(dest + 1, regs, wrapped)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va + vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_binop(:add, va, vb, state, proto, hint_a, hint_b)
+            {value, state} = Executor.dispatcher_binop(:add, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_subtract, dest, a, b, hint_a, hint_b} ->
@@ -341,16 +352,16 @@ defmodule Lua.VM.Dispatcher do
             diff = va - vb
             wrapped = if diff >= @min_int and diff <= @max_int, do: diff, else: Numeric.to_signed_int64(diff)
             regs = :erlang.setelement(dest + 1, regs, wrapped)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va - vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_binop(:subtract, va, vb, state, proto, hint_a, hint_b)
+            {value, state} = Executor.dispatcher_binop(:subtract, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_multiply, dest, a, b, hint_a, hint_b} ->
@@ -362,16 +373,16 @@ defmodule Lua.VM.Dispatcher do
             prod = va * vb
             wrapped = if prod >= @min_int and prod <= @max_int, do: prod, else: Numeric.to_signed_int64(prod)
             regs = :erlang.setelement(dest + 1, regs, wrapped)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va * vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_binop(:multiply, va, vb, state, proto, hint_a, hint_b)
+            {value, state} = Executor.dispatcher_binop(:multiply, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_divide, dest, a, b, hint_a, hint_b} ->
@@ -380,14 +391,14 @@ defmodule Lua.VM.Dispatcher do
             :divide,
             :erlang.element(a + 1, regs),
             :erlang.element(b + 1, regs),
-            state,
+            sync(state, cs, cd),
             proto,
             hint_a,
             hint_b
           )
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_floor_divide, dest, a, b, hint_a, hint_b} ->
         {value, state} =
@@ -395,14 +406,14 @@ defmodule Lua.VM.Dispatcher do
             :floor_divide,
             :erlang.element(a + 1, regs),
             :erlang.element(b + 1, regs),
-            state,
+            sync(state, cs, cd),
             proto,
             hint_a,
             hint_b
           )
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_modulo, dest, a, b, hint_a, hint_b} ->
         {value, state} =
@@ -410,14 +421,14 @@ defmodule Lua.VM.Dispatcher do
             :modulo,
             :erlang.element(a + 1, regs),
             :erlang.element(b + 1, regs),
-            state,
+            sync(state, cs, cd),
             proto,
             hint_a,
             hint_b
           )
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_power, dest, a, b, hint_a, hint_b} ->
         {value, state} =
@@ -425,21 +436,21 @@ defmodule Lua.VM.Dispatcher do
             :power,
             :erlang.element(a + 1, regs),
             :erlang.element(b + 1, regs),
-            state,
+            sync(state, cs, cd),
             proto,
             hint_a,
             hint_b
           )
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_negate, dest, src, hint} ->
         {value, state} =
-          Executor.dispatcher_unop(:negate, :erlang.element(src + 1, regs), state, proto, hint)
+          Executor.dispatcher_unop(:negate, :erlang.element(src + 1, regs), sync(state, cs, cd), proto, hint)
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Bitwise ─────────────────────────────────────────────────────
       #
@@ -463,11 +474,11 @@ defmodule Lua.VM.Dispatcher do
 
         if is_integer(va) and is_integer(vb) do
           regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(Bitwise.band(va, vb)))
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         else
-          {value, state} = Executor.dispatcher_bitwise(:band, va, vb, state, proto, hint_a, hint_b)
+          {value, state} = Executor.dispatcher_bitwise(:band, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
           regs = :erlang.setelement(dest + 1, regs, value)
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_bitwise_or, dest, a, b, hint_a, hint_b} ->
@@ -476,11 +487,11 @@ defmodule Lua.VM.Dispatcher do
 
         if is_integer(va) and is_integer(vb) do
           regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(Bitwise.bor(va, vb)))
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         else
-          {value, state} = Executor.dispatcher_bitwise(:bor, va, vb, state, proto, hint_a, hint_b)
+          {value, state} = Executor.dispatcher_bitwise(:bor, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
           regs = :erlang.setelement(dest + 1, regs, value)
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_bitwise_xor, dest, a, b, hint_a, hint_b} ->
@@ -489,32 +500,32 @@ defmodule Lua.VM.Dispatcher do
 
         if is_integer(va) and is_integer(vb) do
           regs = :erlang.setelement(dest + 1, regs, Numeric.to_signed_int64(Bitwise.bxor(va, vb)))
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         else
-          {value, state} = Executor.dispatcher_bitwise(:bxor, va, vb, state, proto, hint_a, hint_b)
+          {value, state} = Executor.dispatcher_bitwise(:bxor, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
           regs = :erlang.setelement(dest + 1, regs, value)
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_shift_left, dest, a, b, hint_a, hint_b} ->
         va = :erlang.element(a + 1, regs)
         vb = :erlang.element(b + 1, regs)
-        {value, state} = Executor.dispatcher_bitwise(:shl, va, vb, state, proto, hint_a, hint_b)
+        {value, state} = Executor.dispatcher_bitwise(:shl, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_shift_right, dest, a, b, hint_a, hint_b} ->
         va = :erlang.element(a + 1, regs)
         vb = :erlang.element(b + 1, regs)
-        {value, state} = Executor.dispatcher_bitwise(:shr, va, vb, state, proto, hint_a, hint_b)
+        {value, state} = Executor.dispatcher_bitwise(:shr, va, vb, sync(state, cs, cd), proto, hint_a, hint_b)
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_bitwise_not, dest, src, hint} ->
         val = :erlang.element(src + 1, regs)
-        {value, state} = Executor.dispatcher_bnot(val, state, proto, hint)
+        {value, state} = Executor.dispatcher_bnot(val, sync(state, cs, cd), proto, hint)
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Comparisons ─────────────────────────────────────────────────
 
@@ -525,16 +536,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va < vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va < vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:less_than, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:less_than, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_less_equal, dest, a, b} ->
@@ -544,16 +555,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va <= vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va <= vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:less_equal, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:less_equal, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_greater_than, dest, a, b} ->
@@ -563,16 +574,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va > vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va > vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:greater_than, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:greater_than, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_greater_equal, dest, a, b} ->
@@ -582,16 +593,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va >= vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va >= vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:greater_equal, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:greater_equal, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_equal, dest, a, b} ->
@@ -601,16 +612,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va == vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va == vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:equal, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:equal, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_not_equal, dest, a, b} ->
@@ -620,16 +631,16 @@ defmodule Lua.VM.Dispatcher do
         cond do
           is_number(va) and is_number(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va != vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           is_binary(va) and is_binary(vb) ->
             regs = :erlang.setelement(dest + 1, regs, va != vb)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           true ->
-            {value, state} = Executor.dispatcher_cmp(:not_equal, va, vb, state, proto)
+            {value, state} = Executor.dispatcher_cmp(:not_equal, va, vb, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_not, dest, src} ->
@@ -638,7 +649,7 @@ defmodule Lua.VM.Dispatcher do
         # values. Saves a function call per `:not` opcode.
         result = v === nil or v === false
         regs = :erlang.setelement(dest + 1, regs, result)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Conditional branching ───────────────────────────────────────
       #
@@ -657,7 +668,7 @@ defmodule Lua.VM.Dispatcher do
             _ -> then_bc
           end
 
-        dispatch(branch, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames, instruction_count)
+        dispatch(branch, 1, regs, upvalues, proto, state, [{code, pc + 1} | cont], frames, instruction_count, cs, cd, ou)
 
       # ── Calls ───────────────────────────────────────────────────────
       #
@@ -686,19 +697,10 @@ defmodule Lua.VM.Dispatcher do
                 do: setup_vararg_proto(callee_proto, regs, base + 1, arg_count),
                 else: callee_proto
 
-            frame =
-              {code, pc + 1, regs, upvalues, proto, cont, :discard, state.open_upvalues}
-
+            frame = {code, pc + 1, regs, upvalues, proto, cont, :discard, ou}
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
-
-            state = %{
-              state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
-                open_upvalues: %{}
-            }
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             dispatch(
               callee_proto.bytecode,
@@ -709,38 +711,40 @@ defmodule Lua.VM.Dispatcher do
               state,
               [],
               [frame | frames],
-              instruction_count
+              instruction_count,
+              [call_info | cs],
+              cd + 1,
+              %{}
             )
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             state = %{
               state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+              | call_stack: [call_info | cs],
+                call_depth: cd + 1,
                 instruction_count: instruction_count
             }
 
             {_results, state} = Executor.call_function(closure, args, state)
             instruction_count = state.instruction_count
-            state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           _ ->
             args = collect_args(regs, base + 1, arg_count)
 
-            state = %{state | instruction_count: instruction_count}
+            state = %{state | call_stack: cs, call_depth: cd, instruction_count: instruction_count}
 
             {_results, state} =
               Executor.dispatcher_call_function(func_value, args, state, proto, name_hint, line)
 
             instruction_count = state.instruction_count
 
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_call_one, base, arg_count, name_hint, line} ->
@@ -756,21 +760,12 @@ defmodule Lua.VM.Dispatcher do
                 else: callee_proto
 
             # Frame is a tuple, not a map: pattern-matching a tuple in
-            # `return_one/3` skips Map.fetch! lookups and lets the BEAM
+            # `return_one/7` skips Map.fetch! lookups and lets the BEAM
             # bind everything in a single `move` per slot.
-            frame =
-              {code, pc + 1, regs, upvalues, proto, cont, base, state.open_upvalues}
-
+            frame = {code, pc + 1, regs, upvalues, proto, cont, base, ou}
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
-
-            state = %{
-              state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
-                open_upvalues: %{}
-            }
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             dispatch(
               callee_proto.bytecode,
@@ -781,25 +776,27 @@ defmodule Lua.VM.Dispatcher do
               state,
               [],
               [frame | frames],
-              instruction_count
+              instruction_count,
+              [call_info | cs],
+              cd + 1,
+              %{}
             )
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, arg_count)
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             state = %{
               state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+              | call_stack: [call_info | cs],
+                call_depth: cd + 1,
                 instruction_count: instruction_count
             }
 
             {results, state} = Executor.call_function(closure, args, state)
             instruction_count = state.instruction_count
-            state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
 
             first =
               case results do
@@ -808,12 +805,12 @@ defmodule Lua.VM.Dispatcher do
               end
 
             regs = :erlang.setelement(base + 1, regs, first)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           _ ->
             args = collect_args(regs, base + 1, arg_count)
 
-            state = %{state | instruction_count: instruction_count}
+            state = %{state | call_stack: cs, call_depth: cd, instruction_count: instruction_count}
 
             {results, state} =
               Executor.dispatcher_call_function(func_value, args, state, proto, name_hint, line)
@@ -827,7 +824,7 @@ defmodule Lua.VM.Dispatcher do
               end
 
             regs = :erlang.setelement(base + 1, regs, first)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       # ── Returns ─────────────────────────────────────────────────────
@@ -840,10 +837,10 @@ defmodule Lua.VM.Dispatcher do
       # `call_function/3` contract.
 
       {@op_return_one, base} ->
-        return_one(:erlang.element(base + 1, regs), state, frames, instruction_count)
+        return_one(:erlang.element(base + 1, regs), state, frames, instruction_count, cs, cd, ou)
 
       {@op_return_zero} ->
-        return_one(nil, state, frames, instruction_count)
+        return_one(nil, state, frames, instruction_count, cs, cd, ou)
 
       # ── Table opcodes ───────────────────────────────────────────────
       #
@@ -855,7 +852,7 @@ defmodule Lua.VM.Dispatcher do
       {@op_new_table, dest} ->
         {tref, state} = State.alloc_table(state)
         regs = :erlang.setelement(dest + 1, regs, tref)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_get_table, dest, table_reg, key_reg, name_hint} ->
         table_val = :erlang.element(table_reg + 1, regs)
@@ -870,19 +867,19 @@ defmodule Lua.VM.Dispatcher do
                 case :erlang.map_get(:metatable, table) do
                   nil ->
                     regs = :erlang.setelement(dest + 1, regs, nil)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
                   _ ->
                     {value, state} =
-                      Executor.dispatcher_get_table(table_val, key, state, proto, name_hint)
+                      Executor.dispatcher_get_table(table_val, key, sync(state, cs, cd), proto, name_hint)
 
                     regs = :erlang.setelement(dest + 1, regs, value)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
                 end
 
               value ->
                 regs = :erlang.setelement(dest + 1, regs, value)
-                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
             end
 
           {:tref, id} when is_integer(key) or is_binary(key) ->
@@ -892,37 +889,37 @@ defmodule Lua.VM.Dispatcher do
             case data do
               %{^key => value} ->
                 regs = :erlang.setelement(dest + 1, regs, value)
-                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
               _ ->
                 case :erlang.map_get(:metatable, table) do
                   nil ->
                     regs = :erlang.setelement(dest + 1, regs, nil)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
                   _ ->
                     {value, state} =
-                      Executor.dispatcher_get_table(table_val, key, state, proto, name_hint)
+                      Executor.dispatcher_get_table(table_val, key, sync(state, cs, cd), proto, name_hint)
 
                     regs = :erlang.setelement(dest + 1, regs, value)
-                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                    dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
                 end
             end
 
           _ ->
             {value, state} =
-              Executor.dispatcher_get_table(table_val, key, state, proto, name_hint)
+              Executor.dispatcher_get_table(table_val, key, sync(state, cs, cd), proto, name_hint)
 
             regs = :erlang.setelement(dest + 1, regs, value)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       {@op_set_table, table_reg, key_reg, value_reg, name_hint} ->
         table_val = :erlang.element(table_reg + 1, regs)
         key = :erlang.element(key_reg + 1, regs)
         value = :erlang.element(value_reg + 1, regs)
-        state = Executor.dispatcher_set_table(table_val, key, value, state, proto, name_hint)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        state = Executor.dispatcher_set_table(table_val, key, value, sync(state, cs, cd), proto, name_hint)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # Mirrors `@op_get_field`'s shape: a tref whose table has no metatable
       # has no `__newindex` to consult, so the write is a direct
@@ -943,14 +940,14 @@ defmodule Lua.VM.Dispatcher do
                   %{state | tables: :maps.put(id, Table.put(table, name, value), state.tables)}
 
                 _ ->
-                  Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
+                  Executor.dispatcher_set_field(table_val, name, value, sync(state, cs, cd), proto, name_hint)
               end
 
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           # Indexing a non-table always raises; the bridge owns the wording.
           _ ->
-            Executor.dispatcher_set_field(table_val, name, value, state, proto, name_hint)
+            Executor.dispatcher_set_field(table_val, name, value, sync(state, cs, cd), proto, name_hint)
         end
 
       # `:set_list` with a positive integer count is the table-constructor
@@ -964,7 +961,7 @@ defmodule Lua.VM.Dispatcher do
             set_list_into_table(table, regs, start, count, offset, 0)
           end)
 
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # `:set_list` multi-return tail (`{f(), 1}`): fold the static prefix
       # `init_count` with the trailing values count the last multi-return
@@ -979,7 +976,7 @@ defmodule Lua.VM.Dispatcher do
             set_list_into_table(table, regs, start, total, offset, 0)
           end)
 
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_length, dest, source} ->
         value = :erlang.element(source + 1, regs)
@@ -994,22 +991,22 @@ defmodule Lua.VM.Dispatcher do
                 # without __len is the border length of the data map.
                 len = Table.length(table)
                 regs = :erlang.setelement(dest + 1, regs, len)
-                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
               _ ->
-                {len, state} = Executor.dispatcher_length(value, state, proto)
+                {len, state} = Executor.dispatcher_length(value, sync(state, cs, cd), proto)
                 regs = :erlang.setelement(dest + 1, regs, len)
-                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+                dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
             end
 
           v when is_binary(v) ->
             regs = :erlang.setelement(dest + 1, regs, byte_size(v))
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           _ ->
-            {len, state} = Executor.dispatcher_length(value, state, proto)
+            {len, state} = Executor.dispatcher_length(value, sync(state, cs, cd), proto)
             regs = :erlang.setelement(dest + 1, regs, len)
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       # ── numeric_for ─────────────────────────────────────────────────
@@ -1026,7 +1023,7 @@ defmodule Lua.VM.Dispatcher do
             :erlang.element(base + 1, regs),
             :erlang.element(base + 2, regs),
             :erlang.element(base + 3, regs),
-            state
+            sync(state, cs, cd)
           )
 
         regs = :erlang.setelement(base + 1, regs, counter)
@@ -1038,12 +1035,26 @@ defmodule Lua.VM.Dispatcher do
 
         if should_continue do
           regs = :erlang.setelement(loop_var + 1, regs, counter)
-          state = close_upv(state, loop_var)
+          ou = close_upv(ou, loop_var)
           marker = {:cps_for, base, loop_var, body_bc, code, pc + 1}
           loop_exit = {:loop_exit, code, pc + 1}
-          dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | cont], frames, instruction_count)
+
+          dispatch(
+            body_bc,
+            1,
+            regs,
+            upvalues,
+            proto,
+            state,
+            [marker, loop_exit | cont],
+            frames,
+            instruction_count,
+            cs,
+            cd,
+            ou
+          )
         else
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
 
       # ── while_loop / repeat_loop / generic_for ─────────────────────
@@ -1056,12 +1067,12 @@ defmodule Lua.VM.Dispatcher do
       {@op_while_loop, test_reg, cond_bc, body_bc} ->
         cps = {:cps_while_test, test_reg, cond_bc, body_bc, code, pc + 1}
         loop_exit = {:loop_exit, code, pc + 1}
-        dispatch(cond_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | cont], frames, instruction_count)
+        dispatch(cond_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | cont], frames, instruction_count, cs, cd, ou)
 
       {@op_repeat_loop, test_reg, body_bc, cond_bc} ->
         cps = {:cps_repeat_body, test_reg, body_bc, cond_bc, code, pc + 1}
         loop_exit = {:loop_exit, code, pc + 1}
-        dispatch(body_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | cont], frames, instruction_count)
+        dispatch(body_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | cont], frames, instruction_count, cs, cd, ou)
 
       {@op_generic_for, base, var_regs, body_bc, line} ->
         # Iterator call follows the same shape as the executor:
@@ -1074,7 +1085,7 @@ defmodule Lua.VM.Dispatcher do
         invariant_state = :erlang.element(base + 2, regs)
         control = :erlang.element(base + 3, regs)
 
-        state = %{state | instruction_count: instruction_count}
+        state = %{state | call_stack: cs, call_depth: cd, instruction_count: instruction_count}
 
         {results, state} =
           Executor.dispatcher_call_value(iter_func, [invariant_state, control], proto, state, line)
@@ -1083,19 +1094,33 @@ defmodule Lua.VM.Dispatcher do
 
         case results do
           [nil | _] ->
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           [] ->
-            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+            dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
           [first | _] ->
             regs = :erlang.setelement(base + 3, regs, first)
             regs = assign_iter_results(regs, var_regs, results, 0)
             first_var_reg = :erlang.element(1, var_regs)
-            state = close_upv(state, first_var_reg)
+            ou = close_upv(ou, first_var_reg)
             marker = {:cps_generic_for, base, var_regs, body_bc, line, code, pc + 1}
             loop_exit = {:loop_exit, code, pc + 1}
-            dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | cont], frames, instruction_count)
+
+            dispatch(
+              body_bc,
+              1,
+              regs,
+              upvalues,
+              proto,
+              state,
+              [marker, loop_exit | cont],
+              frames,
+              instruction_count,
+              cs,
+              cd,
+              ou
+            )
         end
 
       # ── break ─────────────────────────────────────────────────────
@@ -1106,7 +1131,7 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_break} ->
         {exit_code, exit_pc, rest_cont} = find_loop_exit(cont)
-        dispatch(exit_code, exit_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(exit_code, exit_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
 
       # ── label / goto ──────────────────────────────────────────────
       #
@@ -1118,16 +1143,16 @@ defmodule Lua.VM.Dispatcher do
       # enclosing `code` recorded on the unwound markers.
 
       {@op_label, _name, _level} ->
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_goto, 0, target_pc, level} ->
-        state = close_upv(state, level)
-        dispatch(code, target_pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+        ou = close_upv(ou, level)
+        dispatch(code, target_pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_goto, depth, target_pc, level} ->
-        state = close_upv(state, level)
+        ou = close_upv(ou, level)
         {dest_code, rest_cont} = unwind_goto(cont, depth)
-        dispatch(dest_code, target_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(dest_code, target_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
 
       # ── Closure construction ──────────────────────────────────────
       #
@@ -1143,7 +1168,7 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_closure, dest, proto_index} ->
         nested_proto = Enum.at(proto.prototypes, proto_index)
-        {cells, state} = build_upvalues(nested_proto.upvalue_descriptors, regs, upvalues, state, [])
+        {cells, state, ou} = build_upvalues(nested_proto.upvalue_descriptors, regs, upvalues, state, ou, [])
         upvalues_tuple = List.to_tuple(:lists.reverse(cells))
 
         closure =
@@ -1153,7 +1178,7 @@ defmodule Lua.VM.Dispatcher do
           end
 
         regs = :erlang.setelement(dest + 1, regs, closure)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Upvalue access ────────────────────────────────────────────
       #
@@ -1168,21 +1193,21 @@ defmodule Lua.VM.Dispatcher do
         cell_ref = :erlang.element(index + 1, upvalues)
         value = :erlang.element(source + 1, regs)
         state = %{state | upvalue_cells: Map.put(state.upvalue_cells, cell_ref, value)}
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_get_open_upvalue, dest, reg} ->
         value =
-          case :maps.get(reg, state.open_upvalues, nil) do
+          case :maps.get(reg, ou, nil) do
             nil -> :erlang.element(reg + 1, regs)
             cell_ref -> :maps.get(cell_ref, state.upvalue_cells, nil)
           end
 
         regs = :erlang.setelement(dest + 1, regs, value)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_set_open_upvalue, reg, source} ->
         state =
-          case :maps.get(reg, state.open_upvalues, nil) do
+          case :maps.get(reg, ou, nil) do
             nil ->
               state
 
@@ -1191,11 +1216,11 @@ defmodule Lua.VM.Dispatcher do
               %{state | upvalue_cells: Map.put(state.upvalue_cells, cell_ref, value)}
           end
 
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_close_upvalues, threshold} ->
-        state = close_upv(state, threshold)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        ou = close_upv(ou, threshold)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Vararg ────────────────────────────────────────────────────
       #
@@ -1210,25 +1235,25 @@ defmodule Lua.VM.Dispatcher do
         varargs = proto.varargs
         {regs, n} = write_varargs(regs, base, varargs, 0)
         state = %{state | multi_return_count: n}
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       {@op_vararg, base, count} ->
         regs = write_varargs_n(regs, base, proto.varargs, count)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Multi-return returns ──────────────────────────────────────
 
       {@op_return_proto_varargs} ->
-        return_multi(proto.varargs, state, frames, instruction_count)
+        return_multi(proto.varargs, state, frames, instruction_count, cs, cd, ou)
 
       {@op_return_collect, base, fixed} ->
         total = fixed + state.multi_return_count
         results = collect_args(regs, base, total)
-        return_multi(results, state, frames, instruction_count)
+        return_multi(results, state, frames, instruction_count, cs, cd, ou)
 
       {@op_return_multi, base, count} ->
         results = collect_args(regs, base, count)
-        return_multi(results, state, frames, instruction_count)
+        return_multi(results, state, frames, instruction_count, cs, cd, ou)
 
       # ── Multi-return calls ────────────────────────────────────────
       #
@@ -1273,17 +1298,10 @@ defmodule Lua.VM.Dispatcher do
                 _ -> {:multi, base, result_count}
               end
 
-            frame = {code, pc + 1, regs, upvalues, proto, cont, dest, state.open_upvalues}
+            frame = {code, pc + 1, regs, upvalues, proto, cont, dest, ou}
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
-
-            state = %{
-              state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
-                open_upvalues: %{}
-            }
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             dispatch(
               callee_proto.bytecode,
@@ -1294,25 +1312,27 @@ defmodule Lua.VM.Dispatcher do
               state,
               [],
               [frame | frames],
-              instruction_count
+              instruction_count,
+              [call_info | cs],
+              cd + 1,
+              %{}
             )
 
           {:lua_closure, _, _} = closure ->
             args = collect_args(regs, base + 1, total_args)
             call_info = {proto.source, 0, name_hint}
-            instruction_count = tick(state, instruction_count)
-            ckdepth(state)
+            instruction_count = tick(state, instruction_count, cs, cd)
+            ckdepth(state, cs, cd)
 
             state = %{
               state
-              | call_stack: [call_info | state.call_stack],
-                call_depth: state.call_depth + 1,
+              | call_stack: [call_info | cs],
+                call_depth: cd + 1,
                 instruction_count: instruction_count
             }
 
             {results, state} = Executor.call_function(closure, args, state)
             instruction_count = state.instruction_count
-            state = %{state | call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
 
             apply_multi_call_result(
               result_count,
@@ -1326,13 +1346,16 @@ defmodule Lua.VM.Dispatcher do
               state,
               cont,
               frames,
-              instruction_count
+              instruction_count,
+              cs,
+              cd,
+              ou
             )
 
           _ ->
             args = collect_args(regs, base + 1, total_args)
 
-            state = %{state | instruction_count: instruction_count}
+            state = %{state | call_stack: cs, call_depth: cd, instruction_count: instruction_count}
 
             {results, state} =
               Executor.dispatcher_call_function(func_value, args, state, proto, name_hint, line)
@@ -1351,7 +1374,10 @@ defmodule Lua.VM.Dispatcher do
               state,
               cont,
               frames,
-              instruction_count
+              instruction_count,
+              cs,
+              cd,
+              ou
             )
         end
 
@@ -1365,10 +1391,10 @@ defmodule Lua.VM.Dispatcher do
 
       {@op_self, base, obj_reg, method_name, name_hint} ->
         obj = :erlang.element(obj_reg + 1, regs)
-        {func, state} = Executor.dispatcher_index_method_target(obj, method_name, state, proto, name_hint)
+        {func, state} = Executor.dispatcher_index_method_target(obj, method_name, sync(state, cs, cd), proto, name_hint)
         regs = :erlang.setelement(base + 2, regs, obj)
         regs = :erlang.setelement(base + 1, regs, func)
-        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+        dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
 
       # ── Concatenation ─────────────────────────────────────────────
       #
@@ -1386,19 +1412,30 @@ defmodule Lua.VM.Dispatcher do
           end
 
           regs = :erlang.setelement(dest + 1, regs, left <> right)
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         else
-          {result, state} = Executor.dispatcher_concat(left, right, state, proto)
+          {result, state} = Executor.dispatcher_concat(left, right, sync(state, cs, cd), proto)
           regs = :erlang.setelement(dest + 1, regs, result)
-          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count)
+          dispatch(code, pc + 1, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
         end
     end
   end
 
   # ── End-of-body handling ────────────────────────────────────────────────
 
-  defp finish_body(regs, upvalues, proto, state, [{next_code, next_pc} | rest_cont], frames, instruction_count) do
-    dispatch(next_code, next_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+  defp finish_body(
+         regs,
+         upvalues,
+         proto,
+         state,
+         [{next_code, next_pc} | rest_cont],
+         frames,
+         instruction_count,
+         cs,
+         cd,
+         ou
+       ) do
+    dispatch(next_code, next_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
   end
 
   # `:numeric_for` body ran to completion. Increment the counter, re-test,
@@ -1415,7 +1452,10 @@ defmodule Lua.VM.Dispatcher do
          state,
          [{:cps_for, base, loop_var, body_bc, outer_code, outer_pc} = marker, {:loop_exit, _, _} = loop_exit | rest_cont],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
     counter = :erlang.element(base + 1, regs)
     step = :erlang.element(base + 3, regs)
@@ -1425,12 +1465,26 @@ defmodule Lua.VM.Dispatcher do
     should_continue = if step > 0, do: new_counter <= limit, else: new_counter >= limit
 
     if should_continue do
-      instruction_count = tick(state, instruction_count)
+      instruction_count = tick(state, instruction_count, cs, cd)
       regs = :erlang.setelement(loop_var + 1, regs, new_counter)
-      state = close_upv(state, loop_var)
-      dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | rest_cont], frames, instruction_count)
+      ou = close_upv(ou, loop_var)
+
+      dispatch(
+        body_bc,
+        1,
+        regs,
+        upvalues,
+        proto,
+        state,
+        [marker, loop_exit | rest_cont],
+        frames,
+        instruction_count,
+        cs,
+        cd,
+        ou
+      )
     else
-      dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+      dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
     end
   end
 
@@ -1446,15 +1500,32 @@ defmodule Lua.VM.Dispatcher do
            {:loop_exit, _, _} = loop_exit | rest_cont
          ],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
     case :erlang.element(test_reg + 1, regs) do
       v when v === nil or v === false ->
-        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
 
       _ ->
         cps = {:cps_while_body, test_reg, cond_bc, body_bc, outer_code, outer_pc}
-        dispatch(body_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
+
+        dispatch(
+          body_bc,
+          1,
+          regs,
+          upvalues,
+          proto,
+          state,
+          [cps, loop_exit | rest_cont],
+          frames,
+          instruction_count,
+          cs,
+          cd,
+          ou
+        )
     end
   end
 
@@ -1470,11 +1541,28 @@ defmodule Lua.VM.Dispatcher do
            {:loop_exit, _, _} = loop_exit | rest_cont
          ],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
-    instruction_count = tick(state, instruction_count)
+    instruction_count = tick(state, instruction_count, cs, cd)
     cps = {:cps_while_test, test_reg, cond_bc, body_bc, outer_code, outer_pc}
-    dispatch(cond_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
+
+    dispatch(
+      cond_bc,
+      1,
+      regs,
+      upvalues,
+      proto,
+      state,
+      [cps, loop_exit | rest_cont],
+      frames,
+      instruction_count,
+      cs,
+      cd,
+      ou
+    )
   end
 
   # `:repeat_loop`: body just finished. Run the condition next.
@@ -1488,10 +1576,27 @@ defmodule Lua.VM.Dispatcher do
            {:loop_exit, _, _} = loop_exit | rest_cont
          ],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
     cps = {:cps_repeat_cond, test_reg, body_bc, cond_bc, outer_code, outer_pc}
-    dispatch(cond_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
+
+    dispatch(
+      cond_bc,
+      1,
+      regs,
+      upvalues,
+      proto,
+      state,
+      [cps, loop_exit | rest_cont],
+      frames,
+      instruction_count,
+      cs,
+      cd,
+      ou
+    )
   end
 
   # `:repeat_loop`: condition just finished. test_reg truthy = exit (Lua's
@@ -1506,16 +1611,33 @@ defmodule Lua.VM.Dispatcher do
            {:loop_exit, _, _} = loop_exit | rest_cont
          ],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
     case :erlang.element(test_reg + 1, regs) do
       v when v === nil or v === false ->
-        instruction_count = tick(state, instruction_count)
+        instruction_count = tick(state, instruction_count, cs, cd)
         cps = {:cps_repeat_body, test_reg, body_bc, cond_bc, outer_code, outer_pc}
-        dispatch(body_bc, 1, regs, upvalues, proto, state, [cps, loop_exit | rest_cont], frames, instruction_count)
+
+        dispatch(
+          body_bc,
+          1,
+          regs,
+          upvalues,
+          proto,
+          state,
+          [cps, loop_exit | rest_cont],
+          frames,
+          instruction_count,
+          cs,
+          cd,
+          ou
+        )
 
       _ ->
-        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
     end
   end
 
@@ -1530,13 +1652,16 @@ defmodule Lua.VM.Dispatcher do
            {:loop_exit, _, _} = loop_exit | rest_cont
          ],
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
     iter_func = :erlang.element(base + 1, regs)
     invariant_state = :erlang.element(base + 2, regs)
     control = :erlang.element(base + 3, regs)
 
-    state = %{state | instruction_count: instruction_count}
+    state = %{state | call_stack: cs, call_depth: cd, instruction_count: instruction_count}
 
     {results, state} =
       Executor.dispatcher_call_value(iter_func, [invariant_state, control], proto, state, line)
@@ -1545,18 +1670,32 @@ defmodule Lua.VM.Dispatcher do
 
     case results do
       [nil | _] ->
-        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
 
       [] ->
-        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+        dispatch(outer_code, outer_pc, regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
 
       [first | _] ->
-        instruction_count = tick(state, instruction_count)
+        instruction_count = tick(state, instruction_count, cs, cd)
         regs = :erlang.setelement(base + 3, regs, first)
         regs = assign_iter_results(regs, var_regs, results, 0)
         first_var_reg = :erlang.element(1, var_regs)
-        state = close_upv(state, first_var_reg)
-        dispatch(body_bc, 1, regs, upvalues, proto, state, [marker, loop_exit | rest_cont], frames, instruction_count)
+        ou = close_upv(ou, first_var_reg)
+
+        dispatch(
+          body_bc,
+          1,
+          regs,
+          upvalues,
+          proto,
+          state,
+          [marker, loop_exit | rest_cont],
+          frames,
+          instruction_count,
+          cs,
+          cd,
+          ou
+        )
     end
   end
 
@@ -1564,8 +1703,8 @@ defmodule Lua.VM.Dispatcher do
   # body ran past its last instruction with the loop_exit still on top).
   # Drop the loop_exit and let the next iteration of finish_body see the
   # cont below it.
-  defp finish_body(regs, upvalues, proto, state, [{:loop_exit, _, _} | rest_cont], frames, instruction_count) do
-    finish_body(regs, upvalues, proto, state, rest_cont, frames, instruction_count)
+  defp finish_body(regs, upvalues, proto, state, [{:loop_exit, _, _} | rest_cont], frames, instruction_count, cs, cd, ou) do
+    finish_body(regs, upvalues, proto, state, rest_cont, frames, instruction_count, cs, cd, ou)
   end
 
   # Body exhausted with no continuation: prototype ran off the end. Lua
@@ -1573,8 +1712,8 @@ defmodule Lua.VM.Dispatcher do
   # values when control falls off the end, not a single `nil` — the
   # caller's `result_count` decides how that's projected (nil for a
   # single-value site, empty slot for a multi-return one).
-  defp finish_body(_regs, _upvalues, _proto, state, [], frames, instruction_count) do
-    return_multi([], state, frames, instruction_count)
+  defp finish_body(_regs, _upvalues, _proto, state, [], frames, instruction_count, cs, cd, ou) do
+    return_multi([], state, frames, instruction_count, cs, cd, ou)
   end
 
   # ── Return propagation through frames ───────────────────────────────────
@@ -1593,29 +1732,33 @@ defmodule Lua.VM.Dispatcher do
   #   {:multi, B, -2} → expand all into regs[B..], set multi_return_count.
   #   {:multi, B, n>1} → write n results into regs[B..], pad nil.
 
-  defp return_one(value, state, [], instruction_count) do
-    # Top of this dispatcher sub-evaluation: stamp the tally back into the
-    # state so a caller in the other engine can resume the same budget.
-    {[value], %{state | instruction_count: instruction_count}}
+  defp return_one(value, state, [], instruction_count, cs, cd, _ou) do
+    # Top of this dispatcher sub-evaluation: stamp the loop-carried control
+    # parameters back into the state so a caller in the other engine
+    # resumes the same budget and the same call stack. A bridge out of the
+    # loop may have left a deeper stack stamped in the struct; `cs`/`cd`
+    # have unwound back to their entry values, so this restores them.
+    {[value], %{state | instruction_count: instruction_count, call_stack: cs, call_depth: cd}}
   end
 
-  defp return_one(value, state, [frame | rest_frames], instruction_count) do
-    {code, pc, regs, upvalues, proto, cont, dest, saved_open} = frame
+  defp return_one(value, state, [frame | rest_frames], instruction_count, cs, cd, _ou) do
+    {code, pc, regs, upvalues, proto, cont, dest, ou} = frame
     # Every dispatcher frame corresponds to a Lua-level call that pushed a
     # call_stack entry. Pop it on the way out — the interpreter's
     # `do_frame_return/6` does the same at executor.ex:1767.
-    state = %{state | open_upvalues: saved_open, call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
+    cs = tl(cs)
+    cd = cd - 1
 
     case dest do
       :discard ->
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       n when is_integer(n) ->
         regs = :erlang.setelement(n + 1, regs, value)
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, _, -1} ->
-        return_one(value, state, rest_frames, instruction_count)
+        return_one(value, state, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, base, -2} ->
         # The expansion dest may sit past the statically reserved register
@@ -1625,31 +1768,32 @@ defmodule Lua.VM.Dispatcher do
         regs = grow_regs(regs, base + 1)
         regs = :erlang.setelement(base + 1, regs, value)
         state = %{state | multi_return_count: 1}
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, base, n} when is_integer(n) and n > 1 ->
         regs = grow_regs(regs, base + n)
         regs = :erlang.setelement(base + 1, regs, value)
         regs = pad_nils(regs, base + 1, n - 1)
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
     end
   end
 
   # List-return path for `:return_multi`, `:return_collect`,
   # `:return_proto_varargs`, and the non-compiled-callee branch of
-  # `:call_multi`. Mirrors `return_one/3`'s frame-variant handling.
+  # `:call_multi`. Mirrors `return_one/7`'s frame-variant handling.
 
-  defp return_multi(results, state, [], instruction_count) do
-    {results, %{state | instruction_count: instruction_count}}
+  defp return_multi(results, state, [], instruction_count, cs, cd, _ou) do
+    {results, %{state | instruction_count: instruction_count, call_stack: cs, call_depth: cd}}
   end
 
-  defp return_multi(results, state, [frame | rest_frames], instruction_count) do
-    {code, pc, regs, upvalues, proto, cont, dest, saved_open} = frame
-    state = %{state | open_upvalues: saved_open, call_stack: tl(state.call_stack), call_depth: state.call_depth - 1}
+  defp return_multi(results, state, [frame | rest_frames], instruction_count, cs, cd, _ou) do
+    {code, pc, regs, upvalues, proto, cont, dest, ou} = frame
+    cs = tl(cs)
+    cd = cd - 1
 
     case dest do
       :discard ->
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       n when is_integer(n) ->
         v =
@@ -1659,43 +1803,67 @@ defmodule Lua.VM.Dispatcher do
           end
 
         regs = :erlang.setelement(n + 1, regs, v)
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, _, -1} ->
-        return_multi(results, state, rest_frames, instruction_count)
+        return_multi(results, state, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, base, -2} ->
         regs = write_results(regs, base, results)
         state = %{state | multi_return_count: length(results)}
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
 
       {:multi, base, n} when is_integer(n) and n > 1 ->
         regs = write_results_n(regs, base, results, n)
-        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count)
+        dispatch(code, pc, regs, upvalues, proto, state, cont, rest_frames, instruction_count, cs, cd, ou)
     end
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────
 
+  # Writes the loop-carried control fields back into the struct. Called
+  # wherever execution leaves the dispatch loop — bridges into `Executor`,
+  # native callbacks, the loop's own raise sites — so anything that reads
+  # `state.call_stack` / `state.call_depth` out there sees the live values.
+  #
+  # The first clause makes a repeat crossing free: a loop body that bridges
+  # every iteration without calling anything (a `t[k] = v` write, an
+  # `__index` read) leaves the struct already carrying this frame's stack,
+  # so only the first crossing rebuilds it.
+  @compile {:inline, sync: 3}
+  defp sync(%{call_stack: call_stack, call_depth: call_depth} = state, call_stack, call_depth), do: state
+
+  defp sync(state, call_stack, call_depth) do
+    %{state | call_stack: call_stack, call_depth: call_depth}
+  end
+
   # Hot-path guards. Each of these fires on every call or loop iteration
   # only to discover it has nothing to do under the default configuration.
   # Inlining the guard here keeps the no-op case to a single function-head
   # match instead of a cross-module call into `Executor`/`State`; the
-  # non-trivial case still routes to the canonical implementation so the
-  # behaviour (and its error shapes) live in one place.
-  @compile {:inline, close_upv: 2, tick: 2, ckdepth: 1}
+  # non-trivial case still routes to the canonical implementation (paying
+  # one `sync/3` on the way) so the behaviour and its error shapes live in
+  # one place.
+  @compile {:inline, close_upv: 2, tick: 4, ckdepth: 3}
 
-  defp close_upv(%{open_upvalues: ou} = state, _threshold) when map_size(ou) == 0, do: state
+  defp close_upv(open_upvalues, _threshold) when map_size(open_upvalues) == 0, do: open_upvalues
 
-  defp close_upv(state, threshold) do
-    Executor.dispatcher_close_open_upvalues_at_or_above(state, threshold)
+  defp close_upv(open_upvalues, threshold) do
+    :maps.filter(fn reg, _cell -> reg < threshold end, open_upvalues)
   end
 
-  defp tick(%{max_instructions: :infinity}, instruction_count), do: instruction_count
-  defp tick(state, instruction_count), do: State.tick!(state, instruction_count)
+  defp tick(%{max_instructions: :infinity}, instruction_count, _call_stack, _call_depth), do: instruction_count
 
-  defp ckdepth(%{max_call_depth: :infinity}), do: :ok
-  defp ckdepth(state), do: State.check_call_depth!(state)
+  defp tick(state, instruction_count, call_stack, call_depth) do
+    State.tick!(sync(state, call_stack, call_depth), instruction_count)
+  end
+
+  defp ckdepth(%{max_call_depth: :infinity}, _call_stack, _call_depth), do: :ok
+  defp ckdepth(%{max_call_depth: max}, _call_stack, call_depth) when call_depth < max, do: :ok
+
+  defp ckdepth(state, call_stack, call_depth) do
+    State.check_call_depth!(sync(state, call_stack, call_depth))
+  end
 
   defp clear_nils(regs, _dest, 0), do: regs
 
@@ -1804,33 +1972,27 @@ defmodule Lua.VM.Dispatcher do
   # Closure upvalue capture. `:parent_local` allocates (or reuses) an
   # open-upvalue cell so multiple closures over the same register share
   # mutation. `:parent_upvalue` forwards our own cell ref to the child.
-  defp build_upvalues([], _regs, _upvalues, state, acc), do: {acc, state}
+  defp build_upvalues([], _regs, _upvalues, state, open_upvalues, acc), do: {acc, state, open_upvalues}
 
-  defp build_upvalues([{:parent_local, reg, _name} | rest], regs, upvalues, state, acc) do
-    {cell_ref, state} =
-      case :maps.get(reg, state.open_upvalues, nil) do
+  defp build_upvalues([{:parent_local, reg, _name} | rest], regs, upvalues, state, open_upvalues, acc) do
+    {cell_ref, state, open_upvalues} =
+      case :maps.get(reg, open_upvalues, nil) do
         nil ->
           new_ref = make_ref()
           value = :erlang.element(reg + 1, regs)
-
-          new_state = %{
-            state
-            | upvalue_cells: Map.put(state.upvalue_cells, new_ref, value),
-              open_upvalues: Map.put(state.open_upvalues, reg, new_ref)
-          }
-
-          {new_ref, new_state}
+          state = %{state | upvalue_cells: Map.put(state.upvalue_cells, new_ref, value)}
+          {new_ref, state, :maps.put(reg, new_ref, open_upvalues)}
 
         existing_cell ->
-          {existing_cell, state}
+          {existing_cell, state, open_upvalues}
       end
 
-    build_upvalues(rest, regs, upvalues, state, [cell_ref | acc])
+    build_upvalues(rest, regs, upvalues, state, open_upvalues, [cell_ref | acc])
   end
 
-  defp build_upvalues([{:parent_upvalue, index, _name} | rest], regs, upvalues, state, acc) do
+  defp build_upvalues([{:parent_upvalue, index, _name} | rest], regs, upvalues, state, open_upvalues, acc) do
     cell_ref = :erlang.element(index + 1, upvalues)
-    build_upvalues(rest, regs, upvalues, state, [cell_ref | acc])
+    build_upvalues(rest, regs, upvalues, state, open_upvalues, [cell_ref | acc])
   end
 
   # `:vararg` count=0 form: write every vararg into regs[base..]
@@ -1946,12 +2108,31 @@ defmodule Lua.VM.Dispatcher do
          state,
          cont,
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
-    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
   end
 
-  defp apply_multi_call_result(1, base, results, code, pc, regs, upvalues, proto, state, cont, frames, instruction_count) do
+  defp apply_multi_call_result(
+         1,
+         base,
+         results,
+         code,
+         pc,
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         instruction_count,
+         cs,
+         cd,
+         ou
+       ) do
     first =
       case results do
         [v | _] -> v
@@ -1959,7 +2140,7 @@ defmodule Lua.VM.Dispatcher do
       end
 
     regs = :erlang.setelement(base + 1, regs, first)
-    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
   end
 
   defp apply_multi_call_result(
@@ -1974,21 +2155,56 @@ defmodule Lua.VM.Dispatcher do
          state,
          _cont,
          frames,
-         instruction_count
+         instruction_count,
+         cs,
+         cd,
+         ou
        ) do
-    return_multi(results, state, frames, instruction_count)
+    return_multi(results, state, frames, instruction_count, cs, cd, ou)
   end
 
-  defp apply_multi_call_result(-2, base, results, code, pc, regs, upvalues, proto, state, cont, frames, instruction_count) do
+  defp apply_multi_call_result(
+         -2,
+         base,
+         results,
+         code,
+         pc,
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         instruction_count,
+         cs,
+         cd,
+         ou
+       ) do
     regs = write_results(regs, base, results)
     state = %{state | multi_return_count: length(results)}
-    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
   end
 
-  defp apply_multi_call_result(n, base, results, code, pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+  defp apply_multi_call_result(
+         n,
+         base,
+         results,
+         code,
+         pc,
+         regs,
+         upvalues,
+         proto,
+         state,
+         cont,
+         frames,
+         instruction_count,
+         cs,
+         cd,
+         ou
+       )
        when is_integer(n) and n > 1 do
     regs = write_results_n(regs, base, results, n)
-    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count)
+    dispatch(code, pc, regs, upvalues, proto, state, cont, frames, instruction_count, cs, cd, ou)
   end
 
   # Lazy regs-tuple growth. Used at the points where multi-return

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -498,12 +498,6 @@ defmodule Lua.VM.Executor do
     coerce_numeric_for_controls(init, limit, step, state)
   end
 
-  @doc false
-  @spec dispatcher_close_open_upvalues_at_or_above(State.t(), non_neg_integer()) :: State.t()
-  def dispatcher_close_open_upvalues_at_or_above(state, threshold) do
-    close_open_upvalues_at_or_above(state, threshold)
-  end
-
   # ── Dispatcher bridges: B5c-v2 ──────────────────────────────────────────
   #
   # `:self` method resolution. Wraps `index_value/6` so __index metamethod
@@ -630,18 +624,12 @@ defmodule Lua.VM.Executor do
     end
   end
 
-  @doc false
-  @spec dispatcher_call_info(term(), term(), non_neg_integer()) :: call_frame()
-  def dispatcher_call_info(proto, name_hint, line) do
-    # Hot path: every Lua call pushes one of these. Keep it a flat 3-tuple
-    # carrying the raw `name_hint` tag, and defer the `hint_name`/
-    # `hint_namewhat` decoding to the cold readers (`frame_name/1`,
-    # `frame_namewhat/1`) that only run during traceback formatting and
-    # `debug.getinfo`. A tuple is ~4 words vs ~7 for the old 4-key map, and
-    # skips two function calls per call frame.
-    {proto.source, line, name_hint}
-  end
-
+  # Every Lua call pushes one call frame, so the runtime shape is a flat
+  # 3-tuple `{source, line, name_hint}` carrying the raw `name_hint` tag;
+  # the `hint_name` / `hint_namewhat` decoding is deferred to the cold
+  # readers (`frame_name/1`, `frame_namewhat/1`) that only run during
+  # traceback formatting and `debug.getinfo`. A tuple is ~4 words against
+  # ~7 for a 4-key map, and skips two function calls per frame.
   @typedoc false
   @type call_frame() :: {term(), non_neg_integer(), term()} | map()
 

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -580,14 +580,22 @@ defmodule Lua.VM.Executor do
     # raise sites reading `current_position/0` — `error()`'s §6.1 prefix,
     # stdlib bad-argument raises — attribute to the right call site.
     # Restored after the call so nested invocations don't leak.
-    prev_pos = Process.get(@position_key, @unset)
-    set_position(line, proto.source)
+    #
+    # Every compiled-mode stdlib call lands here, so the bridge talks to the
+    # process dictionary through the BIFs and restores explicitly instead of
+    # paying for the `Process.*` wrappers and a `try` frame. A raise skips
+    # the restore; `execute/5`'s `after restore_position/1` is the outer net
+    # that stops a published position outliving the evaluation.
+    prev_pos = :erlang.get(@position_key)
+    :erlang.put(@position_key, {line, proto.source})
+    result = call_function(nf, args, state)
 
-    try do
-      call_function(nf, args, state)
-    after
-      restore_position(prev_pos)
+    case prev_pos do
+      :undefined -> :erlang.erase(@position_key)
+      pos -> :erlang.put(@position_key, pos)
     end
+
+    result
   end
 
   def dispatcher_call_function(other, args, state, proto, name_hint, line) do
@@ -949,7 +957,7 @@ defmodule Lua.VM.Executor do
          instruction_count
        ) do
     cell_ref = elem(upvalues, index)
-    value = Map.get(state.upvalue_cells, cell_ref)
+    value = :maps.get(cell_ref, state.upvalue_cells, nil)
     regs = put_elem(regs, dest, value)
     do_execute(rest, regs, upvalues, proto, state, cont, frames, line, instruction_count)
   end
@@ -991,9 +999,9 @@ defmodule Lua.VM.Executor do
          instruction_count
        ) do
     value =
-      case Map.get(state.open_upvalues, reg) do
+      case :maps.get(reg, state.open_upvalues, nil) do
         nil -> elem(regs, reg)
-        cell_ref -> Map.get(state.upvalue_cells, cell_ref)
+        cell_ref -> :maps.get(cell_ref, state.upvalue_cells, nil)
       end
 
     regs = put_elem(regs, dest, value)
@@ -1043,7 +1051,7 @@ defmodule Lua.VM.Executor do
          instruction_count
        ) do
     state =
-      case Map.get(state.open_upvalues, reg) do
+      case :maps.get(reg, state.open_upvalues, nil) do
         nil ->
           state
 
@@ -1287,7 +1295,7 @@ defmodule Lua.VM.Executor do
     {captured_upvalues_reversed, state} =
       Enum.reduce(nested_proto.upvalue_descriptors, {[], state}, fn
         {:parent_local, reg, _name}, {cells, state} ->
-          case Map.get(state.open_upvalues, reg) do
+          case :maps.get(reg, state.open_upvalues, nil) do
             nil ->
               cell_ref = make_ref()
               value = elem(regs, reg)
@@ -3751,7 +3759,7 @@ defmodule Lua.VM.Executor do
   # environment lives in upvalue slot 0 when present (a chunk loaded via
   # `load(..., env)`), otherwise default to the global table `_G`.
   defp load_env_value(upvalues, state) when tuple_size(upvalues) > 0 do
-    Map.get(state.upvalue_cells, elem(upvalues, 0))
+    :maps.get(elem(upvalues, 0), state.upvalue_cells, nil)
   end
 
   defp load_env_value(_upvalues, state), do: State.g_ref(state)

--- a/lib/lua/vm/executor.ex
+++ b/lib/lua/vm/executor.ex
@@ -187,9 +187,10 @@ defmodule Lua.VM.Executor do
 
   def call_function({:compiled_closure, callee_proto, callee_upvalues}, args, state) do
     # Compiled callees route through the dispatcher. The dispatcher manages
-    # its own register file setup, vararg routing, and open-upvalue save/
-    # restore — `Dispatcher.execute/4` mirrors the semantics of this
-    # function for the bytecode-encoded path.
+    # its own register file setup and vararg routing, and isolates open
+    # upvalues by threading them as a dispatch-loop parameter seeded empty
+    # at this boundary — `Dispatcher.execute/4` mirrors the semantics of
+    # this function for the bytecode-encoded path.
     Dispatcher.execute(callee_proto, args, callee_upvalues, state)
   end
 
@@ -573,23 +574,25 @@ defmodule Lua.VM.Executor do
     # Publish the source line baked into the call opcode by the encoder so
     # raise sites reading `current_position/0` — `error()`'s §6.1 prefix,
     # stdlib bad-argument raises — attribute to the right call site.
-    # Restored after the call so nested invocations don't leak.
     #
     # Every compiled-mode stdlib call lands here, so the bridge talks to the
-    # process dictionary through the BIFs and restores explicitly instead of
-    # paying for the `Process.*` wrappers and a `try` frame. A raise skips
-    # the restore; `execute/5`'s `after restore_position/1` is the outer net
-    # that stops a published position outliving the evaluation.
+    # process dictionary through the BIFs instead of the `Process.*`
+    # wrappers. The restore must run on raise too — not every entry into
+    # this bridge sits under `execute/5`'s `after restore_position/1` net
+    # (e.g. `Lua.call_function/3` invoking a compiled closure), so a
+    # raise-skipped restore would leak a stale position into later,
+    # unrelated evaluations' diagnostics.
     prev_pos = :erlang.get(@position_key)
     :erlang.put(@position_key, {line, proto.source})
-    result = call_function(nf, args, state)
 
-    case prev_pos do
-      :undefined -> :erlang.erase(@position_key)
-      pos -> :erlang.put(@position_key, pos)
+    try do
+      call_function(nf, args, state)
+    after
+      case prev_pos do
+        :undefined -> :erlang.erase(@position_key)
+        pos -> :erlang.put(@position_key, pos)
+      end
     end
-
-    result
   end
 
   def dispatcher_call_function(other, args, state, proto, name_hint, line) do

--- a/lib/lua/vm/state.ex
+++ b/lib/lua/vm/state.ex
@@ -7,6 +7,15 @@ defmodule Lua.VM.State do
   alias Lua.VM.RuntimeError
   alias Lua.VM.Table
 
+  # `call_stack`, `call_depth` and `open_upvalues` are control state, not
+  # heap state. The interpreter keeps them here; the dispatcher threads
+  # them as loop parameters (the same discipline as `instruction_count`
+  # below) so an in-mode Lua call allocates no struct at all, and writes
+  # them back into these fields whenever execution leaves the dispatch
+  # loop — an `Executor` bridge, a native callback, a raise site. Anything
+  # outside the loop that reads them (`debug.getinfo`, `error(msg, level)`,
+  # traceback formatting, `check_call_depth!/1`) therefore still sees live
+  # values.
   defstruct call_stack: [],
             # Call depth tracked as an O(1) counter that moves in lockstep
             # with `call_stack` — `length(call_stack)` would be O(depth) per

--- a/lib/lua/vm/table.ex
+++ b/lib/lua/vm/table.ex
@@ -84,6 +84,10 @@ defmodule Lua.VM.Table do
   encode) get split storage with no extra effort.
   """
   @spec from_data(map()) :: t()
+  # Every `{}` constructor allocates through here; an empty map has nothing
+  # to sort and nothing to fold, so skip straight to the empty struct.
+  def from_data(data) when map_size(data) == 0, do: %__MODULE__{}
+
   def from_data(data) when is_map(data) do
     split_from_map(%__MODULE__{}, data)
   end
@@ -198,6 +202,27 @@ defmodule Lua.VM.Table do
     end
   end
 
+  # No dead keys means the resurrection branch cannot apply, so the write is
+  # either an in-place overwrite or a fresh append. This is the shape every
+  # `t.field = v` / `t[k] = v` on a table that has never had a key removed
+  # takes, so it skips the `dead` probe entirely.
+  defp insert_hash(%__MODULE__{data: data, order_tail: order_tail, dead: dead} = table, key, value)
+       when map_size(dead) == 0 do
+    table = if positive_int?(key), do: %{table | border: :dirty}, else: table
+
+    if :maps.is_key(key, data) do
+      %{table | data: :maps.put(key, value, data)}
+    else
+      %{
+        table
+        | data: :maps.put(key, value, data),
+          order_tail: [key | order_tail],
+          order_index: nil,
+          order_arr: nil
+      }
+    end
+  end
+
   defp insert_hash(%__MODULE__{data: data, order: order, order_tail: order_tail, dead: dead} = table, key, value) do
     # A positive-integer hash key sits adjacent to the probe range and can
     # change #t once a contiguous fill reaches it, so invalidate the cache.
@@ -205,7 +230,7 @@ defmodule Lua.VM.Table do
     table = if positive_int?(key), do: %{table | border: :dirty}, else: table
 
     cond do
-      Map.has_key?(dead, key) ->
+      :maps.is_key(key, dead) ->
         merged_order = order ++ Enum.reverse(order_tail)
         new_order = Enum.reject(merged_order, &(&1 === key))
 

--- a/test/lua/call_function_error_value_test.exs
+++ b/test/lua/call_function_error_value_test.exs
@@ -285,4 +285,60 @@ defmodule Lua.CallFunctionErrorValueTest do
       assert Lua.format_exception(error) =~ "regression.lua:2:"
     end
   end
+
+  describe "call_function/3 position hygiene across evaluations" do
+    test "a raise inside a compiled closure's stdlib call does not leak its position" do
+      # The dispatcher publishes {line, source} around every native stdlib
+      # call so raise sites attribute to the right call site. That position
+      # must be restored even when the native call raises: `call_function/3`
+      # has no outer save/restore net, so a leak here surfaces in a *later*,
+      # unrelated evaluation whose own error carries no line info.
+      {[ref], lua} =
+        Lua.eval!(
+          Lua.new(),
+          """
+          local function boom()
+
+
+            error("kaboom")
+          end
+          return boom
+          """,
+          decode: false,
+          source: "first.lua"
+        )
+
+      # Pin that `boom` bytecode-compiled: the leak under test lives in the
+      # dispatcher's native-call bridge, not the interpreter's.
+      assert {:compiled_closure, _, _} = ref.ref
+
+      assert {:error, %RuntimeException{kind: :error}, %Lua{} = lua} =
+               Lua.call_function(lua, ref, [])
+
+      error =
+        assert_raise RuntimeException, fn ->
+          Lua.eval!(
+            lua,
+            """
+            local function g()
+              local t = nil
+              return t.x
+            end
+            return g()
+            """,
+            source: "second.lua"
+          )
+        end
+
+      # Indexing nil inside a compiled body raises without line info, and
+      # the exception falls back to `current_position/0`. A leaked position
+      # would attribute this error to first.lua:4 instead of no line.
+      assert %TypeError{error_kind: :index_non_table, line: nil, source: "second.lua"} =
+               error.original
+
+      message = Lua.format_exception(error)
+      refute message =~ "first.lua"
+      refute message =~ ":4:"
+    end
+  end
 end

--- a/test/lua/vm/dispatcher_test.exs
+++ b/test/lua/vm/dispatcher_test.exs
@@ -1072,6 +1072,51 @@ defmodule Lua.VM.DispatcherTest do
       assert results == [18]
     end
 
+    test ":set_field — nil assignment deletes the key" do
+      {proto, results} =
+        run!("""
+        function f()
+          local t = { x = 1, y = 2 }
+          t.x = nil
+          local count = 0
+          for _ in pairs(t) do count = count + 1 end
+          return t.x, t.y, count
+        end
+        return f()
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [nil, 2, 1]
+    end
+
+    test ":set_field — __newindex function handler (slow-path bridge)" do
+      {proto, results} =
+        run!("""
+        function f(t, v) t.x = v end
+        local log = {}
+        local t = setmetatable({}, {__newindex = function(_, k, v) log[k] = v + 1 end})
+        f(t, 41)
+        return rawget(t, "x"), log.x
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [nil, 42]
+    end
+
+    test ":set_field — __newindex table handler (slow-path bridge)" do
+      {proto, results} =
+        run!("""
+        function f(t, v) t.x = v end
+        local backing = {}
+        local t = setmetatable({}, {__newindex = backing})
+        f(t, 7)
+        return rawget(t, "x"), backing.x
+        """)
+
+      assert first_sub(proto).bytecode
+      assert results == [nil, 7]
+    end
+
     test ":get_table — integer-key fast path" do
       {proto, results} =
         run!("""

--- a/test/lua/vm/require_open_upvalue_test.exs
+++ b/test/lua/vm/require_open_upvalue_test.exs
@@ -119,6 +119,13 @@ defmodule Lua.VM.RequireOpenUpvalueTest do
     return outer()
     """
 
+    # Pin that `outer` actually bytecode-compiles, so this exercises the
+    # dispatcher rather than silently degrading into an interpreter test.
+    {:ok, ast} = Lua.Parser.parse(code)
+    {:ok, proto} = Lua.Compiler.compile(ast, source: "test.lua")
+    assert %Lua.Compiler.Prototype{prototypes: [outer_proto | _]} = proto
+    assert outer_proto.bytecode
+
     assert {["reassigned", "inner", "inner_value"], _} = eval_with_path(code, tmp_dir)
   end
 end

--- a/test/lua/vm/require_open_upvalue_test.exs
+++ b/test/lua/vm/require_open_upvalue_test.exs
@@ -88,4 +88,37 @@ defmodule Lua.VM.RequireOpenUpvalueTest do
 
     assert {["registered:ok"], _} = eval_with_path(code, tmp_dir)
   end
+
+  test "compiled caller's open upvalues survive a require in its body", %{tmp_dir: tmp_dir} do
+    # Same invariant, entered from the bytecode dispatcher rather than the
+    # interpreter. The dispatcher carries its open upvalues as a loop
+    # parameter, so a nested evaluation cannot reach them; this pins that
+    # a `require` between capturing a local and reading it back through
+    # the cell still yields the caller's value.
+    File.write!(Path.join(tmp_dir, "inner.lua"), """
+    local inner_local = "inner_value"
+
+    local function captures_it()
+      return inner_local
+    end
+
+    return { tag = "inner", fn = captures_it }
+    """)
+
+    # The body runs on the dispatcher: `outer/0` is reached by a call, and
+    # its own body creates the closure over `mine`.
+    code = ~S"""
+    local function outer()
+      local mine = "outer_value"
+      local function read_mine() return mine end
+      local m = require("inner")
+      mine = "reassigned"
+      return read_mine(), m.tag, m.fn()
+    end
+
+    return outer()
+    """
+
+    assert {["reassigned", "inner", "inner_value"], _} = eval_with_path(code, tmp_dir)
+  end
 end


### PR DESCRIPTION
Cuts per-call and per-iteration overhead in the bytecode dispatcher. Runtime only — the bytecode format, the encoder, and codegen are untouched, so the codegen work (peephole, static-arity calls, new opcodes) lands independently on top of this.

Two commits, each independently green on the full suite.

## 1. `vm: inline hot-path guards and fast paths in the dispatcher`

Mechanical micro-fixes. Nothing changes semantics; each removes work the default configuration paid for a result it already knew.

- `close_upv/2`, `tick/2`, `ckdepth/1` — inlined local shims so the empty-`open_upvalues`, `max_instructions: :infinity` and `max_call_depth: :infinity` cases resolve in one function-head match instead of a cross-module call into `Executor`/`State`. The empty-open-upvalues guard alone was two cross-module calls per loop iteration.
- Call frames build `{source, line, name_hint}` inline instead of through `Executor.dispatcher_call_info/3`.
- `setup_vararg_proto/4` is guarded by the callee's `is_vararg` at the call site, so a non-vararg call pays one field read. (The vararg path still copies the whole `%Prototype{}`.)
- `Map.get/2` → `:maps.get/3` on the upvalue-cell and open-upvalue reads, killing the `Map.get/2` → `Map.get/3` hop.
- `@op_set_field` gets the inline no-metatable fast path `@op_get_field` already had. Tables carrying a metatable still bridge, so the `__newindex` chain stays exactly the interpreter's.
- `Table.from_data/1` short-circuits the empty map — every `{}` constructor was paying `Enum.sort` plus a fold over nothing.
- `Table.insert_hash/3` gains a no-dead-keys clause, skipping the resurrection probe on tables that have never had a key removed.
- The compiled-mode native-call position bridge (on the path of every stdlib call) uses the process-dictionary BIFs directly and restores explicitly rather than through a `try/after`. `Executor.execute/5`'s `after restore_position/1` remains the outer net.

## 2. `vm: thread call stack, depth, and open upvalues as loop parameters`

Every in-mode Lua call rebuilt the 17-field `%State{}` twice — once to push `call_stack`/`call_depth` and reset `open_upvalues`, once to undo all three — for ~42 words of garbage per call on a path that otherwise allocates almost nothing.

These are control state, not heap state, so they now follow the discipline `instruction_count` already used: parameters of the dispatch loop, living in X-registers, allocating nothing. Pushing a frame is a cons plus an increment; popping is `tl/1` plus a decrement, with the caller's open upvalues coming back off the frame tuple that already carried them.

`%State{}` keeps the fields — the interpreter still stores them there, and everything outside the loop reads them from the struct (`debug.getinfo`, `error(msg, level)`, traceback formatting, `State.check_call_depth!/1`, `State.tick!/2`). So the loop writes them back (`sync/3`) wherever execution leaves it: an `Executor` bridge, a native callback, its own raise sites. `sync/3` returns the struct untouched when it already agrees, so a loop body that bridges every iteration without calling anything (`t[k] = v`, an `__index` read) pays the write once instead of per iteration.

This differs from the sketch in the brief, which proposed dropping `state.call_stack` entirely and materializing the traceback lazily from the dispatcher's `frames` list on the error path. Threading it eagerly was chosen instead: the frame entry is 4 words plus a cons against the 42 the struct rebuild cost, so nearly all of the win is kept, while lazy materialization would rebuild an O(depth) list at every bridge crossing — a regression for bridge-heavy code at depth (OOP `self.x` on a table with a metatable bridges on every read) — and would have needed the traceback reconstructed from call opcodes rather than pushed by them.

`close_upv/2` now filters the parameter directly, retiring `Executor.dispatcher_close_open_upvalues_at_or_above/2`; `Executor.dispatcher_call_info/3` went unused in commit 1 and goes with it, its frame-shape rationale moving to the `call_frame/0` typedoc.

### Debug fidelity

Unchanged by construction — the same `{source, line, name_hint}` frames in the same order, pushed onto a parameter rather than a struct field. Verified by diffing `Lua.format_exception/1` output across thirteen failing programs (nested runtime errors, `error()` at levels 1 and 2, stdlib bad-argument raises, `__index` arithmetic errors, `debug.traceback` from depth, `debug.getinfo` currentline/name, error-after-caught-error, concat errors, deep recursion tracebacks) plus the exact trip points of `:max_instructions` across 7 budgets and `:max_call_depth` across 11 depths. Byte-identical before and after, including the 200-frame `... 190 more frames ...` traceback elision and `pcall`-caught `"stack overflow"`.

## Numbers

`MIX_ENV=prod`, min-of-9 × 100 reps per measurement, alternating A/B by swapping the source files in place and recompiling between runs. The machine had concurrent load: within-configuration spread across rounds was up to 5%, so these are the best round for each configuration, and the alternation is what makes the comparison meaningful rather than any single number.

Workload bodies are wrapped in a Lua function, because `Lua.VM.execute/3` runs the *main* chunk on the interpreter and only enters the dispatcher through a call.

Per commit:

| workload | main | after commit 1 | after commit 2 |
|---|---|---|---|
| `fib(15)` | 479.9 µs | 459.2 µs (-4.3%) | 365.5 µs (-22.7% on commit 1) |
| closures 100×10 | 506.7 µs | 493.2 µs (-2.7%) | 448.5 µs (-11.0%) |
| oop 2000 | 4590.1 µs | 4468.6 µs (-2.6%) | 4386.8 µs (-4.6%) |
| table build 5000 | 3799.3 µs | 3633.3 µs (-4.4%) | 3792.7 µs (-0.7%) |
| set_field 20000 | 5961.0 µs | 5588.4 µs (-6.3%) | 5659.4 µs (+0.5%) |

End to end, `main` vs the branch tip, measured in one alternating run:

| workload | main | branch | |
|---|---|---|---|
| `fib(15)` | 488.2 µs | 363.8 µs | **1.34×** |
| closures 100×10 | 527.7 µs | 438.4 µs | **1.20×** |
| oop 2000 | 4660.2 µs | 4306.4 µs | 1.08× |
| table build 5000 | 3833.9 µs | 3672.6 µs | 1.04× |
| set_field 20000 | 5979.5 µs | 5527.7 µs | 1.08× |

## 3. `vm: pin dispatcher-side open-upvalue isolation across require`

One regression test. The existing `require` open-upvalue tests only exercise a main chunk, which runs on the interpreter; the invariant they pin (a nested evaluation cannot see the caller's register-keyed upvalue cells) now holds on the dispatcher side by construction rather than by a save/restore, so it gets a test entered from compiled code.

## Validation

- `mix format --check-formatted` clean; no compiler warnings.
- `mix test --include slow --include lua53` — 2639 passed, 16 skipped (includes the official Lua 5.3 suite and the error-message/traceback tests) after each commit.
- `mix test --include differential` — 2618 passed.
- `mix docs --warnings-as-errors` clean; `mix dialyzer` clean (0 errors).
