### PR TITLE
website: parse playground snippets once per run

### DIFF
--- a/website/lib/website/lua_sandbox.ex
+++ b/website/lib/website/lua_sandbox.ex
@@ -212,13 +212,16 @@ defmodule Website.LuaSandbox do
       end)
 
     try do
-      bytecode =
+      # Parse once and reuse the chunk for both the bytecode pane and the
+      # evaluation itself. A parse failure falls through to eval!/2 on the
+      # source so the error path still raises the usual CompilerException.
+      {bytecode, runnable} =
         case Lua.parse_chunk(source) do
-          {:ok, %Lua.Chunk{prototype: proto}} -> disassemble(proto)
-          _ -> []
+          {:ok, %Lua.Chunk{prototype: proto} = chunk} -> {disassemble(proto), chunk}
+          _ -> {[], source}
         end
 
-      {results, _lua} = Lua.eval!(lua, source)
+      {results, _lua} = Lua.eval!(lua, runnable)
 
       %{
         status: :ok,


### PR DESCRIPTION
## What

`LuaSandbox.eval/3` parsed every playground snippet twice: once via `Lua.parse_chunk/1` to build the bytecode pane, and again inside `Lua.eval!/2`. This reuses the compiled chunk for evaluation.

## Why

Saves a full parse+compile per playground run — up to ~83µs on the metatables example snippet at current parse costs (and still the entire front-end cost once the lexer/compiler perf PRs land). Part of the sub-millisecond playground effort alongside #398–#401.

## Behavior

Unchanged. A parse failure falls through to `Lua.eval!/2` on the raw source, so the `CompilerException` error path (and its formatted messages) is exactly as before. All 52 website tests pass.