### PR TITLE
fix(parser): allow comments between a bare return and its terminator

### DIFF
--- a/lib/lua/parser.ex
+++ b/lib/lua/parser.ex
@@ -252,7 +252,11 @@ defmodule Lua.Parser do
 
   # Placeholder implementations for statements (Phase 3)
   defp parse_return([{:keyword, :return, pos} | rest]) do
-    case peek(rest) do
+    # Comments are whitespace between the `return` keyword and the block
+    # terminator, so look past them when deciding whether this is a bare
+    # (valueless) return. For terminator/EOF the comment tokens stay in `rest`
+    # for the block parser to collect as orphaned/trailing comments.
+    case peek(skip_comments(rest)) do
       # End of block or statement
       {:keyword, terminator, _} when terminator in [:end, :else, :elseif, :until] ->
         {:ok, %Statement.Return{values: [], meta: Meta.new(pos)}, rest}
@@ -261,7 +265,7 @@ defmodule Lua.Parser do
         {:ok, %Statement.Return{values: [], meta: Meta.new(pos)}, rest}
 
       {:delimiter, :semicolon, _} ->
-        {_, rest2} = consume(rest)
+        {_, rest2} = consume(skip_comments(rest))
         {:ok, %Statement.Return{values: [], meta: Meta.new(pos)}, rest2}
 
       _ ->

--- a/test/lua/parser/statement_test.exs
+++ b/test/lua/parser/statement_test.exs
@@ -201,6 +201,39 @@ defmodule Lua.Parser.StatementTest do
              } = chunk
     end
 
+    test "parses a bare return followed by a comment before elseif/else" do
+      # A comment sits between an empty `return` and the block terminator.
+      # Comments are whitespace to Lua, so the return is still empty and the
+      # branch continues normally. Regression: the parser used to treat the
+      # comment token as the start of a return expression and fail with
+      # "Expected expression".
+      assert {:ok, chunk} =
+               Parser.parse("""
+               if x > 0 then
+                 return
+               -- leading comment on elseif
+               elseif x < 0 then
+                 return
+               -- leading comment on else
+               else
+                 return
+               -- trailing comment before end
+               end
+               """)
+
+      assert %{
+               block: %{
+                 stmts: [
+                   %Statement.If{
+                     then_block: %{stmts: [%Statement.Return{values: []}]},
+                     elseifs: [{%Expr.BinOp{op: :lt}, %{stmts: [%Statement.Return{values: []}]}}],
+                     else_block: %{stmts: [%Statement.Return{values: []}]}
+                   }
+                 ]
+               }
+             } = chunk
+    end
+
     test "parses if with elseif" do
       assert {:ok, chunk} =
                Parser.parse("""


### PR DESCRIPTION
## Problem

A valueless `return` followed by a **comment** before the block terminator (`elseif` / `else` / `end` / `until`) fails to parse:

```lua
local function f(method)
  if method == "GET" then
    return
  -- handle other methods
  elseif method == "POST" then
    return
  end
end
```

```
Parse Error: Expected expression
```

Comments are whitespace in Lua, so the `return` here is simply a bare (valueless) return and the branch continues normally. Reference Lua 5.3 accepts this, and it's a common idiom (`then return -- note \n elseif ...`).

## Root cause

`Lua.Parser.parse_return/1` peeked at the **raw** next token to decide whether the `return` was valueless. A comment token is not one of the terminators (`end`/`else`/`elseif`/`until`), nor EOF/`;`, so it fell through to `parse_expr_list`, which then choked on the comment → "Expected expression".

## Fix

Peek **past** comment tokens (via the existing `skip_comments/1`) when detecting the terminator. The comment tokens are left in the stream so the block parser still collects them as orphaned/trailing comments — no comment metadata is lost.

```elixir
case peek(skip_comments(rest)) do
```

The semicolon branch consumes past comments as well, so `return -- note` followed by `;` is handled too.

## Tests

Added a regression test in `test/lua/parser/statement_test.exs` covering a bare `return` with a comment before `elseif`/`else`/`end` — fails before, passes after.

- `mix test test/lua/parser/` — all green
- `mix test` (full suite) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)